### PR TITLE
Han-convert (TC→SC) toggle + GUI .pkg installer

### DIFF
--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -50,6 +50,8 @@ final class InputController: IMKInputController {
     private let associatedPhrases: AssociatedPhrases
     private let cangjieTable: CangjieTable
     private let simplexTable: SimplexTable
+    // Traditional→Simplified character converter, applied only when Preferences.outputSimplifiedEnabled.
+    private let hanConvertFilter: HanConvertFilter
     private let layout: LayoutChoice = .standard
     private var method: InputMethodChoice = .cangjie
     private var engine: InputEngine
@@ -105,6 +107,18 @@ final class InputController: IMKInputController {
         // Cangjie radicals → all matching characters).
         let simplexTable = SimplexTable(cangjie: cangjieTable)
         self.simplexTable = simplexTable
+
+        // Load the bundled TC→SC table for the "輸出簡體字" toggle; fail safe to an empty
+        // (pass-through) table if missing, so the toggle simply leaves text unchanged.
+        let hanConvertTable: HanConvertTable
+        if let url = Bundle.main.url(forResource: "opencc-TSCharacters", withExtension: "txt"),
+           let loaded = try? HanConvertTable(contentsOf: url) {
+            hanConvertTable = loaded
+        } else {
+            NSLog("YahooKeyKey: opencc-TSCharacters.txt missing; Simplified output disabled (pass-through)")
+            hanConvertTable = HanConvertTable(text: "")
+        }
+        self.hanConvertFilter = HanConvertFilter(direction: .traditionalToSimplified, table: hanConvertTable)
 
         // Start on Cangjie; IMK calls setValue(_:forTag:client:) with the active input mode
         // (and on every mode switch), which rebuilds the engine accordingly.
@@ -199,7 +213,7 @@ final class InputController: IMKInputController {
                 if index < count {
                     let phrase = associations[index]
                     clearAssociations()
-                    client.insertText(phrase, replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
+                    client.insertText(applyHanConvert(phrase), replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
                     return true
                 }
                 return true // digit beyond this page: swallow, no insert
@@ -331,7 +345,7 @@ final class InputController: IMKInputController {
         candidatePage = 0
         let text = engine.commit()
         if !text.isEmpty {
-            client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
+            client.insertText(applyHanConvert(text), replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
         }
         client.setMarkedText("", selectionRange: NSRange(location: 0, length: 0),
                              replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
@@ -349,6 +363,12 @@ final class InputController: IMKInputController {
         associations = []
         candidateWindow.hide()
         return true
+    }
+
+    // Apply Traditional→Simplified conversion iff the user enabled "輸出簡體字" (read live).
+    // Used for both committed text and candidate/association display so they stay WYSIWYG.
+    private func applyHanConvert(_ text: String) -> String {
+        Preferences.outputSimplifiedEnabled ? hanConvertFilter.convert(text) : text
     }
 
     // Leave association mode: drop the suggestions, reset paging, hide the candidate window.
@@ -376,7 +396,8 @@ final class InputController: IMKInputController {
             // Guard against a stale candidatePage pointing past the end (would trap on slice).
             if candidatePage * size >= cands.count { candidatePage = 0 }
             let start = candidatePage * size
-            let page = Array(cands[start..<min(start + size, cands.count)])
+            // Convert only the displayed strings (WYSIWYG); selection still indexes `cands`.
+            let page = cands[start..<min(start + size, cands.count)].map(applyHanConvert)
             var rect = NSRect.zero
             client.attributes(forCharacterIndex: 0, lineHeightRectangle: &rect)
             candidateWindow.show(page, page: candidatePage, pageCount: pageCount,

--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -156,10 +156,20 @@ final class InputController: IMKInputController {
     // action, independent of which controller instance receives it.
     override func menu() -> NSMenu! {
         let menu = NSMenu()
+        // Quick toggle: convert committed output Traditional -> Simplified. Check reflects state.
+        let convert = NSMenuItem(title: "輸出簡體字", action: #selector(toggleSimplified), keyEquivalent: "")
+        convert.target = self
+        convert.state = Preferences.outputSimplifiedEnabled ? .on : .off
+        menu.addItem(convert)
+        menu.addItem(.separator())
         let item = NSMenuItem(title: "偏好設定…", action: #selector(openPreferences), keyEquivalent: "")
         item.target = self
         menu.addItem(item)
         return menu
+    }
+
+    @objc private func toggleSimplified() {
+        Preferences.outputSimplifiedEnabled.toggle()
     }
 
     @objc private func openPreferences() {

--- a/App/Preferences.swift
+++ b/App/Preferences.swift
@@ -7,6 +7,7 @@ enum Preferences {
         static let candidateFontSize = "candidateFontSize"
         static let associatedPhrasesEnabled = "associatedPhrasesEnabled"
         static let fullWidthPunctuationEnabled = "fullWidthPunctuationEnabled"
+        static let outputSimplifiedEnabled = "outputSimplifiedEnabled"
     }
 
     static let minFontSize: CGFloat = 14
@@ -19,6 +20,7 @@ enum Preferences {
             Key.candidateFontSize: Double(defaultFontSize),
             Key.associatedPhrasesEnabled: true,
             Key.fullWidthPunctuationEnabled: true,
+            Key.outputSimplifiedEnabled: false,
         ])
     }
 
@@ -41,5 +43,10 @@ enum Preferences {
     static var fullWidthPunctuationEnabled: Bool {
         get { UserDefaults.standard.bool(forKey: Key.fullWidthPunctuationEnabled) }
         set { UserDefaults.standard.set(newValue, forKey: Key.fullWidthPunctuationEnabled) }
+    }
+
+    static var outputSimplifiedEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: Key.outputSimplifiedEnabled) }
+        set { UserDefaults.standard.set(newValue, forKey: Key.outputSimplifiedEnabled) }
     }
 }

--- a/App/PreferencesWindow.swift
+++ b/App/PreferencesWindow.swift
@@ -10,9 +10,10 @@ final class PreferencesWindowController: NSWindowController {
     private let fontSizeLabel = NSTextField(labelWithString: "")
     private let associatedPhrasesCheckbox = NSButton(checkboxWithTitle: "", target: nil, action: nil)
     private let fullWidthPunctuationCheckbox = NSButton(checkboxWithTitle: "", target: nil, action: nil)
+    private let outputSimplifiedCheckbox = NSButton(checkboxWithTitle: "", target: nil, action: nil)
 
     private init() {
-        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 360, height: 170),
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 360, height: 200),
                               styleMask: [.titled, .closable],
                               backing: .buffered, defer: false)
         window.title = "偏好設定"
@@ -41,11 +42,15 @@ final class PreferencesWindowController: NSWindowController {
         fullWidthPunctuationCheckbox.target = self
         fullWidthPunctuationCheckbox.action = #selector(fullWidthPunctuationChanged)
 
+        outputSimplifiedCheckbox.title = "輸出簡體字"
+        outputSimplifiedCheckbox.target = self
+        outputSimplifiedCheckbox.action = #selector(outputSimplifiedChanged)
+
         let fontRow = NSStackView(views: [fontTitle, fontSizeStepper, fontSizeLabel])
         fontRow.spacing = 8
         fontRow.alignment = .centerY
 
-        let stack = NSStackView(views: [fontRow, associatedPhrasesCheckbox, fullWidthPunctuationCheckbox])
+        let stack = NSStackView(views: [fontRow, associatedPhrasesCheckbox, fullWidthPunctuationCheckbox, outputSimplifiedCheckbox])
         stack.orientation = .vertical
         stack.alignment = .leading
         stack.spacing = 16
@@ -64,6 +69,7 @@ final class PreferencesWindowController: NSWindowController {
         fontSizeLabel.stringValue = "\(Int(Preferences.candidateFontSize)) pt"
         associatedPhrasesCheckbox.state = Preferences.associatedPhrasesEnabled ? .on : .off
         fullWidthPunctuationCheckbox.state = Preferences.fullWidthPunctuationEnabled ? .on : .off
+        outputSimplifiedCheckbox.state = Preferences.outputSimplifiedEnabled ? .on : .off
     }
 
     func show() {
@@ -84,5 +90,9 @@ final class PreferencesWindowController: NSWindowController {
 
     @objc private func fullWidthPunctuationChanged() {
         Preferences.fullWidthPunctuationEnabled = (fullWidthPunctuationCheckbox.state == .on)
+    }
+
+    @objc private func outputSimplifiedChanged() {
+        Preferences.outputSimplifiedEnabled = (outputSimplifiedCheckbox.state == .on)
     }
 }

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -107,3 +107,77 @@ The script prints a final summary stating the version, signing status
 - **Input method doesn't appear** in System Settings: confirm the app is in
   `~/Library/Input Methods/`, then **log out and back in** — the login scan is
   required.
+
+---
+
+## GUI installer (`.pkg`)
+
+For a native double-click experience, `tools/package-installer.sh` builds a
+**GUI `.pkg`** that drives the macOS **Installer.app** flow: it installs
+`YahooKeyKey2.app` into **`~/Library/Input Methods/`** (the **current user's
+home — no admin password**) and ends with a **Log Out** button so the user can
+log out/in to activate the input method.
+
+It first builds the app — via `tools/package-release.sh` when `DEVELOPER_ID_APP`
+is set (signed/notarized app), otherwise via `tools/build-app.sh` (ad-hoc) — then
+wraps it with `pkgbuild` + `productbuild`.
+
+### Prerequisites (for a signed + notarized installer)
+
+A `.pkg` distributed by download must be signed with a **"Developer ID
+Installer"** certificate (distinct from the **Developer ID Application** cert
+that signs the app) and notarized. You need:
+
+1. The app-signing prerequisites above (Developer ID Application cert + the same
+   notarytool keychain profile).
+
+2. A **"Developer ID Installer"** certificate in your login keychain. Create it
+   once in **Xcode ▸ Settings ▸ Accounts ▸ Manage Certificates ▸ "+" ▸
+   "Developer ID Installer"**. Confirm it is present:
+
+   ```sh
+   security find-identity -v   # look for: Developer ID Installer: Teddy Chan (TEAMID)
+   ```
+
+> Without `DEVELOPER_ID_INSTALLER` the script still builds an **UNSIGNED** `.pkg`,
+> which is fine for **local testing** (right-click ▸ **Open** to bypass
+> Gatekeeper). It just can't be distributed by download.
+
+### Build the installer
+
+```sh
+export DEVELOPER_ID_APP="Developer ID Application: Teddy Chan (TEAMID)"
+export DEVELOPER_ID_INSTALLER="Developer ID Installer: Teddy Chan (TEAMID)"
+export NOTARY_PROFILE="YahooKeyKeyNotary"
+./tools/package-installer.sh
+```
+
+For a quick **local / unsigned** installer, run it with no env vars:
+
+```sh
+./tools/package-installer.sh
+```
+
+Either way it produces, in `build/`:
+
+- `build/YahooKeyKey2-1.0.0.pkg` — the GUI installer.
+
+The installer resources (`distribution.xml.template`, `welcome.txt`,
+`conclusion.txt`, `postinstall`) live in `installer/`; the script materializes
+them into temp build dirs at run time and cleans up afterwards. The component
+pkg uses `enable_currentUserHome` (current-user-home domain → no admin) and
+`onConclusion="RequireLogout"` (the Log Out prompt). The summary states the
+version, pkg signing status, and notarization status.
+
+### End-user experience
+
+1. **Double-click `YahooKeyKey2-1.0.0.pkg`** → the macOS Installer GUI opens.
+   (For an unsigned pkg, right-click ▸ **Open** the first time.)
+2. Click through; it installs **without** an admin password into
+   **`~/Library/Input Methods/`**.
+3. At the end, click **Log Out** (then log back in) — required so macOS
+   registers the new input method.
+4. Open **System Settings ▸ Keyboard ▸ Input Sources ▸ `+`**, choose
+   **Traditional Chinese**, and add **Yahoo KeyKey 2 — Cangjie** and/or
+   **Yahoo KeyKey 2 — Simplex**.
+5. Switch input source with **Ctrl-Space** and start typing.

--- a/installer/conclusion.txt
+++ b/installer/conclusion.txt
@@ -1,0 +1,18 @@
+Yahoo KeyKey 2 was installed into:
+
+    ~/Library/Input Methods/YahooKeyKey2.app
+
+To finish setup:
+
+  1. LOG OUT and log back in (or restart). macOS only scans for input
+     methods at login, so this step is required before it appears.
+     Use the "Log Out" button below to do this now.
+
+  2. Open System Settings ▸ Keyboard ▸ Input Sources ▸ "+",
+     choose Traditional Chinese, and add:
+         Yahoo KeyKey 2 — Cangjie    and/or
+         Yahoo KeyKey 2 — Simplex
+
+  3. Switch input source with Ctrl-Space and start typing.
+
+Enjoy Yahoo KeyKey 2!

--- a/installer/distribution.xml.template
+++ b/installer/distribution.xml.template
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  productbuild distribution definition for "Yahoo KeyKey 2".
+
+  Placeholders below are substituted by tools/package-installer.sh at build time:
+    __VERSION__        CFBundleShortVersionString read from the built app
+    __COMPONENT_PKG__  filename of the pkgbuild component pkg (e.g. component.pkg)
+
+  Key behaviours:
+    * <domains enable_currentUserHome="true" ...>  -> installs into the CURRENT
+      user's home (~/Library/Input Methods), so NO admin password is needed.
+    * onConclusion="RequireLogout"  -> Installer shows the "Log Out" button at the
+      end, which is what activates the input method (macOS only scans Input Methods
+      at login).
+    * customize="never"  -> single straightforward flow, no component selection.
+-->
+<installer-gui-script minSpecVersion="1">
+    <title>Yahoo KeyKey 2</title>
+
+    <welcome file="welcome.txt" mime-type="text/plain"/>
+    <conclusion file="conclusion.txt" mime-type="text/plain"/>
+
+    <domains enable_currentUserHome="true" enable_anywhere="false" enable_localSystem="false"/>
+    <options customize="never" require-scripts="false" rootVolumeOnly="false"/>
+
+    <choices-outline>
+        <line choice="default">
+            <line choice="com.github.teddychan.inputmethod.YahooKeyKey2.pkg"/>
+        </line>
+    </choices-outline>
+
+    <choice id="default"/>
+    <choice id="com.github.teddychan.inputmethod.YahooKeyKey2.pkg" visible="false">
+        <pkg-ref id="com.github.teddychan.inputmethod.YahooKeyKey2.pkg"/>
+    </choice>
+
+    <pkg-ref id="com.github.teddychan.inputmethod.YahooKeyKey2.pkg"
+             version="__VERSION__"
+             onConclusion="RequireLogout">__COMPONENT_PKG__</pkg-ref>
+</installer-gui-script>

--- a/installer/postinstall
+++ b/installer/postinstall
@@ -1,0 +1,7 @@
+#!/bin/bash
+# postinstall for Yahoo KeyKey 2.
+# Refresh any running instance so a re-install picks up the new bundle.
+# macOS still requires a logout/login to register a freshly added input method;
+# Installer handles that via the onConclusion="RequireLogout" prompt.
+killall YahooKeyKey2 2>/dev/null || true
+exit 0

--- a/installer/welcome.txt
+++ b/installer/welcome.txt
@@ -1,0 +1,18 @@
+Yahoo KeyKey 2 — Traditional Chinese Input Method
+
+This installer adds Yahoo KeyKey 2 to your Mac. It is a Traditional
+Chinese input method offering two input modes:
+
+    • Cangjie (倉頡)
+    • Simplex / Quick (速成)
+
+It installs into your personal Input Methods folder
+(~/Library/Input Methods/YahooKeyKey2.app), so NO administrator
+password is required — only your own user account is affected.
+
+After installation you will need to LOG OUT and log back in so macOS
+can register the new input method, then enable it in
+System Settings ▸ Keyboard ▸ Input Sources. The next screen has the
+details.
+
+Click Continue to proceed.

--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -64,6 +64,13 @@ if [ ! -f "$ROOT/Resources/cangjie.txt" ]; then
 fi
 cp "$ROOT/Resources/cangjie.txt" "$APP/Contents/Resources/cangjie.txt"
 
+echo "==> Copying bundled Han-conversion table (opencc-TSCharacters.txt)"
+if [ ! -f "$ROOT/Packages/KeyKeyEngine/Resources/opencc-TSCharacters.txt" ]; then
+  echo "ERROR: Packages/KeyKeyEngine/Resources/opencc-TSCharacters.txt missing" >&2
+  exit 1
+fi
+cp "$ROOT/Packages/KeyKeyEngine/Resources/opencc-TSCharacters.txt" "$APP/Contents/Resources/opencc-TSCharacters.txt"
+
 echo "==> Copying localized strings (.lproj)"
 for lproj in "$APP_SRC"/*.lproj; do
   [ -d "$lproj" ] && cp -R "$lproj" "$APP/Contents/Resources/"

--- a/tools/package-installer.sh
+++ b/tools/package-installer.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Build a GUI .pkg installer for "Yahoo KeyKey 2" (an InputMethodKit input method).
+#
+# The resulting double-clickable .pkg drives the native macOS Installer.app flow,
+# installs YahooKeyKey2.app into the CURRENT user's ~/Library/Input Methods/
+# (NO admin password required), and ends with a "Log Out" button so the user can
+# log out/in to activate the input method (macOS only scans Input Methods at login).
+#
+# Signing and notarization are OPTIONAL and driven entirely by environment
+# variables so this script never embeds Teddy's identity:
+#
+#   DEVELOPER_ID_APP        "Developer ID Application: NAME (TEAMID)"
+#                           When set (optionally with NOTARY_PROFILE), the .app is
+#                           built+signed (and notarized) via tools/package-release.sh.
+#                           When unset, an ad-hoc app is built via tools/build-app.sh.
+#
+#   DEVELOPER_ID_INSTALLER  "Developer ID Installer: NAME (TEAMID)"
+#                           When set, the .pkg is signed (productbuild --sign).
+#                           Required for download distribution; absent => UNSIGNED pkg.
+#
+#   NOTARY_PROFILE          notarytool keychain profile. When set together with
+#                           DEVELOPER_ID_INSTALLER, the signed .pkg is notarized+stapled.
+#                           (Also used by package-release.sh to notarize the app.)
+#
+# Requires: tools/build-app.sh deps, plus pkgbuild, productbuild, plutil, xcrun.
+# Produces ./build/YahooKeyKey2-<version>.pkg.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD="$ROOT/build"
+APP="$BUILD/YahooKeyKey2.app"
+INSTALLER_SRC="$ROOT/installer"
+PKG_IDENTIFIER="com.github.teddychan.inputmethod.YahooKeyKey2.pkg"
+
+# --- 1. Build the .app (signed/notarized if env set, else ad-hoc) -----------
+if [ -n "${DEVELOPER_ID_APP:-}" ]; then
+  echo "==> DEVELOPER_ID_APP set -- building signed app via package-release.sh"
+  "$ROOT/tools/package-release.sh"
+else
+  echo "==> DEVELOPER_ID_APP not set -- building ad-hoc app via build-app.sh"
+  "$ROOT/tools/build-app.sh"
+fi
+
+if [ ! -d "$APP" ]; then
+  echo "ERROR: expected $APP after build" >&2
+  exit 1
+fi
+
+VERSION="$(/usr/bin/plutil -extract CFBundleShortVersionString raw "$APP/Contents/Info.plist")"
+if [ -z "$VERSION" ]; then
+  echo "ERROR: could not read CFBundleShortVersionString from Info.plist" >&2
+  exit 1
+fi
+echo "==> Version: $VERSION"
+
+PKG="$BUILD/YahooKeyKey2-$VERSION.pkg"
+COMPONENT_PKG="$BUILD/component.pkg"
+
+# --- 2. Component pkg: payload installed to ~/Library/Input Methods/ --------
+# Stage a root whose layout mirrors the user's home. With the distribution's
+# enable_currentUserHome domain, "/Library/Input Methods" resolves under the
+# installing user's home, so no admin rights are needed.
+echo "==> Staging payload"
+STAGE="$BUILD/pkg-stage"
+SCRIPTS="$BUILD/pkg-scripts"
+rm -rf "$STAGE" "$SCRIPTS"
+mkdir -p "$STAGE/Library/Input Methods" "$SCRIPTS"
+cp -R "$APP" "$STAGE/Library/Input Methods/YahooKeyKey2.app"
+
+cp "$INSTALLER_SRC/postinstall" "$SCRIPTS/postinstall"
+chmod +x "$SCRIPTS/postinstall"
+
+echo "==> Building component pkg"
+rm -f "$COMPONENT_PKG"
+pkgbuild \
+  --root "$STAGE" \
+  --install-location "/" \
+  --identifier "$PKG_IDENTIFIER" \
+  --version "$VERSION" \
+  --scripts "$SCRIPTS" \
+  "$COMPONENT_PKG"
+
+# --- 3. Distribution pkg via productbuild -----------------------------------
+# Materialize distribution.xml + welcome/conclusion into a temp dir, substituting
+# the version and component pkg filename.
+echo "==> Preparing distribution resources"
+DIST_DIR="$BUILD/pkg-dist"
+RES_DIR="$BUILD/pkg-resources"
+rm -rf "$DIST_DIR" "$RES_DIR"
+mkdir -p "$DIST_DIR" "$RES_DIR"
+
+sed -e "s/__VERSION__/$VERSION/g" \
+    -e "s|__COMPONENT_PKG__|$(basename "$COMPONENT_PKG")|g" \
+    "$INSTALLER_SRC/distribution.xml.template" > "$DIST_DIR/distribution.xml"
+
+cp "$INSTALLER_SRC/welcome.txt" "$RES_DIR/welcome.txt"
+cp "$INSTALLER_SRC/conclusion.txt" "$RES_DIR/conclusion.txt"
+
+echo "==> Building distribution pkg: $PKG"
+rm -f "$PKG"
+
+PRODUCTBUILD_SIGN=()
+SIGN_STATUS="UNSIGNED"
+if [ -n "${DEVELOPER_ID_INSTALLER:-}" ]; then
+  echo "==> Signing pkg with: $DEVELOPER_ID_INSTALLER"
+  PRODUCTBUILD_SIGN=(--sign "$DEVELOPER_ID_INSTALLER")
+  SIGN_STATUS="Developer ID Installer ($DEVELOPER_ID_INSTALLER)"
+else
+  echo "WARNING: DEVELOPER_ID_INSTALLER not set -- the .pkg will be UNSIGNED."
+  echo "         An unsigned pkg is fine for LOCAL testing (right-click > Open)."
+  echo "         For download distribution you need a \"Developer ID Installer\""
+  echo "         certificate. Create it once in Xcode > Settings > Accounts >"
+  echo "         Manage Certificates > + > Developer ID Installer, then set"
+  echo "         DEVELOPER_ID_INSTALLER. See docs/RELEASE.md."
+fi
+
+productbuild \
+  --distribution "$DIST_DIR/distribution.xml" \
+  --package-path "$BUILD" \
+  --resources "$RES_DIR" \
+  ${PRODUCTBUILD_SIGN[@]+"${PRODUCTBUILD_SIGN[@]}"} \
+  "$PKG"
+
+# --- 4. Notarization (optional; signed pkgs only) ---------------------------
+NOTARY_STATUS="skipped"
+if [ -n "${NOTARY_PROFILE:-}" ]; then
+  if [ -n "${DEVELOPER_ID_INSTALLER:-}" ]; then
+    echo "==> Notarizing pkg with keychain profile: $NOTARY_PROFILE"
+    xcrun notarytool submit "$PKG" --keychain-profile "$NOTARY_PROFILE" --wait
+    echo "==> Stapling notarization ticket onto the pkg"
+    xcrun stapler staple "$PKG"
+    NOTARY_STATUS="notarized + stapled"
+  else
+    echo "WARNING: NOTARY_PROFILE is set but DEVELOPER_ID_INSTALLER is not."
+    echo "         Notarizing a pkg requires a Developer ID Installer signature -- skipping."
+    NOTARY_STATUS="skipped (no Developer ID Installer signature)"
+  fi
+else
+  echo "==> NOTARY_PROFILE not set -- skipping pkg notarization."
+fi
+
+# --- 5. Clean up temp artifacts ---------------------------------------------
+rm -rf "$STAGE" "$SCRIPTS" "$DIST_DIR" "$RES_DIR" "$COMPONENT_PKG"
+
+# --- 6. Summary -------------------------------------------------------------
+echo
+echo "================== INSTALLER SUMMARY ==================="
+echo "Version          : $VERSION"
+echo "Installer pkg    : $PKG"
+echo "Pkg signing      : $SIGN_STATUS"
+echo "Notarization     : $NOTARY_STATUS"
+echo "Install location : ~/Library/Input Methods/YahooKeyKey2.app (current user, no admin)"
+echo "Activation       : Installer ends with a Log Out button; user logs out/in,"
+echo "                   then enables it in System Settings > Keyboard > Input Sources."
+echo "========================================================"
+if [ "$SIGN_STATUS" = "UNSIGNED" ]; then
+  echo "NOTE: UNSIGNED pkg -- local testing only (right-click > Open)."
+  echo "      For public download, set DEVELOPER_ID_INSTALLER (and NOTARY_PROFILE)."
+  echo "      See docs/RELEASE.md."
+fi


### PR DESCRIPTION
**Held for live-test confirmation before merge.**

- **Han-convert toggle** — Preferences `輸出簡體字`; bundles OpenCC TC→SC table; converts candidate display + committed output (WYSIWYG) when on, Traditional when off.
- **GUI .pkg installer** — `tools/package-installer.sh` + `installer/` resources: native Installer.app flow, installs to `~/Library/Input Methods/` (no admin), ends with a **Log Out** prompt to activate. Unsigned today (needs a one-time 'Developer ID Installer' cert to sign+notarize for download).
- Preferences window (font size / 聯想 / punctuation / 簡體) — needs live confirmation that the menu item opens it.

176 engine tests green; app builds, signs (Developer ID 4AF3KGGV29), notarizes + staples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)