### PR TITLE
fix: rank Cangjie/Simplex candidates by frequency (wildcard usable)

### DIFF
--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -46,6 +46,7 @@ private enum InputMethodChoice: String {
 @objc(InputController)
 final class InputController: IMKInputController {
     private let lm: LanguageModel
+    private let characterRank: [Character: Double]
     private let associatedPhrases: AssociatedPhrases
     private let cangjieTable: CangjieTable
     private let simplexTable: SimplexTable
@@ -72,6 +73,11 @@ final class InputController: IMKInputController {
             lm = LanguageModel(text: "# format org.openvanilla.mcbopomofo.sorted")
         }
         self.lm = lm
+
+        // Rank single characters by LM score (higher = more common) so Cangjie/Simplex
+        // wildcard matches surface common characters first. Computed once.
+        let characterRank = lm.characterScores()
+        self.characterRank = characterRank
 
         // Build associated phrases from the same bundled data.txt; fail safe to empty if missing.
         let associatedPhrases: AssociatedPhrases
@@ -103,7 +109,8 @@ final class InputController: IMKInputController {
         // Start on Cangjie; IMK calls setValue(_:forTag:client:) with the active input mode
         // (and on every mode switch), which rebuilds the engine accordingly.
         self.engine = InputController.makeEngine(method: .cangjie, layout: .standard,
-                                                 lm: lm, cangjieTable: cangjieTable,
+                                                 lm: lm, characterRank: characterRank,
+                                                 cangjieTable: cangjieTable,
                                                  simplexTable: simplexTable)
         super.init(server: server, delegate: delegate, client: inputClient)
     }
@@ -111,7 +118,8 @@ final class InputController: IMKInputController {
     // Build the engine for the active method, wrapping in an adapter where the engine
     // surface doesn't already match the app-internal InputEngine protocol.
     private static func makeEngine(method: InputMethodChoice, layout: LayoutChoice,
-                                   lm: LanguageModel, cangjieTable: CangjieTable,
+                                   lm: LanguageModel, characterRank: [Character: Double],
+                                   cangjieTable: CangjieTable,
                                    simplexTable: SimplexTable) -> InputEngine {
         switch method {
         case .smartPhonetic:
@@ -119,9 +127,9 @@ final class InputController: IMKInputController {
         case .plainPhonetic:
             return PlainPhoneticEngineAdapter(PlainPhoneticEngine(languageModel: lm, layout: layout.makeLayout()))
         case .cangjie:
-            return CangjieEngine(table: cangjieTable)
+            return CangjieEngine(table: cangjieTable, characterRank: characterRank)
         case .simplex:
-            return SimplexEngine(table: simplexTable)
+            return SimplexEngine(table: simplexTable, characterRank: characterRank)
         }
     }
 
@@ -147,6 +155,7 @@ final class InputController: IMKInputController {
         candidateWindow.hide()
         method = choice
         engine = InputController.makeEngine(method: choice, layout: layout, lm: lm,
+                                            characterRank: characterRank,
                                             cangjieTable: cangjieTable, simplexTable: simplexTable)
     }
 

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/CangjieEngine.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/CangjieEngine.swift
@@ -14,11 +14,13 @@ public final class CangjieEngine {
     private static let maxRadicals = 5
 
     private let table: CangjieTable
+    private let characterRank: [Character: Double]
     private var code: String = ""
     private var selected: String?
 
-    public init(table: CangjieTable) {
+    public init(table: CangjieTable, characterRank: [Character: Double] = [:]) {
         self.table = table
+        self.characterRank = characterRank
     }
 
     /// Returns true if the key was consumed by the engine.
@@ -41,9 +43,19 @@ public final class CangjieEngine {
         return String(code.map { Self.radicals[$0] ?? $0 })
     }
 
-    /// Characters whose code matches the current radical sequence (supports `*`).
+    /// Characters whose code matches the current radical sequence (supports `*`),
+    /// stable-sorted so common characters (higher rank) come first. With an empty
+    /// rank the table order is preserved unchanged.
     public var candidates: [String] {
-        code.isEmpty ? [] : table.characters(matching: code)
+        guard !code.isEmpty else { return [] }
+        let matches = table.characters(matching: code)
+        if characterRank.isEmpty { return matches }
+        return matches.enumerated().sorted { lhs, rhs in
+            let l = lhs.element.first.flatMap { characterRank[$0] } ?? -.greatestFiniteMagnitude
+            let r = rhs.element.first.flatMap { characterRank[$0] } ?? -.greatestFiniteMagnitude
+            if l != r { return l > r }
+            return lhs.offset < rhs.offset
+        }.map(\.element)
     }
 
     public func selectCandidate(_ index: Int) {

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/LanguageModel.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/LanguageModel.swift
@@ -27,4 +27,18 @@ public struct LanguageModel {
 
     public func unigrams(forKey key: String) -> [Unigram] { table[key] ?? [] }
     public func hasKey(_ key: String) -> Bool { table[key] != nil }
+
+    /// Maps each single-character value to the MAX score seen for it across all
+    /// unigrams. Multi-character values are excluded. Higher score = more common.
+    public func characterScores() -> [Character: Double] {
+        var scores: [Character: Double] = [:]
+        for grams in table.values {
+            for g in grams where g.value.count == 1 {
+                let ch = g.value.first!
+                if let existing = scores[ch] { scores[ch] = max(existing, g.score) }
+                else { scores[ch] = g.score }
+            }
+        }
+        return scores
+    }
 }

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/SimplexEngine.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/SimplexEngine.swift
@@ -4,11 +4,13 @@
 // CangjieEngine.radicals for the composing-display glyphs.
 public final class SimplexEngine {
     private let table: SimplexTable
+    private let characterRank: [Character: Double]
     private var code: String = ""
     private var selected: String?
 
-    public init(table: SimplexTable) {
+    public init(table: SimplexTable, characterRank: [Character: Double] = [:]) {
         self.table = table
+        self.characterRank = characterRank
     }
 
     /// Returns true if the key was consumed by the engine. Accepts a–z radical keys.
@@ -29,9 +31,19 @@ public final class SimplexEngine {
         return String(code.map { CangjieEngine.radicals[$0] ?? $0 })
     }
 
-    /// Characters whose Simplex code matches the current radical sequence.
+    /// Characters whose Simplex code matches the current radical sequence,
+    /// stable-sorted so common characters (higher rank) come first. With an empty
+    /// rank the table order is preserved unchanged.
     public var candidates: [String] {
-        code.isEmpty ? [] : table.characters(forCode: code)
+        guard !code.isEmpty else { return [] }
+        let matches = table.characters(forCode: code)
+        if characterRank.isEmpty { return matches }
+        return matches.enumerated().sorted { lhs, rhs in
+            let l = lhs.element.first.flatMap { characterRank[$0] } ?? -.greatestFiniteMagnitude
+            let r = rhs.element.first.flatMap { characterRank[$0] } ?? -.greatestFiniteMagnitude
+            if l != r { return l > r }
+            return lhs.offset < rhs.offset
+        }.map(\.element)
     }
 
     public func selectCandidate(_ index: Int) {

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/CangjieEngineTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/CangjieEngineTests.swift
@@ -135,6 +135,22 @@ final class CangjieEngineTests: XCTestCase {
         XCTAssertEqual(e.composingText, "*****")   // capped at 5
     }
 
+    func testWildcardCandidatesRerankedByCharacterRank() {
+        // Rank a normally-late char (漏) highest so it leads the "a*" list.
+        let rank: [Character: Double] = ["漏": 0.0, "韻": -1.0]
+        let e = CangjieEngine(table: Self.table, characterRank: rank)
+        _ = e.handleKey("a"); _ = e.handleKey("*")
+        // Default table order is ["明","冒","韻","漏"]; ranked chars move ahead
+        // (漏 > 韻), unranked ("明","冒") keep their relative order after.
+        XCTAssertEqual(e.candidates, ["漏", "韻", "明", "冒"])
+    }
+
+    func testEmptyRankLeavesOrderUnchanged() {
+        let e = CangjieEngine(table: Self.table, characterRank: [:])
+        _ = e.handleKey("a"); _ = e.handleKey("*")
+        XCTAssertEqual(e.candidates, ["明", "冒", "韻", "漏"])
+    }
+
     func testRadicalMapCoversFullAlphabet() {
         for k in "abcdefghijklmnopqrstuvwxyz" {
             XCTAssertNotNil(CangjieEngine.radicals[k], "missing radical for \(k)")

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/LanguageModelTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/LanguageModelTests.swift
@@ -33,4 +33,22 @@ final class LanguageModelTests: XCTestCase {
         XCTAssertFalse(lm.hasKey("ㄓㄨ"))
         XCTAssertTrue(lm.hasKey("ㄅㄚ"))
     }
+
+    func testCharacterScoresKeepsSingleCharsAndMaxScore() {
+        let lm = LanguageModel(text: Self.fixture)
+        let scores = lm.characterScores()
+        // Single-char values only; multi-char "貓咪" excluded.
+        XCTAssertEqual(Set(scores.keys), Set(["八", "吧", "貓"]))
+        // 貓 appears once at -4.1.
+        XCTAssertEqual(scores["貓"] ?? 0, -4.10000000, accuracy: 1e-6)
+    }
+
+    func testCharacterScoresRecordsMaxAcrossEntries() {
+        // 我 appears under two readings with different scores; keep the larger.
+        let lm = LanguageModel(text: """
+        ㄨㄛ 我 -5.00000000
+        ㄜ 我 -3.00000000
+        """)
+        XCTAssertEqual(lm.characterScores()["我"] ?? 0, -3.00000000, accuracy: 1e-6)
+    }
 }

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/SimplexEngineTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/SimplexEngineTests.swift
@@ -106,6 +106,20 @@ final class SimplexEngineTests: XCTestCase {
         XCTAssertEqual(e.composingText, "")
     }
 
+    func testCandidatesRerankedByCharacterRank() {
+        // simplex "ab" -> ["明","昌"]; rank 昌 highest so it leads.
+        let rank: [Character: Double] = ["昌": 1.0]
+        let e = SimplexEngine(table: Self.table, characterRank: rank)
+        _ = e.handleKey("a"); _ = e.handleKey("b")
+        XCTAssertEqual(e.candidates, ["昌", "明"])
+    }
+
+    func testEmptyRankLeavesOrderUnchanged() {
+        let e = SimplexEngine(table: Self.table, characterRank: [:])
+        _ = e.handleKey("a"); _ = e.handleKey("b")
+        XCTAssertEqual(e.candidates, ["明", "昌"])
+    }
+
     func testNonLetterIgnored() {
         let e = make()
         _ = e.handleKey("a")


### PR DESCRIPTION
Wildcard `*` returned hundreds of matches ordered by code length, burying common characters (我 was on page 3 for `h*i`). Now candidates are stable-sorted by single-character frequency from the bundled LM (data.txt) — common characters first (我 → first page). Adds `LanguageModel.characterScores()`; Cangjie/SimplexEngine take an optional `characterRank`. 176 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)