### PR TITLE
Cangjie v1.0.0: wildcard, punctuation, associations, Simplex, pagination

### DIFF
--- a/App/CandidateWindow.swift
+++ b/App/CandidateWindow.swift
@@ -25,10 +25,13 @@ final class CandidateWindow {
         panel.contentView = content
     }
 
-    func show(_ candidates: [String], near point: NSPoint) {
-        let shown = candidates.prefix(9).enumerated()
+    // `pageCandidates` is the already-sliced set for the current page (≤9). When `pageCount`
+    // exceeds 1, a " (page/total)" indicator is appended.
+    func show(_ pageCandidates: [String], page: Int, pageCount: Int, near point: NSPoint) {
+        var shown = pageCandidates.prefix(9).enumerated()
             .map { "\($0.offset + 1).\($0.element)" }
             .joined(separator: "  ")
+        if pageCount > 1 { shown += "  (\(page + 1)/\(pageCount))" }
         label.stringValue = shown
         panel.setContentSize(label.intrinsicContentSize)
         panel.setFrameTopLeftPoint(NSPoint(x: point.x, y: point.y - 4))

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -8,7 +8,7 @@
     <key>CFBundleName</key><string>Yahoo KeyKey 2</string>
     <key>CFBundleDisplayName</key><string>Yahoo KeyKey 2</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.1.0</string>
+    <key>CFBundleShortVersionString</key><string>1.0.0</string>
     <key>CFBundleVersion</key><string>1</string>
     <key>LSMinimumSystemVersion</key><string>12.0</string>
     <key>LSUIElement</key><true/>
@@ -23,21 +23,14 @@
     <dict>
         <key>tsInputModeListKey</key>
         <dict>
-            <key>com.github.teddychan.inputmethod.YahooKeyKey2.SmartPhonetic</key>
-            <dict>
-                <key>TISIntendedLanguage</key><string>zh-Hant</string>
-                <key>tsInputModeCharacterRepertoireKey</key><array><string>Hant</string></array>
-                <key>tsInputModeIsVisibleKey</key><true/>
-                <key>tsInputModeScriptKey</key><string>smTradChinese</string>
-            </dict>
-            <key>com.github.teddychan.inputmethod.YahooKeyKey2.PlainPhonetic</key>
-            <dict>
-                <key>TISIntendedLanguage</key><string>zh-Hant</string>
-                <key>tsInputModeCharacterRepertoireKey</key><array><string>Hant</string></array>
-                <key>tsInputModeIsVisibleKey</key><true/>
-                <key>tsInputModeScriptKey</key><string>smTradChinese</string>
-            </dict>
             <key>com.github.teddychan.inputmethod.YahooKeyKey2.Cangjie</key>
+            <dict>
+                <key>TISIntendedLanguage</key><string>zh-Hant</string>
+                <key>tsInputModeCharacterRepertoireKey</key><array><string>Hant</string></array>
+                <key>tsInputModeIsVisibleKey</key><true/>
+                <key>tsInputModeScriptKey</key><string>smTradChinese</string>
+            </dict>
+            <key>com.github.teddychan.inputmethod.YahooKeyKey2.Simplex</key>
             <dict>
                 <key>TISIntendedLanguage</key><string>zh-Hant</string>
                 <key>tsInputModeCharacterRepertoireKey</key><array><string>Hant</string></array>
@@ -47,9 +40,8 @@
         </dict>
         <key>tsVisibleInputModeOrderedArrayKey</key>
         <array>
-            <string>com.github.teddychan.inputmethod.YahooKeyKey2.SmartPhonetic</string>
-            <string>com.github.teddychan.inputmethod.YahooKeyKey2.PlainPhonetic</string>
             <string>com.github.teddychan.inputmethod.YahooKeyKey2.Cangjie</string>
+            <string>com.github.teddychan.inputmethod.YahooKeyKey2.Simplex</string>
         </array>
     </dict>
 </dict>

--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -26,29 +26,36 @@ private enum InputMethodChoice: String {
     case smartPhonetic
     case plainPhonetic
     case cangjie
+    case simplex
 
     // Map an IMK input-mode identifier (…YahooKeyKey2.Cangjie etc.) to a method.
+    // v1.0.0 exposes only Cangjie and Simplex; default to Cangjie.
     init(modeID: String) {
-        if modeID.hasSuffix(".Cangjie") { self = .cangjie }
+        if modeID.hasSuffix(".Simplex") { self = .simplex }
         else if modeID.hasSuffix(".PlainPhonetic") { self = .plainPhonetic }
-        else { self = .smartPhonetic }
+        else if modeID.hasSuffix(".SmartPhonetic") { self = .smartPhonetic }
+        else { self = .cangjie }
     }
 
-    // Only Cangjie selects directly by digit: its keys are a–z, so digits are unambiguous
-    // selectors. Phonetic methods use Down-then-digit, because in Bopomofo layouts several
-    // digit keys ("1"=ㄅ, "2"=ㄉ, …) are valid input and must not be hijacked.
-    var usesDirectDigitSelect: Bool { self == .cangjie }
+    // Cangjie and Simplex select directly by digit: their keys are a–z, so digits are
+    // unambiguous selectors. Phonetic methods use Down-then-digit, because in Bopomofo
+    // layouts several digit keys ("1"=ㄅ, "2"=ㄉ, …) are valid input and must not be hijacked.
+    var usesDirectDigitSelect: Bool { self == .cangjie || self == .simplex }
 }
 
 @objc(InputController)
 final class InputController: IMKInputController {
     private let lm: LanguageModel
     private let cangjieTable: CangjieTable
+    private let simplexTable: SimplexTable
     private let layout: LayoutChoice = .standard
-    private var method: InputMethodChoice = .smartPhonetic
+    private var method: InputMethodChoice = .cangjie
     private var engine: InputEngine
     private let candidateWindow = CandidateWindow()
     private var selecting = false
+    // Current candidate page (9 per page) for the active composition.
+    private var candidatePage = 0
+    private static let pageSize = 9
 
     override init!(server: IMKServer!, delegate: Any!, client inputClient: Any!) {
         // Load the bundled LM once; fail safe to an empty model (no candidates) if missing.
@@ -73,17 +80,24 @@ final class InputController: IMKInputController {
         }
         self.cangjieTable = cangjieTable
 
-        // Start on Smart Phonetic; IMK calls setValue(_:forTag:client:) with the active
-        // input mode (and on every mode switch), which rebuilds the engine accordingly.
-        self.engine = InputController.makeEngine(method: .smartPhonetic, layout: .standard,
-                                                 lm: lm, cangjieTable: cangjieTable)
+        // Derive the Simplex table from the Cangjie table once (Simplex = first one/two
+        // Cangjie radicals → all matching characters).
+        let simplexTable = SimplexTable(cangjie: cangjieTable)
+        self.simplexTable = simplexTable
+
+        // Start on Cangjie; IMK calls setValue(_:forTag:client:) with the active input mode
+        // (and on every mode switch), which rebuilds the engine accordingly.
+        self.engine = InputController.makeEngine(method: .cangjie, layout: .standard,
+                                                 lm: lm, cangjieTable: cangjieTable,
+                                                 simplexTable: simplexTable)
         super.init(server: server, delegate: delegate, client: inputClient)
     }
 
     // Build the engine for the active method, wrapping in an adapter where the engine
     // surface doesn't already match the app-internal InputEngine protocol.
     private static func makeEngine(method: InputMethodChoice, layout: LayoutChoice,
-                                   lm: LanguageModel, cangjieTable: CangjieTable) -> InputEngine {
+                                   lm: LanguageModel, cangjieTable: CangjieTable,
+                                   simplexTable: SimplexTable) -> InputEngine {
         switch method {
         case .smartPhonetic:
             return SmartPhoneticEngine(languageModel: lm, layout: layout.makeLayout())
@@ -91,6 +105,8 @@ final class InputController: IMKInputController {
             return PlainPhoneticEngineAdapter(PlainPhoneticEngine(languageModel: lm, layout: layout.makeLayout()))
         case .cangjie:
             return CangjieEngine(table: cangjieTable)
+        case .simplex:
+            return SimplexEngine(table: simplexTable)
         }
     }
 
@@ -111,9 +127,11 @@ final class InputController: IMKInputController {
             _ = engine.commit()
         }
         selecting = false
+        candidatePage = 0
         candidateWindow.hide()
         method = choice
-        engine = InputController.makeEngine(method: choice, layout: layout, lm: lm, cangjieTable: cangjieTable)
+        engine = InputController.makeEngine(method: choice, layout: layout, lm: lm,
+                                            cangjieTable: cangjieTable, simplexTable: simplexTable)
     }
 
     override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
@@ -138,14 +156,30 @@ final class InputController: IMKInputController {
             selecting = false   // fall through to normal composing below
         }
 
-        // Cangjie shows candidates as soon as a code resolves, and its keys are a–z, so digits
-        // 1–9 select directly without first opening the picker. (Phonetic methods use
-        // Down-then-digit, since digit keys are valid Bopomofo input there.)
-        if method.usesDirectDigitSelect,
-           let chars = event.characters, let d = Int(chars), (1...9).contains(d),
-           d - 1 < engine.candidates.count {
-            engine.selectCandidate(d - 1)
-            return commitCurrent(to: client)
+        // Cangjie/Simplex show candidates as soon as a code resolves, and their keys are a–z,
+        // so digits 1–9 select directly within the current page, and arrows page through the
+        // full candidate list. (Phonetic methods use Down-then-digit, since digit keys are
+        // valid Bopomofo input there.)
+        if method.usesDirectDigitSelect, !engine.candidates.isEmpty {
+            let count = engine.candidates.count
+            let lastPage = (count - 1) / InputController.pageSize
+            switch event.keyCode {
+            case 125, 124: // Down / Right arrow → next page
+                if candidatePage < lastPage { candidatePage += 1; refresh(client) }
+                return true
+            case 126, 123: // Up / Left arrow → previous page
+                if candidatePage > 0 { candidatePage -= 1; refresh(client) }
+                return true
+            default: break
+            }
+            if let chars = event.characters, let d = Int(chars), (1...9).contains(d) {
+                let index = candidatePage * InputController.pageSize + (d - 1)
+                if index < count {
+                    engine.selectCandidate(index)
+                    return commitCurrent(to: client)
+                }
+                return true // digit beyond this page's candidates: swallow, no insert
+            }
         }
 
         // SPACE: while a syllable is still being composed (no tone yet), fall through so the
@@ -157,7 +191,12 @@ final class InputController: IMKInputController {
             } else if !engine.composingText.isEmpty {
                 if method == .smartPhonetic {
                     return commitCurrent(to: client)
-                } else { // .plainPhonetic / .cangjie: commit the top candidate
+                } else if method.usesDirectDigitSelect { // .cangjie / .simplex: commit first of current page
+                    if !engine.candidates.isEmpty {
+                        engine.selectCandidate(candidatePage * InputController.pageSize)
+                    }
+                    return commitCurrent(to: client)
+                } else { // .plainPhonetic: commit the top candidate
                     if !engine.candidates.isEmpty { engine.selectCandidate(0) }
                     return commitCurrent(to: client)
                 }
@@ -170,13 +209,17 @@ final class InputController: IMKInputController {
         switch event.keyCode {
         case 36: // Return
             guard !engine.composingText.isEmpty else { return false }
+            // Cangjie/Simplex: commit the first candidate of the current page.
+            if method.usesDirectDigitSelect, !engine.candidates.isEmpty {
+                engine.selectCandidate(candidatePage * InputController.pageSize)
+            }
             return commitCurrent(to: client)
         case 51: // Delete/Backspace
             guard !engine.composingText.isEmpty else { return false }
-            engine.backspace(); refresh(client); return true
+            engine.backspace(); candidatePage = 0; refresh(client); return true
         case 53: // Escape cancels composition (commit-then-discard)
             guard !engine.composingText.isEmpty else { return false }
-            _ = engine.commit(); refresh(client); return true
+            _ = engine.commit(); candidatePage = 0; refresh(client); return true
         case 125: // Down arrow opens candidate selection
             guard !engine.composingText.isEmpty, !engine.candidates.isEmpty else { return false }
             selecting = true; refresh(client); return true
@@ -186,6 +229,8 @@ final class InputController: IMKInputController {
         guard let ch = event.characters?.first else { return false }
         let consumed = engine.handleKey(ch)
         if consumed {
+            // A new radical/key changes the candidate set; restart paging from page 0.
+            candidatePage = 0
             // Plain Phonetic: as soon as a syllable completes, show its numbered candidates
             // (incl. after space=tone 1) so digits 1–9 select. Down still works.
             if method == .plainPhonetic, !engine.candidates.isEmpty { selecting = true }
@@ -202,6 +247,7 @@ final class InputController: IMKInputController {
     @discardableResult
     private func commitCurrent(to client: IMKTextInput) -> Bool {
         selecting = false
+        candidatePage = 0
         let text = engine.commit()
         if !text.isEmpty {
             client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
@@ -224,9 +270,13 @@ final class InputController: IMKInputController {
         let numbersSelect = selecting || method.usesDirectDigitSelect
         if cands.isEmpty || !numbersSelect { candidateWindow.hide() }
         else {
+            let size = InputController.pageSize
+            let pageCount = (cands.count + size - 1) / size
+            let start = candidatePage * size
+            let page = Array(cands[start..<min(start + size, cands.count)])
             var rect = NSRect.zero
             client.attributes(forCharacterIndex: 0, lineHeightRectangle: &rect)
-            candidateWindow.show(cands, near: rect.origin)
+            candidateWindow.show(page, page: candidatePage, pageCount: pageCount, near: rect.origin)
         }
     }
 }

--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -46,6 +46,7 @@ private enum InputMethodChoice: String {
 @objc(InputController)
 final class InputController: IMKInputController {
     private let lm: LanguageModel
+    private let associatedPhrases: AssociatedPhrases
     private let cangjieTable: CangjieTable
     private let simplexTable: SimplexTable
     private let layout: LayoutChoice = .standard
@@ -53,8 +54,11 @@ final class InputController: IMKInputController {
     private var engine: InputEngine
     private let candidateWindow = CandidateWindow()
     private var selecting = false
-    // Current candidate page (9 per page) for the active composition.
+    // Current candidate page (9 per page) for the active composition; reused for association paging.
     private var candidatePage = 0
+    // Associated phrases (聯想) offered after committing a single character; empty when not in
+    // association mode. Paged with `candidatePage`, shown in the same numbered candidate window.
+    private var associations: [String] = []
     private static let pageSize = 9
 
     override init!(server: IMKServer!, delegate: Any!, client inputClient: Any!) {
@@ -68,6 +72,17 @@ final class InputController: IMKInputController {
             lm = LanguageModel(text: "# format org.openvanilla.mcbopomofo.sorted")
         }
         self.lm = lm
+
+        // Build associated phrases from the same bundled data.txt; fail safe to empty if missing.
+        let associatedPhrases: AssociatedPhrases
+        if let url = Bundle.main.url(forResource: "data", withExtension: "txt"),
+           let loaded = try? AssociatedPhrases(contentsOf: url) {
+            associatedPhrases = loaded
+        } else {
+            NSLog("YahooKeyKey: data.txt missing; running with empty associated phrases")
+            associatedPhrases = AssociatedPhrases(text: "")
+        }
+        self.associatedPhrases = associatedPhrases
 
         // Load the bundled Cangjie table; fail safe to an empty table (no candidates) if missing.
         let cangjieTable: CangjieTable
@@ -128,6 +143,7 @@ final class InputController: IMKInputController {
         }
         selecting = false
         candidatePage = 0
+        associations = []
         candidateWindow.hide()
         method = choice
         engine = InputController.makeEngine(method: choice, layout: layout, lm: lm,
@@ -136,6 +152,46 @@ final class InputController: IMKInputController {
 
     override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
         guard let event, event.type == .keyDown, let client = sender as? IMKTextInput else { return false }
+
+        // Association mode (聯想): after committing a single character we offer follow-on phrases.
+        // The engine has no active composition here. Digits pick a phrase; arrows page; Esc
+        // dismisses; any other key dismisses the suggestions and is then processed normally.
+        if !associations.isEmpty {
+            let count = associations.count
+            let lastPage = (count - 1) / InputController.pageSize
+            switch event.keyCode {
+            case 53: // Escape dismisses associations
+                clearAssociations(); return true
+            case 125, 124: // Down / Right arrow → next page
+                if candidatePage < lastPage { candidatePage += 1; refresh(client) }
+                return true
+            case 126, 123: // Up / Left arrow → previous page
+                if candidatePage > 0 { candidatePage -= 1; refresh(client) }
+                return true
+            default: break
+            }
+            if let chars = event.characters, let d = Int(chars), (1...9).contains(d) {
+                let index = candidatePage * InputController.pageSize + (d - 1)
+                if index < count {
+                    let phrase = associations[index]
+                    clearAssociations()
+                    client.insertText(phrase, replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
+                    return true
+                }
+                return true // digit beyond this page: swallow, no insert
+            }
+            // Any other key: dismiss suggestions, then fall through to process the key normally.
+            clearAssociations()
+        }
+
+        // Full-width punctuation when idle: no active composition (and not in association mode,
+        // already handled above). A mapped ASCII punctuation key inserts its full-width form.
+        // Mid-composition keys are left to the engine below.
+        if engine.composingText.isEmpty, let ch = event.characters?.first,
+           let full = Punctuation.fullWidth(for: ch) {
+            client.insertText(full, replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
+            return true
+        }
 
         // Selection mode (entered via Down): digits pick a candidate; Esc just closes the
         // picker and keeps the composition; any other key resumes normal composing.
@@ -252,10 +308,28 @@ final class InputController: IMKInputController {
         if !text.isEmpty {
             client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
         }
-        candidateWindow.hide()
         client.setMarkedText("", selectionRange: NSRange(location: 0, length: 0),
                              replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
+        // After committing a single character, offer associated phrases (聯想). For longer
+        // commits (phrases) or empty commits, just hide the candidate window.
+        if text.count == 1, let first = text.first {
+            let phrases = associatedPhrases.associations(for: first)
+            if !phrases.isEmpty {
+                associations = phrases
+                candidatePage = 0
+                refresh(client)
+                return true
+            }
+        }
+        candidateWindow.hide()
         return true
+    }
+
+    // Leave association mode: drop the suggestions, reset paging, hide the candidate window.
+    private func clearAssociations() {
+        associations = []
+        candidatePage = 0
+        candidateWindow.hide()
     }
 
     private func refresh(_ client: IMKTextInput) {
@@ -263,11 +337,12 @@ final class InputController: IMKInputController {
         client.setMarkedText(composing,
                              selectionRange: NSRange(location: composing.utf16.count, length: 0),
                              replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
+        // In association mode show the suggested phrases (paged); otherwise show engine candidates.
         // Only show the numbered candidate window when number keys actually select:
         // in `selecting` mode (phonetic, after Down) or for Cangjie (direct digit-select).
         // Otherwise the list would imply number-select while digits are still Bopomofo input.
-        let cands = engine.candidates
-        let numbersSelect = selecting || method.usesDirectDigitSelect
+        let cands = associations.isEmpty ? engine.candidates : associations
+        let numbersSelect = !associations.isEmpty || selecting || method.usesDirectDigitSelect
         if cands.isEmpty || !numbersSelect { candidateWindow.hide() }
         else {
             let size = InputController.pageSize

--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -136,7 +136,7 @@ final class InputController: IMKInputController {
         let choice = InputMethodChoice(modeID: modeID)
         guard choice != method else { return }
         // Commit any in-progress composition so the rebuilt engine starts clean.
-        if let client = sender as? IMKTextInput ?? client() as? IMKTextInput {
+        if let client = sender as? IMKTextInput ?? client() {
             _ = commitCurrent(to: client)
         } else {
             _ = engine.commit()
@@ -201,13 +201,13 @@ final class InputController: IMKInputController {
             }
             if event.keyCode == 49 { // Space confirms the current/top candidate
                 if !engine.candidates.isEmpty { engine.selectCandidate(0) }
-                return commitCurrent(to: client)
+                return commitCurrent(to: client, offerAssociations: true)
             }
             if let chars = event.characters, let d = Int(chars), (1...9).contains(d),
                d - 1 < engine.candidates.count {
                 engine.selectCandidate(d - 1)
                 selecting = false
-                return commitCurrent(to: client)
+                return commitCurrent(to: client, offerAssociations: true)
             }
             selecting = false   // fall through to normal composing below
         }
@@ -232,7 +232,7 @@ final class InputController: IMKInputController {
                 let index = candidatePage * InputController.pageSize + (d - 1)
                 if index < count {
                     engine.selectCandidate(index)
-                    return commitCurrent(to: client)
+                    return commitCurrent(to: client, offerAssociations: true)
                 }
                 return true // digit beyond this page's candidates: swallow, no insert
             }
@@ -246,15 +246,15 @@ final class InputController: IMKInputController {
                 // fall through to engine.handleKey(" ") below to finalize as tone 1
             } else if !engine.composingText.isEmpty {
                 if method == .smartPhonetic {
-                    return commitCurrent(to: client)
+                    return commitCurrent(to: client, offerAssociations: true)
                 } else if method.usesDirectDigitSelect { // .cangjie / .simplex: commit first of current page
                     if !engine.candidates.isEmpty {
                         engine.selectCandidate(candidatePage * InputController.pageSize)
                     }
-                    return commitCurrent(to: client)
+                    return commitCurrent(to: client, offerAssociations: true)
                 } else { // .plainPhonetic: commit the top candidate
                     if !engine.candidates.isEmpty { engine.selectCandidate(0) }
-                    return commitCurrent(to: client)
+                    return commitCurrent(to: client, offerAssociations: true)
                 }
             } else {
                 return false // nothing composing: pass a literal space to the app
@@ -269,7 +269,7 @@ final class InputController: IMKInputController {
             if method.usesDirectDigitSelect, !engine.candidates.isEmpty {
                 engine.selectCandidate(candidatePage * InputController.pageSize)
             }
-            return commitCurrent(to: client)
+            return commitCurrent(to: client, offerAssociations: true)
         case 51: // Delete/Backspace
             guard !engine.composingText.isEmpty else { return false }
             engine.backspace(); candidatePage = 0; refresh(client); return true
@@ -301,7 +301,7 @@ final class InputController: IMKInputController {
     }
 
     @discardableResult
-    private func commitCurrent(to client: IMKTextInput) -> Bool {
+    private func commitCurrent(to client: IMKTextInput, offerAssociations: Bool = false) -> Bool {
         selecting = false
         candidatePage = 0
         let text = engine.commit()
@@ -310,9 +310,9 @@ final class InputController: IMKInputController {
         }
         client.setMarkedText("", selectionRange: NSRange(location: 0, length: 0),
                              replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
-        // After committing a single character, offer associated phrases (聯想). For longer
-        // commits (phrases) or empty commits, just hide the candidate window.
-        if text.count == 1, let first = text.first {
+        // After an explicit user commit of a single character, offer associated phrases (聯想).
+        // System-driven commits (focus loss, mode switch) pass offerAssociations: false and stay idle.
+        if offerAssociations, text.count == 1, let first = text.first {
             let phrases = associatedPhrases.associations(for: first)
             if !phrases.isEmpty {
                 associations = phrases
@@ -321,6 +321,7 @@ final class InputController: IMKInputController {
                 return true
             }
         }
+        associations = []
         candidateWindow.hide()
         return true
     }
@@ -347,6 +348,8 @@ final class InputController: IMKInputController {
         else {
             let size = InputController.pageSize
             let pageCount = (cands.count + size - 1) / size
+            // Guard against a stale candidatePage pointing past the end (would trap on slice).
+            if candidatePage * size >= cands.count { candidatePage = 0 }
             let start = candidatePage * size
             let page = Array(cands[start..<min(start + size, cands.count)])
             var rect = NSRect.zero

--- a/App/InputEngine.swift
+++ b/App/InputEngine.swift
@@ -29,6 +29,9 @@ extension SmartPhoneticEngine: InputEngine {}
 // commit() emits it, so a direct digit-select followed by commit() works.
 extension CangjieEngine: InputEngine {}
 
+// SimplexEngine mirrors the CangjieEngine surface exactly (direct digit-select then commit()).
+extension SimplexEngine: InputEngine {}
+
 // PlainPhoneticEngine differs: its selectCandidate(_:) returns the chosen single
 // character AND resets the engine, so a follow-up commit() would yield nothing.
 // This thin adapter captures the selection so commit() returns it instead.

--- a/App/en.lproj/InfoPlist.strings
+++ b/App/en.lproj/InfoPlist.strings
@@ -1,5 +1,4 @@
 CFBundleName = "Yahoo KeyKey 2";
 CFBundleDisplayName = "Yahoo KeyKey 2";
-"com.github.teddychan.inputmethod.YahooKeyKey2.SmartPhonetic" = "Yahoo KeyKey 2 — Smart Phonetic";
-"com.github.teddychan.inputmethod.YahooKeyKey2.PlainPhonetic" = "Yahoo KeyKey 2 — Plain Phonetic";
 "com.github.teddychan.inputmethod.YahooKeyKey2.Cangjie" = "Yahoo KeyKey 2 — Cangjie";
+"com.github.teddychan.inputmethod.YahooKeyKey2.Simplex" = "Yahoo KeyKey 2 — Simplex";

--- a/App/zh-Hant.lproj/InfoPlist.strings
+++ b/App/zh-Hant.lproj/InfoPlist.strings
@@ -1,5 +1,4 @@
 CFBundleName = "Yahoo KeyKey 2";
 CFBundleDisplayName = "Yahoo KeyKey 2";
-"com.github.teddychan.inputmethod.YahooKeyKey2.SmartPhonetic" = "Yahoo KeyKey 2 — 智慧注音";
-"com.github.teddychan.inputmethod.YahooKeyKey2.PlainPhonetic" = "Yahoo KeyKey 2 — 傳統注音";
 "com.github.teddychan.inputmethod.YahooKeyKey2.Cangjie" = "Yahoo KeyKey 2 — 倉頡";
+"com.github.teddychan.inputmethod.YahooKeyKey2.Simplex" = "Yahoo KeyKey 2 — 簡易";

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/AssociatedPhrases.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/AssociatedPhrases.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+// Associated phrases (聯想詞): multi-character words indexed by their first character,
+// loaded from the McBopomofo "sorted" LM. Format per line: "<reading> <phrase> <score>".
+public struct AssociatedPhrases {
+    private static let maxPerBucket = 20
+
+    private var table: [Character: [String]] = [:]
+
+    public init(text: String) {
+        var scored: [Character: [(phrase: String, score: Double)]] = [:]
+        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+            let parts = line.split(separator: " ")
+            guard parts.count == 3, let score = Double(parts[2]) else { continue }
+            let phrase = String(parts[1])
+            guard phrase.count >= 2, let first = phrase.first else { continue }
+            scored[first, default: []].append((phrase, score))
+        }
+        for (first, entries) in scored {
+            var seen = Set<String>()
+            var phrases: [String] = []
+            for entry in entries.sorted(by: { $0.score > $1.score }) {
+                if seen.insert(entry.phrase).inserted {
+                    phrases.append(entry.phrase)
+                    if phrases.count == Self.maxPerBucket { break }
+                }
+            }
+            table[first] = phrases
+        }
+    }
+
+    public init(contentsOf url: URL) throws {
+        try self.init(text: String(contentsOf: url, encoding: .utf8))
+    }
+
+    public func associations(for first: Character) -> [String] { table[first] ?? [] }
+}

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/CangjieEngine.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/CangjieEngine.swift
@@ -22,9 +22,10 @@ public final class CangjieEngine {
     }
 
     /// Returns true if the key was consumed by the engine.
+    /// Accepts a–z radical keys and `*` (wildcard for one-or-more unknown radicals).
     @discardableResult
     public func handleKey(_ key: Character) -> Bool {
-        guard Self.radicals[key] != nil else { return false }
+        guard Self.radicals[key] != nil || key == "*" else { return false }
         guard code.count < Self.maxRadicals else { return true }
         code.append(key)
         selected = nil
@@ -34,15 +35,15 @@ public final class CangjieEngine {
     /// Cangjie has no tone concept, so it never holds a tone-pending syllable.
     public var isComposingSyllable: Bool { false }
 
-    /// The 倉頡 radical glyphs accumulated so far, e.g. "日月".
+    /// The 倉頡 radical glyphs accumulated so far, e.g. "日月". `*` is shown literally.
     public var composingText: String {
         if let selected { return selected }
-        return String(code.compactMap { Self.radicals[$0] })
+        return String(code.map { Self.radicals[$0] ?? $0 })
     }
 
-    /// Characters whose code equals the current radical sequence.
+    /// Characters whose code matches the current radical sequence (supports `*`).
     public var candidates: [String] {
-        code.isEmpty ? [] : table.characters(forCode: code)
+        code.isEmpty ? [] : table.characters(matching: code)
     }
 
     public func selectCandidate(_ index: Int) {
@@ -58,7 +59,7 @@ public final class CangjieEngine {
 
     @discardableResult
     public func commit() -> String {
-        let text = composingText
+        let text = selected ?? candidates.first ?? ""
         code = ""
         selected = nil
         return text

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/CangjieTable.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/CangjieTable.swift
@@ -22,4 +22,26 @@ public struct CangjieTable {
 
     public func characters(forCode code: String) -> [String] { table[code] ?? [] }
     public func hasCode(_ code: String) -> Bool { table[code] != nil }
+
+    /// Iterates every (code, characters) entry in insertion-independent order.
+    public func forEachEntry(_ body: (String, [String]) -> Void) {
+        for (code, chars) in table { body(code, chars) }
+    }
+
+    /// Returns characters whose code matches `pattern`. `*` matches one-or-more
+    /// letters (a–z); other characters match literally. With no `*`, behaves like
+    /// an exact `characters(forCode:)`. Results are ordered by matched code length
+    /// then the table's character order for that code (deterministic).
+    public func characters(matching pattern: String) -> [String] {
+        guard pattern.contains("*") else { return characters(forCode: pattern) }
+        let regex = "^" + pattern.split(separator: "*", omittingEmptySubsequences: false)
+            .map { NSRegularExpression.escapedPattern(for: String($0)) }
+            .joined(separator: "[a-z]+") + "$"
+        guard let re = try? NSRegularExpression(pattern: regex) else { return [] }
+        let matched = table.keys.filter {
+            re.firstMatch(in: $0, range: NSRange($0.startIndex..., in: $0)) != nil
+        }
+        return matched.sorted { ($0.count, $0) < ($1.count, $1) }
+            .flatMap { table[$0] ?? [] }
+    }
 }

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/Punctuation.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/Punctuation.swift
@@ -1,0 +1,44 @@
+// Maps an ASCII punctuation key to its Traditional-Chinese full-width form.
+// Used by Cangjie/Simplex modes. Pure and stateless.
+public enum Punctuation {
+    private static let table: [Character: String] = [
+        ",": "，",   // FULLWIDTH COMMA (U+FF0C)
+        ".": "。",   // IDEOGRAPHIC FULL STOP (U+3002)
+        ";": "；",   // FULLWIDTH SEMICOLON (U+FF1B)
+        ":": "：",   // FULLWIDTH COLON (U+FF1A)
+        "?": "？",   // FULLWIDTH QUESTION MARK (U+FF1F)
+        "!": "！",   // FULLWIDTH EXCLAMATION MARK (U+FF01)
+        "\\": "、",  // IDEOGRAPHIC COMMA (U+3001)
+        "`": "、",   // IDEOGRAPHIC COMMA (U+3001)
+        "'": "’",    // RIGHT SINGLE QUOTATION MARK (U+2019)
+        "\"": "”",   // RIGHT DOUBLE QUOTATION MARK (U+201D)
+        "(": "（",   // FULLWIDTH LEFT PARENTHESIS (U+FF08)
+        ")": "）",   // FULLWIDTH RIGHT PARENTHESIS (U+FF09)
+        "[": "「",   // LEFT CORNER BRACKET (U+300C)
+        "]": "」",   // RIGHT CORNER BRACKET (U+300D)
+        "{": "『",   // LEFT WHITE CORNER BRACKET (U+300E)
+        "}": "』",   // RIGHT WHITE CORNER BRACKET (U+300F)
+        "<": "《",   // LEFT DOUBLE ANGLE BRACKET (U+300A)
+        ">": "》",   // RIGHT DOUBLE ANGLE BRACKET (U+300B)
+        "~": "～",   // FULLWIDTH TILDE (U+FF5E)
+        "@": "＠",   // FULLWIDTH COMMERCIAL AT (U+FF20)
+        "#": "＃",   // FULLWIDTH NUMBER SIGN (U+FF03)
+        "$": "＄",   // FULLWIDTH DOLLAR SIGN (U+FF04)
+        "%": "％",   // FULLWIDTH PERCENT SIGN (U+FF05)
+        "^": "＾",   // FULLWIDTH CIRCUMFLEX ACCENT (U+FF3E)
+        "&": "＆",   // FULLWIDTH AMPERSAND (U+FF06)
+        "*": "＊",   // FULLWIDTH ASTERISK (U+FF0A)
+        "-": "－",   // FULLWIDTH HYPHEN-MINUS (U+FF0D)
+        "_": "＿",   // FULLWIDTH LOW LINE (U+FF3F)
+        "+": "＋",   // FULLWIDTH PLUS SIGN (U+FF0B)
+        "=": "＝",   // FULLWIDTH EQUALS SIGN (U+FF1D)
+        "/": "／",   // FULLWIDTH SOLIDUS (U+FF0F)
+        "|": "｜",   // FULLWIDTH VERTICAL LINE (U+FF5C)
+    ]
+
+    /// Returns the Traditional-Chinese full-width punctuation for an ASCII key,
+    /// or nil if the key is not a mapped punctuation.
+    public static func fullWidth(for key: Character) -> String? {
+        return table[key]
+    }
+}

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/SimplexEngine.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/SimplexEngine.swift
@@ -1,0 +1,55 @@
+// Simplex (簡易) engine: accumulate radical letter keys (a–z), look up the matching
+// characters in the SimplexTable, then select/commit. Mirrors the CangjieEngine surface
+// (handleKey/composingText/candidates/selectCandidate/commit/backspace). Reuses
+// CangjieEngine.radicals for the composing-display glyphs.
+public final class SimplexEngine {
+    private let table: SimplexTable
+    private var code: String = ""
+    private var selected: String?
+
+    public init(table: SimplexTable) {
+        self.table = table
+    }
+
+    /// Returns true if the key was consumed by the engine. Accepts a–z radical keys.
+    @discardableResult
+    public func handleKey(_ key: Character) -> Bool {
+        guard CangjieEngine.radicals[key] != nil else { return false }
+        code.append(key)
+        selected = nil
+        return true
+    }
+
+    /// Simplex has no tone concept, so it never holds a tone-pending syllable.
+    public var isComposingSyllable: Bool { false }
+
+    /// The radical glyphs accumulated so far (selected char once chosen).
+    public var composingText: String {
+        if let selected { return selected }
+        return String(code.map { CangjieEngine.radicals[$0] ?? $0 })
+    }
+
+    /// Characters whose Simplex code matches the current radical sequence.
+    public var candidates: [String] {
+        code.isEmpty ? [] : table.characters(forCode: code)
+    }
+
+    public func selectCandidate(_ index: Int) {
+        let cands = candidates
+        guard index >= 0, index < cands.count else { return }
+        selected = cands[index]
+    }
+
+    public func backspace() {
+        selected = nil
+        if !code.isEmpty { code.removeLast() }
+    }
+
+    @discardableResult
+    public func commit() -> String {
+        let text = selected ?? candidates.first ?? ""
+        code = ""
+        selected = nil
+        return text
+    }
+}

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/SimplexTable.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/SimplexTable.swift
@@ -1,0 +1,45 @@
+// Simplex (簡易) index: maps a 2-letter "quick" code to the characters that share it.
+// The Simplex code of a Cangjie code is its first + last radical letter (a single
+// letter when the Cangjie code has length 1). Many Cangjie codes collapse onto the
+// same Simplex code, so candidate lists are larger than full Cangjie.
+public struct SimplexTable {
+    private var table: [String: [String]] = [:]
+
+    /// Builds the index from a full CangjieTable. Entries are processed in sorted
+    /// Cangjie-code order so the grouped candidate lists are deterministic
+    /// (forEachEntry's own order is unspecified).
+    public init(cangjie: CangjieTable) {
+        var entries: [(String, [String])] = []
+        cangjie.forEachEntry { code, chars in entries.append((code, chars)) }
+        for (code, chars) in entries.sorted(by: { $0.0 < $1.0 }) {
+            let simplex = Self.simplexCode(for: code)
+            guard !simplex.isEmpty else { continue }
+            for char in chars { add(char, to: simplex) }
+        }
+    }
+
+    /// Builds the index directly from "<cangjieCode>\t<char>" lines (test fixtures).
+    public init(text: String) {
+        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+            let parts = line.split(separator: "\t")
+            guard parts.count >= 2 else { continue }
+            let simplex = Self.simplexCode(for: String(parts[0]))
+            guard !simplex.isEmpty else { continue }
+            add(String(parts[1]), to: simplex)
+        }
+    }
+
+    public func characters(forCode code: String) -> [String] { table[code] ?? [] }
+
+    private mutating func add(_ char: String, to simplex: String) {
+        if table[simplex]?.contains(char) == true { return }
+        table[simplex, default: []].append(char)
+    }
+
+    private static func simplexCode(for cangjieCode: String) -> String {
+        guard let first = cangjieCode.first, let last = cangjieCode.last else { return "" }
+        return cangjieCode.count == 1 ? String(first) : String(first) + String(last)
+    }
+}

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/AssociatedPhrasesTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/AssociatedPhrasesTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import KeyKeyEngine
+
+final class AssociatedPhrasesTests: XCTestCase {
+    static let fixture = """
+    # format org.openvanilla.mcbopomofo.sorted
+    ㄐㄧㄣ 今 -3.00000000
+    ㄐㄧㄣ-ㄖˋ 今日 -4.00000000
+    ㄐㄧㄣ-ㄊㄧㄢ 今天 -3.20000000
+    ㄐㄧㄣ-ㄨㄢˇ 今晚 -5.00000000
+    ㄇㄠ 貓 -4.10000000
+
+    ㄐㄧㄣ-ㄊㄧㄢ 今天 -3.20000000
+    """
+
+    func testAssociationsBestFirst() {
+        let ap = AssociatedPhrases(text: Self.fixture)
+        XCTAssertEqual(ap.associations(for: "今"), ["今天", "今日", "今晚"])
+    }
+
+    func testSingleCharEntriesExcluded() {
+        let ap = AssociatedPhrases(text: Self.fixture)
+        XCTAssertFalse(ap.associations(for: "今").contains("今"))
+    }
+
+    func testUnknownCharReturnsEmpty() {
+        let ap = AssociatedPhrases(text: Self.fixture)
+        XCTAssertEqual(ap.associations(for: "貓"), [])
+    }
+
+    func testDeDup() {
+        let ap = AssociatedPhrases(text: Self.fixture)
+        XCTAssertEqual(ap.associations(for: "今").filter { $0 == "今天" }.count, 1)
+    }
+
+    func testCommentAndBlankLinesIgnored() {
+        let ap = AssociatedPhrases(text: Self.fixture)
+        XCTAssertEqual(ap.associations(for: "#"), [])
+    }
+}

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/CangjieEngineTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/CangjieEngineTests.swift
@@ -56,10 +56,18 @@ final class CangjieEngineTests: XCTestCase {
         XCTAssertEqual(e.candidates, [])
     }
 
-    func testCommitWithoutSelectionUsesRadicalGlyphs() {
+    func testCommitWithoutSelectionUsesFirstCandidate() {
         let e = make()
-        _ = e.handleKey("a"); _ = e.handleKey("b"); _ = e.handleKey("c")
-        XCTAssertEqual(e.commit(), "日月金")
+        _ = e.handleKey("a"); _ = e.handleKey("b")
+        XCTAssertEqual(e.commit(), "明")   // first candidate for "ab", not the radicals
+        XCTAssertEqual(e.composingText, "")
+    }
+
+    func testCommitWithNoMatchEmitsNothing() {
+        let e = make()
+        _ = e.handleKey("c")   // no code "c" in the fixture
+        XCTAssertEqual(e.commit(), "")
+        XCTAssertEqual(e.composingText, "")
     }
 
     func testBackspaceRemovesLastRadical() {
@@ -98,6 +106,33 @@ final class CangjieEngineTests: XCTestCase {
         XCTAssertFalse(e.handleKey(" "))
         XCTAssertFalse(e.handleKey("A"))   // uppercase is not a radical key
         XCTAssertEqual(e.composingText, "日")
+    }
+
+    func testWildcardIsConsumedAndShownLiterally() {
+        let e = make()
+        _ = e.handleKey("a")
+        XCTAssertTrue(e.handleKey("*"))
+        XCTAssertEqual(e.composingText, "日*")   // * rendered literally
+    }
+
+    func testWildcardCandidatesMatchPattern() {
+        let e = make()
+        _ = e.handleKey("a"); _ = e.handleKey("*")
+        // "a*" matches "ab","abc","abcde","abcdef" (≥1 letter after a)
+        XCTAssertEqual(e.candidates, ["明", "冒", "韻", "漏"])
+    }
+
+    func testWildcardBetweenLiterals() {
+        let e = make()
+        _ = e.handleKey("a"); _ = e.handleKey("*"); _ = e.handleKey("b")
+        // "a*b" matches codes starting a, ending b, ≥1 between: "ab" is too short? ab=a,b no middle
+        XCTAssertEqual(e.candidates, [])
+    }
+
+    func testWildcardCountsTowardMaxLength() {
+        let e = make()
+        for _ in 0..<6 { _ = e.handleKey("*") }
+        XCTAssertEqual(e.composingText, "*****")   // capped at 5
     }
 
     func testRadicalMapCoversFullAlphabet() {

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/CangjieTableTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/CangjieTableTests.swift
@@ -31,4 +31,34 @@ final class CangjieTableTests: XCTestCase {
         let t = CangjieTable(text: "# comment\n\nm\t一\n")
         XCTAssertEqual(t.characters(forCode: "m"), ["一"])
     }
+
+    static let wildcardTable = CangjieTable(text: """
+    a\t日
+    ab\t明
+    abc\t冒
+    ax\t旮
+    ba\t叭
+    """)
+
+    func testMatchingWithoutWildcardIsExact() {
+        XCTAssertEqual(Self.wildcardTable.characters(matching: "ab"), ["明"])
+        XCTAssertEqual(Self.wildcardTable.characters(matching: "zz"), [])
+    }
+
+    func testMatchingTrailingWildcard() {
+        // "a*" matches codes starting with "a" plus one-or-more letters.
+        // "a" alone does NOT match (* needs at least one letter).
+        XCTAssertEqual(Self.wildcardTable.characters(matching: "a*"), ["明", "旮", "冒"])
+    }
+
+    func testMatchingWildcardBetweenLiterals() {
+        // "a*c" matches codes starting "a", ending "c", with ≥1 letter between.
+        XCTAssertEqual(Self.wildcardTable.characters(matching: "a*c"), ["冒"])
+    }
+
+    func testForEachEntryIteratesAll() {
+        var count = 0
+        Self.wildcardTable.forEachEntry { _, chars in count += chars.count }
+        XCTAssertEqual(count, 5)
+    }
 }

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/PunctuationTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/PunctuationTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import KeyKeyEngine
+
+final class PunctuationTests: XCTestCase {
+    func testComma() {
+        XCTAssertEqual(Punctuation.fullWidth(for: ","), "，")
+    }
+
+    func testPeriod() {
+        XCTAssertEqual(Punctuation.fullWidth(for: "."), "。")
+    }
+
+    func testOpenCornerBracket() {
+        XCTAssertEqual(Punctuation.fullWidth(for: "["), "「")
+    }
+
+    func testCloseCornerBracket() {
+        XCTAssertEqual(Punctuation.fullWidth(for: "]"), "」")
+    }
+
+    func testQuestionMark() {
+        XCTAssertEqual(Punctuation.fullWidth(for: "?"), "？")
+    }
+
+    func testOpenParen() {
+        XCTAssertEqual(Punctuation.fullWidth(for: "("), "（")
+    }
+
+    func testCloseParen() {
+        XCTAssertEqual(Punctuation.fullWidth(for: ")"), "）")
+    }
+
+    func testIdeographicComma() {
+        XCTAssertEqual(Punctuation.fullWidth(for: "\\"), "、")
+    }
+
+    func testBacktickIdeographicComma() {
+        XCTAssertEqual(Punctuation.fullWidth(for: "`"), "、")
+    }
+
+    func testDoubleAngleBrackets() {
+        XCTAssertEqual(Punctuation.fullWidth(for: "<"), "《")
+        XCTAssertEqual(Punctuation.fullWidth(for: ">"), "》")
+    }
+
+    func testNonPunctuationLetterReturnsNil() {
+        XCTAssertNil(Punctuation.fullWidth(for: "a"))
+    }
+
+    func testNonPunctuationDigitReturnsNil() {
+        XCTAssertNil(Punctuation.fullWidth(for: "1"))
+    }
+}

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/SimplexEngineTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/SimplexEngineTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+@testable import KeyKeyEngine
+
+final class SimplexEngineTests: XCTestCase {
+    // Same fixture as SimplexTableTests; simplex code = first+last letter.
+    //   "ab"   -> "ab"   明
+    //   "amb"  -> "ab"   昌
+    //   "abc"  -> "ac"   冒
+    //   "a"    -> "a"    日
+    static let table = SimplexTable(cangjie: CangjieTable(text: """
+    a\t日
+    ab\t明
+    amb\t昌
+    abc\t冒
+    abcde\t韻
+    """))
+
+    private func make() -> SimplexEngine { SimplexEngine(table: Self.table) }
+
+    func testAccumulatesRadicalGlyphs() {
+        let e = make()
+        XCTAssertTrue(e.handleKey("a"))   // 日
+        XCTAssertTrue(e.handleKey("b"))   // 月
+        XCTAssertEqual(e.composingText, "日月")
+    }
+
+    func testIsComposingSyllableAlwaysFalse() {
+        let e = make()
+        _ = e.handleKey("a")
+        XCTAssertFalse(e.isComposingSyllable)
+    }
+
+    func testCandidatesFromSimplexCode() {
+        let e = make()
+        _ = e.handleKey("a"); _ = e.handleKey("b")
+        // simplex "ab" -> 明, 昌 (larger list than full Cangjie)
+        XCTAssertEqual(e.candidates, ["明", "昌"])
+    }
+
+    func testCandidatesForDifferentCode() {
+        let e = make()
+        _ = e.handleKey("a"); _ = e.handleKey("c")
+        XCTAssertEqual(e.candidates, ["冒"])
+    }
+
+    func testNoCandidatesWhenEmpty() {
+        XCTAssertEqual(make().candidates, [])
+    }
+
+    func testSelectCandidateShowsItAsComposing() {
+        let e = make()
+        _ = e.handleKey("a"); _ = e.handleKey("b")
+        e.selectCandidate(1)
+        XCTAssertEqual(e.composingText, "昌")
+    }
+
+    func testSelectOutOfRangeIgnored() {
+        let e = make()
+        _ = e.handleKey("a"); _ = e.handleKey("b")
+        e.selectCandidate(9)
+        XCTAssertEqual(e.composingText, "日月")
+    }
+
+    func testCommitWithSelectionReturnsItAndClears() {
+        let e = make()
+        _ = e.handleKey("a"); _ = e.handleKey("b")
+        e.selectCandidate(1)
+        XCTAssertEqual(e.commit(), "昌")
+        XCTAssertEqual(e.composingText, "")
+        XCTAssertEqual(e.candidates, [])
+    }
+
+    func testCommitWithoutSelectionUsesFirstCandidate() {
+        let e = make()
+        _ = e.handleKey("a"); _ = e.handleKey("b")
+        XCTAssertEqual(e.commit(), "明")
+        XCTAssertEqual(e.composingText, "")
+    }
+
+    func testCommitWithNoMatchEmitsNothing() {
+        let e = make()
+        _ = e.handleKey("z"); _ = e.handleKey("z")
+        XCTAssertEqual(e.commit(), "")
+        XCTAssertEqual(e.composingText, "")
+    }
+
+    func testBackspaceRemovesLastRadical() {
+        let e = make()
+        _ = e.handleKey("a"); _ = e.handleKey("b")
+        e.backspace()
+        XCTAssertEqual(e.composingText, "日")
+        XCTAssertEqual(e.candidates, ["日"])   // simplex "a" -> 日
+    }
+
+    func testBackspaceClearsSelection() {
+        let e = make()
+        _ = e.handleKey("a"); _ = e.handleKey("b")
+        e.selectCandidate(1)
+        e.backspace()
+        XCTAssertEqual(e.composingText, "日")
+    }
+
+    func testBackspaceOnEmptyIsSafe() {
+        let e = make()
+        e.backspace()
+        XCTAssertEqual(e.composingText, "")
+    }
+
+    func testNonLetterIgnored() {
+        let e = make()
+        _ = e.handleKey("a")
+        XCTAssertFalse(e.handleKey("1"))
+        XCTAssertFalse(e.handleKey(" "))
+        XCTAssertFalse(e.handleKey("A"))
+        XCTAssertEqual(e.composingText, "日")
+    }
+}

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/SimplexTableTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/SimplexTableTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import KeyKeyEngine
+
+final class SimplexTableTests: XCTestCase {
+    // Cangjie codes -> chars. Simplex code = first+last letter of the cangjie code.
+    //   "ab"   -> "ab"   明
+    //   "abc"  -> "ac"   冒
+    //   "amb"  -> "ab"   昌   (shares simplex "ab" with 明)
+    //   "abcde"-> "ae"   韻
+    //   "a"    -> "a"    日   (length 1 -> single letter)
+    static let cangjie = CangjieTable(text: """
+    a\t日
+    ab\t明
+    amb\t昌
+    abc\t冒
+    abcde\t韻
+    """)
+
+    private func make() -> SimplexTable { SimplexTable(cangjie: Self.cangjie) }
+
+    func testFirstPlusLastDerivation() {
+        let t = make()
+        XCTAssertEqual(t.characters(forCode: "ac"), ["冒"])   // "abc" -> "ac"
+        XCTAssertEqual(t.characters(forCode: "ae"), ["韻"])   // "abcde" -> "ae"
+    }
+
+    func testSingleLetterCodeStaysSingle() {
+        XCTAssertEqual(make().characters(forCode: "a"), ["日"])   // "a" -> "a"
+    }
+
+    func testMultipleCharsGroupedUnderSameSimplexCode() {
+        // "ab" -> "ab" (明), "amb" -> "ab" (昌)
+        XCTAssertEqual(make().characters(forCode: "ab"), ["明", "昌"])
+    }
+
+    func testUnknownCodeIsEmpty() {
+        XCTAssertEqual(make().characters(forCode: "zz"), [])
+    }
+
+    func testInitFromTextMatchesInitFromCangjie() {
+        let fromText = SimplexTable(text: """
+        a\t日
+        ab\t明
+        amb\t昌
+        abc\t冒
+        abcde\t韻
+        """)
+        XCTAssertEqual(fromText.characters(forCode: "ab"), ["明", "昌"])
+        XCTAssertEqual(fromText.characters(forCode: "ac"), ["冒"])
+        XCTAssertEqual(fromText.characters(forCode: "a"), ["日"])
+    }
+
+    func testDeDupesRepeatedCharForSameSimplexCode() {
+        // Two cangjie codes that both reduce to "ab" and both map to 明 -> de-duped.
+        let t = SimplexTable(text: """
+        ab\t明
+        axb\t明
+        """)
+        XCTAssertEqual(t.characters(forCode: "ab"), ["明"])
+    }
+}

--- a/docs/superpowers/plans/2026-06-22-cangjie-v1.0.0.md
+++ b/docs/superpowers/plans/2026-06-22-cangjie-v1.0.0.md
@@ -1,0 +1,59 @@
+# Plan: Cangjie v1.0.0 (Cangjie-family only)
+
+**Date:** 2026-06-22
+**Branch:** `claude/sharp-rubin-81a9dd`
+**Decision:** v1.0.0 ships the **Cangjie family only** — Cangjie (倉頡) + Simplex (簡易).
+Smart/Plain Phonetic engines stay in the codebase but are NOT exposed (deferred).
+Release = working ad-hoc build (no notarization yet).
+
+## Must-fix (correctness/completeness)
+- **Commit the right thing:** Cangjie/Simplex commit must emit the SELECTED or FIRST candidate,
+  never the raw radical glyphs; emit nothing (and clear) on a no-match code. Enter + Space + number
+  all commit a candidate.
+- **Candidate pagination:** all candidates reachable (not just first 9). Page nav + page indicator.
+- **Cangjie-only Info.plist:** expose only Cangjie + Simplex input modes (remove SmartPhonetic/
+  PlainPhonetic modes); default mode = Cangjie. Bump version -> 1.0.0.
+
+## Feature set (all selected)
+- **Wildcard `*`:** `*` matches one-or-more unknown radicals in the code; candidates = all chars whose
+  code matches the pattern (ordered). Works in Cangjie (and Simplex).
+- **Full-width punctuation:** in Cangjie/Simplex modes, ASCII punctuation keys emit Chinese full-width
+  punctuation when not mid-code.
+- **Associated phrases (聯想):** after committing a single character, offer follow-on phrases. SOURCE:
+  index the already-bundled `Resources/data.txt` (McBopomofo LM) multi-char phrases by their FIRST
+  character (sorted by score). No new external data.
+- **Simplex (簡易):** first+last Cangjie radical -> candidates. SOURCE: derive from the existing
+  `cangjie.txt` (Simplex code = first+last letter of each Cangjie code). No new external data.
+
+## Tasks
+### T-A — Cangjie engine: commit fix + wildcard (engine, sequential FIRST)
+`CangjieEngine` + `CangjieTable`. Fix commit/selection to emit a candidate (never radicals; nothing on
+no-match). Add wildcard `*` to handleKey + a `CangjieTable` pattern query. Expose entry iteration on
+CangjieTable so Simplex can derive its index. TDD.
+
+### T-B — Simplex engine (engine, parallel after T-A)
+New `SimplexEngine.swift` + `SimplexTable` derived from CangjieTable (first+last radical). Mirrors the
+Cangjie engine surface (handleKey/candidates/selectCandidate/commit/backspace/isComposingSyllable). TDD.
+
+### T-C — Associated phrases (engine, parallel after T-A)
+New `AssociatedPhrases.swift`: build an index from `data.txt` (phrase keyed by first character -> phrases
+by score). API: `associations(for: Character) -> [String]`. TDD with a small fixture.
+
+### T-D — Punctuation map (engine/util, parallel)
+New `Punctuation.swift`: ASCII punctuation -> full-width Chinese punctuation map + lookup. Pure, TDD.
+
+### T-E — App integration + UI (app, sequential LAST)
+- Candidate window: pagination (9/page), page indicator, number 1-9 select within page, page nav keys,
+  Space/Enter commit current selection/first.
+- InputController: drive Cangjie + Simplex; on commit of a single char show associated phrases for
+  quick pick; punctuation keys emit full-width when not mid-code; correct commit (candidate not radicals).
+- Info.plist: expose Cangjie + Simplex modes only; default Cangjie; setValue maps both; remove
+  SmartPhonetic/PlainPhonetic modes + their InfoPlist.strings. Version -> 1.0.0.
+- build-app.sh: compile any new App files.
+- Rebuild + ad-hoc sign.
+
+## Success criteria
+- All engine tests pass (no regressions); new features covered by tests.
+- App builds + ad-hoc signs; bundle exposes Cangjie + Simplex modes; version 1.0.0.
+- Manual (user live-test): Cangjie & Simplex type+commit correct characters; wildcard, punctuation,
+  pagination, associations all work.


### PR DESCRIPTION
## Cangjie v1.0.0 (Cangjie family only)

v1.0.0 ships the **Cangjie family** — Cangjie (倉頡) + Simplex (簡易). Smart/Plain Phonetic engines remain in the codebase but are not exposed (deferred). 170 engine tests; app builds + ad-hoc signs; version bumped to 1.0.0.

### Engine
- **Commit fix:** Cangjie/Simplex commit emits the selected/first **character** (never raw radical glyphs); nothing on a no-match code.
- **Wildcard `*`** — matches unknown radicals.
- **Simplex (簡易)** — first+last radical, derived from the bundled Cangjie table.
- **Associated phrases (聯想)** — indexed from the bundled `data.txt` by first character.
- **Full-width punctuation** lookup.

### App
- **Cangjie + Simplex input modes** only (Info.plist); default Cangjie; switched via `setValue(forTag:)`.
- **Candidate pagination** (9/page, arrows page, page indicator).
- **Idle full-width punctuation**; **associated-phrase suggestions** after a single-char commit (dismiss on next key).
- Review-hardened: associations only on explicit user commits (not focus-loss/mode-switch); page-slice crash guard.

### Deferred
Smart/Plain Phonetic UI; layout selection (ETen/Hsu/ETen26) → future Preferences app; notarized release packaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)