### PR TITLE
fix(app): reliable input-method switching via IMK input modes

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -23,18 +23,34 @@
     <dict>
         <key>tsInputModeListKey</key>
         <dict>
-            <key>com.github.teddychan.inputmethod.YahooKeyKey2.Bopomofo</key>
+            <key>com.github.teddychan.inputmethod.YahooKeyKey2.SmartPhonetic</key>
             <dict>
                 <key>TISIntendedLanguage</key><string>zh-Hant</string>
                 <key>tsInputModeCharacterRepertoireKey</key><array><string>Hant</string></array>
-                <key>tsInputModeDefaultStateKey</key><true/>
                 <key>tsInputModeIsVisibleKey</key><true/>
                 <key>tsInputModeScriptKey</key><string>smTradChinese</string>
-                <key>tsInputModePrimaryInScriptKey</key><true/>
+            </dict>
+            <key>com.github.teddychan.inputmethod.YahooKeyKey2.PlainPhonetic</key>
+            <dict>
+                <key>TISIntendedLanguage</key><string>zh-Hant</string>
+                <key>tsInputModeCharacterRepertoireKey</key><array><string>Hant</string></array>
+                <key>tsInputModeIsVisibleKey</key><true/>
+                <key>tsInputModeScriptKey</key><string>smTradChinese</string>
+            </dict>
+            <key>com.github.teddychan.inputmethod.YahooKeyKey2.Cangjie</key>
+            <dict>
+                <key>TISIntendedLanguage</key><string>zh-Hant</string>
+                <key>tsInputModeCharacterRepertoireKey</key><array><string>Hant</string></array>
+                <key>tsInputModeIsVisibleKey</key><true/>
+                <key>tsInputModeScriptKey</key><string>smTradChinese</string>
             </dict>
         </dict>
         <key>tsVisibleInputModeOrderedArrayKey</key>
-        <array><string>com.github.teddychan.inputmethod.YahooKeyKey2.Bopomofo</string></array>
+        <array>
+            <string>com.github.teddychan.inputmethod.YahooKeyKey2.SmartPhonetic</string>
+            <string>com.github.teddychan.inputmethod.YahooKeyKey2.PlainPhonetic</string>
+            <string>com.github.teddychan.inputmethod.YahooKeyKey2.Cangjie</string>
+        </array>
     </dict>
 </dict>
 </plist>

--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -2,7 +2,8 @@ import Cocoa
 import InputMethodKit
 import KeyKeyEngine
 
-// Persisted phonetic-layout choice. Raw values are the keys stored in UserDefaults.
+// Phonetic keyboard layout. Layout selection UI is deferred to Preferences; the engine
+// supports all four and defaults to Standard (大千).
 private enum LayoutChoice: String {
     case standard
     case eten
@@ -19,31 +20,35 @@ private enum LayoutChoice: String {
     }
 }
 
-// Persisted input-method choice. Raw values are the keys stored in UserDefaults.
+// The input method, selected by the user as an IMK input MODE (see Info.plist
+// ComponentInputModeDict). IMK delivers the selection via setValue(_:forTag:client:).
 private enum InputMethodChoice: String {
     case smartPhonetic
     case plainPhonetic
     case cangjie
 
-    // Cangjie has no Bopomofo keyboard layout; the layout submenu applies only to phonetic methods.
-    var isPhonetic: Bool { self != .cangjie }
-}
+    // Map an IMK input-mode identifier (…YahooKeyKey2.Cangjie etc.) to a method.
+    init(modeID: String) {
+        if modeID.hasSuffix(".Cangjie") { self = .cangjie }
+        else if modeID.hasSuffix(".PlainPhonetic") { self = .plainPhonetic }
+        else { self = .smartPhonetic }
+    }
 
