### PR TITLE
v1.0.0: Preferences window + release packaging

### DIFF
--- a/App/CandidateWindow.swift
+++ b/App/CandidateWindow.swift
@@ -26,8 +26,10 @@ final class CandidateWindow {
     }
 
     // `pageCandidates` is the already-sliced set for the current page (≤9). When `pageCount`
-    // exceeds 1, a " (page/total)" indicator is appended.
-    func show(_ pageCandidates: [String], page: Int, pageCount: Int, near point: NSPoint) {
+    // exceeds 1, a " (page/total)" indicator is appended. `fontSize` is read live from
+    // Preferences by the caller so size changes apply without restarting the IME.
+    func show(_ pageCandidates: [String], page: Int, pageCount: Int, fontSize: CGFloat, near point: NSPoint) {
+        label.font = .systemFont(ofSize: fontSize)
         var shown = pageCandidates.prefix(9).enumerated()
             .map { "\($0.offset + 1).\($0.element)" }
             .joined(separator: "  ")

--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -137,6 +137,21 @@ final class InputController: IMKInputController {
         Int(NSEvent.EventTypeMask.keyDown.rawValue)
     }
 
+    // IMK input-menu (the menu shown in the input-method menu-bar item). A single
+    // "Preferences…" item opens the SHARED Preferences window — a stateless "open window"
+    // action, independent of which controller instance receives it.
+    override func menu() -> NSMenu! {
+        let menu = NSMenu()
+        let item = NSMenuItem(title: "偏好設定…", action: #selector(openPreferences), keyEquivalent: "")
+        item.target = self
+        menu.addItem(item)
+        return menu
+    }
+
+    @objc private func openPreferences() {
+        PreferencesWindowController.shared.show()
+    }
+
     // IMK calls this when the user selects one of our input modes (Info.plist
     // ComponentInputModeDict). The value is the mode identifier string.
     override func setValue(_ value: Any!, forTag tag: Int, client sender: Any!) {
@@ -196,7 +211,8 @@ final class InputController: IMKInputController {
         // Full-width punctuation when idle: no active composition (and not in association mode,
         // already handled above). A mapped ASCII punctuation key inserts its full-width form.
         // Mid-composition keys are left to the engine below.
-        if engine.composingText.isEmpty, let ch = event.characters?.first,
+        if Preferences.fullWidthPunctuationEnabled,
+           engine.composingText.isEmpty, let ch = event.characters?.first,
            let full = Punctuation.fullWidth(for: ch) {
             client.insertText(full, replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
             return true
@@ -321,7 +337,7 @@ final class InputController: IMKInputController {
                              replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
         // After an explicit user commit of a single character, offer associated phrases (聯想).
         // System-driven commits (focus loss, mode switch) pass offerAssociations: false and stay idle.
-        if offerAssociations, text.count == 1, let first = text.first {
+        if offerAssociations, Preferences.associatedPhrasesEnabled, text.count == 1, let first = text.first {
             let phrases = associatedPhrases.associations(for: first)
             if !phrases.isEmpty {
                 associations = phrases
@@ -363,7 +379,8 @@ final class InputController: IMKInputController {
             let page = Array(cands[start..<min(start + size, cands.count)])
             var rect = NSRect.zero
             client.attributes(forCharacterIndex: 0, lineHeightRectangle: &rect)
-            candidateWindow.show(page, page: candidatePage, pageCount: pageCount, near: rect.origin)
+            candidateWindow.show(page, page: candidatePage, pageCount: pageCount,
+                                 fontSize: Preferences.candidateFontSize, near: rect.origin)
         }
     }
 }

--- a/App/Preferences.swift
+++ b/App/Preferences.swift
@@ -1,0 +1,45 @@
+import Cocoa
+
+// Typed accessors for the three user-facing settings, persisted in the IME process's
+// standard UserDefaults. Read live (no caching) so changes apply without restarting.
+enum Preferences {
+    private enum Key {
+        static let candidateFontSize = "candidateFontSize"
+        static let associatedPhrasesEnabled = "associatedPhrasesEnabled"
+        static let fullWidthPunctuationEnabled = "fullWidthPunctuationEnabled"
+    }
+
+    static let minFontSize: CGFloat = 14
+    static let maxFontSize: CGFloat = 28
+    static let defaultFontSize: CGFloat = 18
+
+    // Register defaults once at process start so first launch reads sensible values.
+    static func registerDefaults() {
+        UserDefaults.standard.register(defaults: [
+            Key.candidateFontSize: Double(defaultFontSize),
+            Key.associatedPhrasesEnabled: true,
+            Key.fullWidthPunctuationEnabled: true,
+        ])
+    }
+
+    static var candidateFontSize: CGFloat {
+        get {
+            let raw = CGFloat(UserDefaults.standard.double(forKey: Key.candidateFontSize))
+            return min(max(raw, minFontSize), maxFontSize)
+        }
+        set {
+            UserDefaults.standard.set(Double(min(max(newValue, minFontSize), maxFontSize)),
+                                      forKey: Key.candidateFontSize)
+        }
+    }
+
+    static var associatedPhrasesEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: Key.associatedPhrasesEnabled) }
+        set { UserDefaults.standard.set(newValue, forKey: Key.associatedPhrasesEnabled) }
+    }
+
+    static var fullWidthPunctuationEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: Key.fullWidthPunctuationEnabled) }
+        set { UserDefaults.standard.set(newValue, forKey: Key.fullWidthPunctuationEnabled) }
+    }
+}

--- a/App/PreferencesWindow.swift
+++ b/App/PreferencesWindow.swift
@@ -1,0 +1,88 @@
+import Cocoa
+
+// A small, native AppKit Preferences window for the three v1.0.0 settings. A single shared
+// instance; `show()` brings it to front and activates the LSUIElement background app so the
+// window is actually visible. Controls write straight to `Preferences` (UserDefaults).
+final class PreferencesWindowController: NSWindowController {
+    static let shared = PreferencesWindowController()
+
+    private let fontSizeStepper = NSStepper()
+    private let fontSizeLabel = NSTextField(labelWithString: "")
+    private let associatedPhrasesCheckbox = NSButton(checkboxWithTitle: "", target: nil, action: nil)
+    private let fullWidthPunctuationCheckbox = NSButton(checkboxWithTitle: "", target: nil, action: nil)
+
+    private init() {
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 360, height: 170),
+                              styleMask: [.titled, .closable],
+                              backing: .buffered, defer: false)
+        window.title = "偏好設定"
+        super.init(window: window)
+        buildUI()
+        window.center()
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func buildUI() {
+        guard let content = window?.contentView else { return }
+
+        let fontTitle = NSTextField(labelWithString: "候選字大小")
+        fontSizeStepper.minValue = Double(Preferences.minFontSize)
+        fontSizeStepper.maxValue = Double(Preferences.maxFontSize)
+        fontSizeStepper.increment = 1
+        fontSizeStepper.target = self
+        fontSizeStepper.action = #selector(fontSizeChanged)
+
+        associatedPhrasesCheckbox.title = "聯想字詞"
+        associatedPhrasesCheckbox.target = self
+        associatedPhrasesCheckbox.action = #selector(associatedPhrasesChanged)
+
+        fullWidthPunctuationCheckbox.title = "全形標點"
+        fullWidthPunctuationCheckbox.target = self
+        fullWidthPunctuationCheckbox.action = #selector(fullWidthPunctuationChanged)
+
+        let fontRow = NSStackView(views: [fontTitle, fontSizeStepper, fontSizeLabel])
+        fontRow.spacing = 8
+        fontRow.alignment = .centerY
+
+        let stack = NSStackView(views: [fontRow, associatedPhrasesCheckbox, fullWidthPunctuationCheckbox])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 16
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        content.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: 20),
+            stack.trailingAnchor.constraint(lessThanOrEqualTo: content.trailingAnchor, constant: -20),
+            stack.topAnchor.constraint(equalTo: content.topAnchor, constant: 20),
+        ])
+    }
+
+    // Reflect current persisted values into the controls each time the window opens.
+    private func syncControls() {
+        fontSizeStepper.integerValue = Int(Preferences.candidateFontSize)
+        fontSizeLabel.stringValue = "\(Int(Preferences.candidateFontSize)) pt"
+        associatedPhrasesCheckbox.state = Preferences.associatedPhrasesEnabled ? .on : .off
+        fullWidthPunctuationCheckbox.state = Preferences.fullWidthPunctuationEnabled ? .on : .off
+    }
+
+    func show() {
+        syncControls()
+        NSApp.activate(ignoringOtherApps: true)
+        showWindow(nil)
+        window?.makeKeyAndOrderFront(nil)
+    }
+
+    @objc private func fontSizeChanged() {
+        Preferences.candidateFontSize = CGFloat(fontSizeStepper.integerValue)
+        fontSizeLabel.stringValue = "\(Int(Preferences.candidateFontSize)) pt"
+    }
+
+    @objc private func associatedPhrasesChanged() {
+        Preferences.associatedPhrasesEnabled = (associatedPhrasesCheckbox.state == .on)
+    }
+
+    @objc private func fullWidthPunctuationChanged() {
+        Preferences.fullWidthPunctuationEnabled = (fullWidthPunctuationCheckbox.state == .on)
+    }
+}

