### PR TITLE
feat: SPACE commits/confirms; Plain Phonetic shows numbered candidates

### DIFF
--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -125,6 +125,10 @@ final class InputController: IMKInputController {
             if event.keyCode == 53 { // Escape exits selection without discarding composition
                 selecting = false; refresh(client); return true
             }
+            if event.keyCode == 49 { // Space confirms the current/top candidate
+                if !engine.candidates.isEmpty { engine.selectCandidate(0) }
+                return commitCurrent(to: client)
+            }
             if let chars = event.characters, let d = Int(chars), (1...9).contains(d),
                d - 1 < engine.candidates.count {
                 engine.selectCandidate(d - 1)
@@ -142,6 +146,24 @@ final class InputController: IMKInputController {
            d - 1 < engine.candidates.count {
             engine.selectCandidate(d - 1)
             return commitCurrent(to: client)
+        }
+
+        // SPACE: while a syllable is still being composed (no tone yet), fall through so the
+        // engine receives " " as tone 1 and finalizes it. Once a composition is finalized,
+        // SPACE confirms/commits it; with nothing composing, let a literal space through.
+        if event.keyCode == 49 { // Space
+            if engine.isComposingSyllable {
+                // fall through to engine.handleKey(" ") below to finalize as tone 1
+            } else if !engine.composingText.isEmpty {
+                if method == .smartPhonetic {
+                    return commitCurrent(to: client)
+                } else { // .plainPhonetic / .cangjie: commit the top candidate
+                    if !engine.candidates.isEmpty { engine.selectCandidate(0) }
+                    return commitCurrent(to: client)
+                }
+            } else {
+                return false // nothing composing: pass a literal space to the app
+            }
         }
 
         // Enter commits; Backspace deletes; Esc cancels; Down opens selection; mapped keys feed the engine.
@@ -163,7 +185,12 @@ final class InputController: IMKInputController {
 
         guard let ch = event.characters?.first else { return false }
         let consumed = engine.handleKey(ch)
-        if consumed { refresh(client) }
+        if consumed {
+            // Plain Phonetic: as soon as a syllable completes, show its numbered candidates
+            // (incl. after space=tone 1) so digits 1–9 select. Down still works.
+            if method == .plainPhonetic, !engine.candidates.isEmpty { selecting = true }
+            refresh(client)
+        }
         return consumed
     }
 

--- a/App/InputEngine.swift
+++ b/App/InputEngine.swift
@@ -14,6 +14,7 @@ import KeyKeyEngine
 protocol InputEngine: AnyObject {
     func handleKey(_ key: Character) -> Bool
     var composingText: String { get }
+    var isComposingSyllable: Bool { get }
     var candidates: [String] { get }
     func selectCandidate(_ index: Int)
     func backspace()
@@ -40,6 +41,9 @@ final class PlainPhoneticEngineAdapter: InputEngine {
     func handleKey(_ key: Character) -> Bool { engine.handleKey(key) }
 
     var composingText: String { pendingSelection ?? engine.composingText }
+
+    // A held selection is already finalized, so it is never a tone-pending syllable.
+    var isComposingSyllable: Bool { pendingSelection == nil ? engine.isComposingSyllable : false }
 
     // Once a selection is pending, the composition is effectively finalized: report no
     // candidates so composingText (= pendingSelection) and candidates stay consistent if

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/CangjieEngine.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/CangjieEngine.swift
@@ -31,6 +31,9 @@ public final class CangjieEngine {
         return true
     }
 
+    /// Cangjie has no tone concept, so it never holds a tone-pending syllable.
+    public var isComposingSyllable: Bool { false }
+
     /// The 倉頡 radical glyphs accumulated so far, e.g. "日月".
     public var composingText: String {
         if let selected { return selected }

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/PlainPhoneticEngine.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/PlainPhoneticEngine.swift
@@ -34,6 +34,9 @@ public final class PlainPhoneticEngine {
         }
     }
 
+    /// True while a phonetic syllable has phonemes typed but no tone applied yet.
+    public var isComposingSyllable: Bool { !pendingBPMF.isEmpty }
+
     /// Mid-syllable: the in-progress BPMF. Otherwise: the completed reading awaiting selection.
     public var composingText: String {
         pendingBPMF.isEmpty ? completedReading : pendingBPMF

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/SmartPhoneticEngine.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/SmartPhoneticEngine.swift
@@ -41,6 +41,9 @@ public final class SmartPhoneticEngine {
         }
     }
 
+    /// True while a phonetic syllable has phonemes typed but no tone applied yet.
+    public var isComposingSyllable: Bool { !buffer.isEmpty }
+
     /// Current selected reading index. Defaults to the last position; clamped to bounds.
     public var cursorPosition: Int {
         guard !readings.isEmpty else { return 0 }

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/SmartPhoneticEngineTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/SmartPhoneticEngineTests.swift
@@ -46,6 +46,15 @@ final class SmartPhoneticEngineTests: XCTestCase {
         XCTAssertFalse(e.handleKey("`"))
     }
 
+    func testIsComposingSyllableTrueWithPhonemesFalseAfterTone() {
+        let e = SmartPhoneticEngine(languageModel: Self.phraseLM)
+        XCTAssertFalse(e.isComposingSyllable)              // nothing typed yet
+        _ = e.handleKey("r"); _ = e.handleKey("u"); _ = e.handleKey("p")  // ㄐㄧㄣ phonemes
+        XCTAssertTrue(e.isComposingSyllable)               // mid-syllable, no tone
+        _ = e.handleKey(" ")                               // tone 1 finalizes
+        XCTAssertFalse(e.isComposingSyllable)
+    }
+
     static let phraseLM = LanguageModel(text: """
     # format org.openvanilla.mcbopomofo.sorted
     ㄐㄧㄣ 今 -4.0


### PR DESCRIPTION
Space now confirms a finalized composition (Smart commits the walked phrase; Plain/Cangjie commit the top candidate); a mid-syllable space still finalizes as tone-1. Plain Phonetic shows the numbered candidate window as soon as a syllable completes. Adds engine `isComposingSyllable`. 124 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)