-private let layoutDefaultsKey = "phoneticLayout"
-private let methodDefaultsKey = "inputMethod"
+    // Only Cangjie selects directly by digit: its keys are a–z, so digits are unambiguous
+    // selectors. Phonetic methods use Down-then-digit, because in Bopomofo layouts several
+    // digit keys ("1"=ㄅ, "2"=ㄉ, …) are valid input and must not be hijacked.
+    var usesDirectDigitSelect: Bool { self == .cangjie }
+}
 
 @objc(InputController)
 final class InputController: IMKInputController {
     private let lm: LanguageModel
     private let cangjieTable: CangjieTable
-    private var method: InputMethodChoice
-    private var layout: LayoutChoice
+    private let layout: LayoutChoice = .standard
+    private var method: InputMethodChoice = .smartPhonetic
     private var engine: InputEngine
     private let candidateWindow = CandidateWindow()
     private var selecting = false
-
-    // UserDefaults suited to the bundle id so the choice is shared across IMK clients.
-    private let defaults = UserDefaults(suiteName: Bundle.main.bundleIdentifier) ?? .standard
 
     override init!(server: IMKServer!, delegate: Any!, client inputClient: Any!) {
         // Load the bundled LM once; fail safe to an empty model (no candidates) if missing.
@@ -68,14 +73,10 @@ final class InputController: IMKInputController {
         }
         self.cangjieTable = cangjieTable
 
-        // self.defaults isn't usable yet (two-phase init: stored props before super.init),
-        // so the UserDefaults suite is constructed inline here to read the persisted choices.
-        let suite = UserDefaults(suiteName: Bundle.main.bundleIdentifier)
-        let method = InputMethodChoice(rawValue: suite?.string(forKey: methodDefaultsKey) ?? "") ?? .smartPhonetic
-        let layout = LayoutChoice(rawValue: suite?.string(forKey: layoutDefaultsKey) ?? "") ?? .standard
-        self.method = method
-        self.layout = layout
-        self.engine = InputController.makeEngine(method: method, layout: layout, lm: lm, cangjieTable: cangjieTable)
+        // Start on Smart Phonetic; IMK calls setValue(_:forTag:client:) with the active
+        // input mode (and on every mode switch), which rebuilds the engine accordingly.
+        self.engine = InputController.makeEngine(method: .smartPhonetic, layout: .standard,
+                                                 lm: lm, cangjieTable: cangjieTable)
         super.init(server: server, delegate: delegate, client: inputClient)
     }
 
@@ -97,28 +98,26 @@ final class InputController: IMKInputController {
         Int(NSEvent.EventTypeMask.keyDown.rawValue)
     }
 
-    // IMK creates one controller per text session, but a menu pick updates only the
-    // instance that owns the menu (plus shared UserDefaults). Re-read the persisted
-    // choice when this session activates and before handling keys, rebuilding the engine
-    // if it changed, so the selection applies to whichever instance handles typing.
-    override func activateServer(_ sender: Any!) {
-        super.activateServer(sender)
-        syncFromDefaults()
-    }
-
-    private func syncFromDefaults() {
-        let m = InputMethodChoice(rawValue: defaults.string(forKey: methodDefaultsKey) ?? "") ?? .smartPhonetic
-        let l = LayoutChoice(rawValue: defaults.string(forKey: layoutDefaultsKey) ?? "") ?? .standard
-        guard m != method || l != layout else { return }
-        method = m
-        layout = l
+    // IMK calls this when the user selects one of our input modes (Info.plist
+    // ComponentInputModeDict). The value is the mode identifier string.
+    override func setValue(_ value: Any!, forTag tag: Int, client sender: Any!) {
+        let modeID = value as? String ?? ""
+        let choice = InputMethodChoice(modeID: modeID)
+        guard choice != method else { return }
+        // Commit any in-progress composition so the rebuilt engine starts clean.
+        if let client = sender as? IMKTextInput ?? client() as? IMKTextInput {
+            _ = commitCurrent(to: client)
+        } else {
+            _ = engine.commit()
+        }
         selecting = false
-        engine = InputController.makeEngine(method: m, layout: l, lm: lm, cangjieTable: cangjieTable)
+        candidateWindow.hide()
+        method = choice
+        engine = InputController.makeEngine(method: choice, layout: layout, lm: lm, cangjieTable: cangjieTable)
     }
 
     override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
         guard let event, event.type == .keyDown, let client = sender as? IMKTextInput else { return false }
-        syncFromDefaults()   // pick up a method/layout change made via another session's menu
 
         // Selection mode (entered via Down): digits pick a candidate; Esc just closes the
         // picker and keeps the composition; any other key resumes normal composing.
@@ -136,7 +135,7 @@ final class InputController: IMKInputController {
         }
 
         // Cangjie shows candidates as soon as a code resolves, and its keys are a–z, so digits
-        // 1–9 select directly without first opening the picker. (Smart and Plain phonetic use
+        // 1–9 select directly without first opening the picker. (Phonetic methods use
         // Down-then-digit, since digit keys are valid Bopomofo input there.)
         if method.usesDirectDigitSelect,
            let chars = event.characters, let d = Int(chars), (1...9).contains(d),
@@ -186,78 +185,13 @@ final class InputController: IMKInputController {
         return true
     }
 
-    // IMK input menu: pick the input method, then (for phonetic methods) the keyboard
-    // layout. A check marks the active item; layout items are shown only when relevant.
-    override func menu() -> NSMenu! {
-        let menu = NSMenu()
-        let currentMethod = InputMethodChoice(rawValue: defaults.string(forKey: methodDefaultsKey) ?? "") ?? .smartPhonetic
-        let currentLayout = LayoutChoice(rawValue: defaults.string(forKey: layoutDefaultsKey) ?? "") ?? .standard
-
-        for (choice, title) in [(InputMethodChoice.smartPhonetic, "Smart Phonetic (智慧注音)"),
-                                (.plainPhonetic, "Plain Phonetic (傳統注音)"),
-                                (.cangjie, "Cangjie (倉頡)")] {
-            let item = NSMenuItem(title: title, action: #selector(switchMethod(_:)), keyEquivalent: "")
-            item.target = self
-            item.representedObject = choice.rawValue
-            item.state = (choice == currentMethod) ? .on : .off
-            menu.addItem(item)
-        }
-
-        // Layout submenu applies only to phonetic methods; Cangjie has no Bopomofo layout.
-        if currentMethod.isPhonetic {
-            menu.addItem(.separator())
-            for (choice, title) in [(LayoutChoice.standard, "Standard (大千)"), (.eten, "ETen (倚天)"),
-                                    (.hsu, "Hsu (許氏)"), (.eten26, "ETen 26 (倚天26鍵)")] {
-                let item = NSMenuItem(title: title, action: #selector(switchLayout(_:)), keyEquivalent: "")
-                item.target = self
-                item.representedObject = choice.rawValue
-                item.state = (choice == currentLayout) ? .on : .off
-                menu.addItem(item)
-            }
-        }
-        return menu
-    }
-
-    @objc private func switchMethod(_ sender: NSMenuItem) {
-        guard let raw = sender.representedObject as? String,
-              let choice = InputMethodChoice(rawValue: raw), choice != method else { return }
-        commitInProgress()
-        defaults.set(raw, forKey: methodDefaultsKey)
-        method = choice
-        let layout = LayoutChoice(rawValue: defaults.string(forKey: layoutDefaultsKey) ?? "") ?? .standard
-        engine = InputController.makeEngine(method: choice, layout: layout, lm: lm, cangjieTable: cangjieTable)
-    }
-
-    @objc private func switchLayout(_ sender: NSMenuItem) {
-        guard let raw = sender.representedObject as? String,
-              let choice = LayoutChoice(rawValue: raw) else { return }
-        commitInProgress()
-        defaults.set(raw, forKey: layoutDefaultsKey)
-        layout = choice
-        // Rebuild the active phonetic engine on the new layout. (No-op shape for Cangjie,
-        // but the layout submenu isn't shown for Cangjie so this stays phonetic-only.)
-        engine = InputController.makeEngine(method: method, layout: choice, lm: lm, cangjieTable: cangjieTable)
-    }
-
-    // Commit any in-progress composition into the document so the rebuilt engine starts
-    // clean without silently dropping the partial text. Used on method/layout switch.
-    private func commitInProgress() {
-        if let client = client() {
-            _ = commitCurrent(to: client)
-        } else {
-            _ = engine.commit()
-        }
-        selecting = false
-        candidateWindow.hide()
-    }
-
     private func refresh(_ client: IMKTextInput) {
         let composing = engine.composingText
         client.setMarkedText(composing,
                              selectionRange: NSRange(location: composing.utf16.count, length: 0),
                              replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
         // Only show the numbered candidate window when number keys actually select:
-        // in `selecting` mode (Smart/Plain, after Down) or for Cangjie (direct digit-select).
+        // in `selecting` mode (phonetic, after Down) or for Cangjie (direct digit-select).
         // Otherwise the list would imply number-select while digits are still Bopomofo input.
         let cands = engine.candidates
         let numbersSelect = selecting || method.usesDirectDigitSelect
@@ -268,11 +202,4 @@ final class InputController: IMKInputController {
             candidateWindow.show(cands, near: rect.origin)
         }
     }
-}
-
-private extension InputMethodChoice {
-    // Only Cangjie selects directly by digit: its keys are a–z, so digits are unambiguous
-    // selectors. Smart and Plain phonetic use Down-then-digit, because in Bopomofo layouts
-    // several digit keys ("1"=ㄅ, "2"=ㄉ, …) are valid input and must not be hijacked.
-    var usesDirectDigitSelect: Bool { self == .cangjie }
 }

--- a/App/en.lproj/InfoPlist.strings
+++ b/App/en.lproj/InfoPlist.strings
@@ -1,3 +1,5 @@
 CFBundleName = "Yahoo KeyKey 2";
 CFBundleDisplayName = "Yahoo KeyKey 2";
-"com.github.teddychan.inputmethod.YahooKeyKey2.Bopomofo" = "Yahoo KeyKey 2";
+"com.github.teddychan.inputmethod.YahooKeyKey2.SmartPhonetic" = "Yahoo KeyKey 2 — Smart Phonetic";
+"com.github.teddychan.inputmethod.YahooKeyKey2.PlainPhonetic" = "Yahoo KeyKey 2 — Plain Phonetic";
+"com.github.teddychan.inputmethod.YahooKeyKey2.Cangjie" = "Yahoo KeyKey 2 — Cangjie";

--- a/App/zh-Hant.lproj/InfoPlist.strings
+++ b/App/zh-Hant.lproj/InfoPlist.strings
@@ -1,3 +1,5 @@
 CFBundleName = "Yahoo KeyKey 2";
 CFBundleDisplayName = "Yahoo KeyKey 2";
-"com.github.teddychan.inputmethod.YahooKeyKey2.Bopomofo" = "Yahoo KeyKey 2";
+"com.github.teddychan.inputmethod.YahooKeyKey2.SmartPhonetic" = "Yahoo KeyKey 2 — 智慧注音";
+"com.github.teddychan.inputmethod.YahooKeyKey2.PlainPhonetic" = "Yahoo KeyKey 2 — 傳統注音";
+"com.github.teddychan.inputmethod.YahooKeyKey2.Cangjie" = "Yahoo KeyKey 2 — 倉頡";


### PR DESCRIPTION
## Summary
Method selection (Smart/Plain/Cangjie) via the custom IMK menu never dispatched to the active controller, so picking a method silently reverted. Replaces it with three real IMK **input modes** switched via `setValue(_:forTag:client:)` — the approach McBopomofo uses. Verified live: selecting **Cangjie** and typing `ab` → 明 works.

## Changes
- `Info.plist`: three symmetric visible input modes (SmartPhonetic/PlainPhonetic/Cangjie).
- `InfoPlist.strings` (en + zh-Hant): localized mode names.
- `InputController`: implement `setValue(forTag:)`; remove the non-working custom menu + UserDefaults switch apparatus.

## Note
Layout switching (ETen/Hsu/ETen 26) is temporarily not in the UI — deferred to the Preferences app (engine still supports all four; defaults to Standard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)