--- a/App/main.swift
+++ b/App/main.swift
@@ -8,6 +8,7 @@ guard let connectionName = Bundle.main.infoDictionary?["InputMethodConnectionNam
       let bundleID = Bundle.main.bundleIdentifier else {
     NSLog("YahooKeyKey: missing Info.plist keys"); exit(EXIT_FAILURE)
 }
+Preferences.registerDefaults()
 server = IMKServer(name: connectionName, bundleIdentifier: bundleID)
 if server == nil { NSLog("YahooKeyKey: failed to create IMKServer"); exit(EXIT_FAILURE) }
 NSApplication.shared.run()

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,109 @@
+# Releasing Yahoo KeyKey 2
+
+This describes how to produce a downloadable build of **Yahoo KeyKey 2** (an
+InputMethodKit input method) for distribution **outside the Mac App Store**.
+App Store distribution is **not** used for this version.
+
+The packaging is handled by `tools/package-release.sh`, which builds the app,
+optionally signs and notarizes it, and produces a `.dmg` and a `.zip`.
+
+---
+
+## Prerequisites (for a signed + notarized public release)
+
+A public download must be signed with a **Developer ID Application** certificate
+and notarized by Apple, otherwise Gatekeeper blocks it. You need:
+
+1. **Apple Developer Program** membership.
+
+2. A **"Developer ID Application"** certificate installed in your login keychain.
+   Create it in Xcode (Settings ▸ Accounts ▸ Manage Certificates ▸ "+") or on
+   the Apple Developer website. Confirm it is present:
+
+   ```sh
+   security find-identity -v -p codesigning
+   ```
+
+   The identity string looks like:
+   `Developer ID Application: Teddy Chan (TEAMID)`
+
+3. A **notarytool keychain profile** that stores your Apple credentials. Create
+   it once with an [app-specific password](https://support.apple.com/en-us/HT204397):
+
+   ```sh
+   xcrun notarytool store-credentials "YahooKeyKeyNotary" \
+     --apple-id "you@example.com" \
+     --team-id "TEAMID" \
+     --password "abcd-efgh-ijkl-mnop"   # app-specific password, not your Apple ID password
+   ```
+
+   `"YahooKeyKeyNotary"` is the profile name you pass via `NOTARY_PROFILE`.
+
+> An **ad-hoc** build (no env vars set) still works for local testing — it just
+> can't be distributed without users manually clearing quarantine.
+
+---
+
+## Build & package
+
+Signing and notarization are controlled by two environment variables. Set both
+for a public release:
+
+```sh
+export DEVELOPER_ID_APP="Developer ID Application: Teddy Chan (TEAMID)"
+export NOTARY_PROFILE="YahooKeyKeyNotary"
+./tools/package-release.sh
+```
+
+For a quick **local / ad-hoc** build (Gatekeeper-blocked), just run it with no
+env vars:
+
+```sh
+./tools/package-release.sh
+```
+
+### Artifacts
+
+Both runs produce, in `build/`:
+
+- `build/YahooKeyKey2-1.0.0.dmg` — the DMG to upload to your release/download page.
+- `build/YahooKeyKey2-1.0.0.zip` — a zip alternative containing the same `.app`.
+
+The DMG contains `YahooKeyKey2.app` plus an `Install.txt` with the user steps below.
+
+The script prints a final summary stating the version, signing status
+(Developer ID vs ad-hoc), and notarization status.
+
+---
+
+## End-user install instructions
+
+(Put these in the release notes / download page.)
+
+1. **Download** and open the DMG.
+2. **Copy `YahooKeyKey2.app`** into `~/Library/Input Methods/`
+   (create the folder if it doesn't exist).
+3. **Log out and log back in** — macOS only scans for input methods at login.
+4. Open **System Settings ▸ Keyboard ▸ Input Sources ▸ `+`**, choose
+   **Traditional Chinese**, and add **Yahoo KeyKey 2 — Cangjie** and/or
+   **Yahoo KeyKey 2 — Simplex**.
+5. Switch input source with **Ctrl-Space** and start typing.
+
+---
+
+## Troubleshooting
+
+- **"App is damaged" / "from an unidentified developer"**: this only happens for
+  **ad-hoc / un-notarized** builds. Either right-click the app ▸ **Open** the
+  first time, or remove the quarantine attribute:
+
+  ```sh
+  xattr -dr com.apple.quarantine ~/Library/Input\ Methods/YahooKeyKey2.app
+  ```
+
+  A **signed + notarized** build (the recommended public release) avoids this
+  entirely.
+
+- **Input method doesn't appear** in System Settings: confirm the app is in
+  `~/Library/Input Methods/`, then **log out and back in** — the login scan is
+  required.

--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -44,7 +44,7 @@ swiftc \
   -swift-version 5 \
   -I "$MODULE_DIR" -L "$MODULE_DIR" -lKeyKeyEngine \
   -framework InputMethodKit -framework Cocoa \
-  "$APP_SRC"/main.swift "$APP_SRC"/InputController.swift "$APP_SRC"/InputEngine.swift "$APP_SRC"/CandidateWindow.swift
+  "$APP_SRC"/main.swift "$APP_SRC"/InputController.swift "$APP_SRC"/InputEngine.swift "$APP_SRC"/CandidateWindow.swift "$APP_SRC"/Preferences.swift "$APP_SRC"/PreferencesWindow.swift
 
 echo "==> Assembling Info.plist (resolving \${EXECUTABLE_NAME})"
 sed "s/\${EXECUTABLE_NAME}/$EXECUTABLE_NAME/g" "$APP_SRC/Info.plist" > "$APP/Contents/Info.plist"

--- a/tools/package-release.sh
+++ b/tools/package-release.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# Package "Yahoo KeyKey 2" for non-App-Store distribution.
+#
+# Produces a downloadable DMG (and a .zip alternative) containing YahooKeyKey2.app,
+# which users copy into ~/Library/Input Methods/ and enable in System Settings.
+#
+# Code signing and notarization are OPTIONAL and driven entirely by environment
+# variables so this script never embeds Teddy's identity and can run on CI or any
+# machine in ad-hoc mode. Signing/notarization must be done on a machine that holds
+# the Developer ID certificate and notarytool credentials.
+#
+#   DEVELOPER_ID_APP   e.g. "Developer ID Application: Teddy Chan (TEAMID)"
+#                      When set, the .app is re-signed with this identity.
+#                      When unset, the .app keeps build-app.sh's ad-hoc signature.
+#
+#   NOTARY_PROFILE     a notarytool keychain profile name (created via
+#                      `xcrun notarytool store-credentials`). When set AND the app
+#                      was Developer-ID-signed, the app is notarized and stapled.
+#
+# Requires: tools/build-app.sh deps, plus codesign, xcrun (notarytool/stapler),
+# hdiutil, ditto, plutil. Produces ./build/YahooKeyKey2-<version>.dmg and .zip.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD="$ROOT/build"
+APP="$BUILD/YahooKeyKey2.app"
+APP_NAME="YahooKeyKey2.app"
+
+# --- 1. Build the .app ------------------------------------------------------
+echo "==> Building YahooKeyKey2.app"
+"$ROOT/tools/build-app.sh"
+
+if [ ! -d "$APP" ]; then
+  echo "ERROR: expected $APP after build-app.sh" >&2
+  exit 1
+fi
+
+# --- 2. Read version from the built Info.plist ------------------------------
+VERSION="$(/usr/bin/plutil -extract CFBundleShortVersionString raw "$APP/Contents/Info.plist")"
+if [ -z "$VERSION" ]; then
+  echo "ERROR: could not read CFBundleShortVersionString from Info.plist" >&2
+  exit 1
+fi
+echo "==> Version: $VERSION"
+
+DMG="$BUILD/YahooKeyKey2-$VERSION.dmg"
+ZIP="$BUILD/YahooKeyKey2-$VERSION.zip"
+
+# --- 3. Code signing (optional) ---------------------------------------------
+# Track signing status for the final summary.
+SIGN_STATUS="ad-hoc"
+if [ -n "${DEVELOPER_ID_APP:-}" ]; then
+  echo "==> Signing with Developer ID: $DEVELOPER_ID_APP"
+  # --options runtime enables the hardened runtime (required for notarization).
+  # --timestamp embeds a secure timestamp. --deep signs nested code (the static
+  # lib is linked in, but --deep is harmless and matches build-app.sh's style).
+  codesign --force --deep --options runtime --timestamp \
+    --sign "$DEVELOPER_ID_APP" "$APP"
+  echo "==> Verifying signature"
+  codesign --verify --strict --verbose=2 "$APP"
+  SIGN_STATUS="Developer ID ($DEVELOPER_ID_APP)"
+else
+  echo "WARNING: DEVELOPER_ID_APP not set -- the app keeps its AD-HOC signature."
+  echo "         Gatekeeper will BLOCK download-distributed copies. Users would need"
+  echo "         to right-click > Open, or remove the quarantine attribute manually."
+  echo "         See docs/RELEASE.md for the signed+notarized release procedure."
+fi
+
+# --- 4. Notarization (optional) ---------------------------------------------
+NOTARY_STATUS="skipped"
+if [ -n "${NOTARY_PROFILE:-}" ]; then
+  if [ -n "${DEVELOPER_ID_APP:-}" ]; then
+    echo "==> Notarizing with keychain profile: $NOTARY_PROFILE"
+    NOTARIZE_ZIP="$BUILD/YahooKeyKey2-notarize.zip"
+    rm -f "$NOTARIZE_ZIP"
+    # notarytool wants an archive; ditto preserves the bundle structure.
+    ditto -c -k --keepParent "$APP" "$NOTARIZE_ZIP"
+    xcrun notarytool submit "$NOTARIZE_ZIP" \
+      --keychain-profile "$NOTARY_PROFILE" --wait
+    echo "==> Stapling notarization ticket onto the app"
+    xcrun stapler staple "$APP"
+    rm -f "$NOTARIZE_ZIP"
+    NOTARY_STATUS="notarized + stapled"
+  else
+    echo "WARNING: NOTARY_PROFILE is set but DEVELOPER_ID_APP is not."
+    echo "         Notarization requires a Developer-ID signature -- skipping."
+    NOTARY_STATUS="skipped (no Developer ID signature)"
+  fi
+else
+  echo "==> NOTARY_PROFILE not set -- skipping notarization."
+fi
+
+# --- 5. Package: DMG + ZIP --------------------------------------------------
+# Stage a clean directory holding the app and a plain-text install guide, then
+# turn it into a read-only DMG. The staging dir keeps the DMG contents tidy.
+echo "==> Staging DMG contents"
+STAGE="$BUILD/dmg-stage"
+rm -rf "$STAGE"
+mkdir -p "$STAGE"
+cp -R "$APP" "$STAGE/$APP_NAME"
+
+cat > "$STAGE/Install.txt" <<EOF
+Yahoo KeyKey 2 — Install
+
+1. Copy "YahooKeyKey2.app" into your Input Methods folder:
+       ~/Library/Input Methods/
+   (Create the folder if it does not exist.)
+
+2. Log out and log back in. macOS only scans input methods at login.
+
+3. Open System Settings > Keyboard > Input Sources > "+",
+   choose Traditional Chinese, and add:
+       Yahoo KeyKey 2 — Cangjie   and/or   Yahoo KeyKey 2 — Simplex
+
+4. Switch input source with Ctrl-Space and start typing.
+
+If macOS reports the app is damaged or from an unidentified developer
+(ad-hoc / un-notarized builds only), remove the quarantine flag:
+       xattr -dr com.apple.quarantine "~/Library/Input Methods/YahooKeyKey2.app"
+EOF
+
+echo "==> Creating DMG: $DMG"
+rm -f "$DMG"
+hdiutil create \
+  -volname "Yahoo KeyKey 2 $VERSION" \
+  -srcfolder "$STAGE" \
+  -ov -format UDZO \
+  "$DMG"
+
+echo "==> Creating ZIP: $ZIP"
+rm -f "$ZIP"
+ditto -c -k --keepParent "$APP" "$ZIP"
+
+rm -rf "$STAGE"
+
+# --- 6. Summary -------------------------------------------------------------
+echo
+echo "==================== RELEASE SUMMARY ===================="
+echo "Version       : $VERSION"
+echo "Signing       : $SIGN_STATUS"
+echo "Notarization  : $NOTARY_STATUS"
+echo "DMG           : $DMG"
+echo "ZIP           : $ZIP"
+echo "========================================================="
+if [ "$SIGN_STATUS" = "ad-hoc" ]; then
+  echo "NOTE: This is an AD-HOC build for local testing only."
+  echo "      For a public download, set DEVELOPER_ID_APP and NOTARY_PROFILE."
+  echo "      See docs/RELEASE.md."
+fi


### PR DESCRIPTION
Adds a Preferences window (candidate font size, 聯想 toggle, full-width punctuation toggle — persisted, wired live, opened via the input-menu '偏好設定…' item) and release tooling: `tools/package-release.sh` (optional Developer ID signing + notarytool notarization via env vars; produces a DMG + zip) and `docs/RELEASE.md`. Cangjie/Simplex only (v1.0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)