### PR TITLE
fix(sparkle): point SUFeedURL at /yahoo-keykey-2/appcast.xml

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -86,7 +86,7 @@
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUFeedURL</key>
-	<string>https://www.dragonapp.com/keykey/appcast.xml</string>
+	<string>https://www.dragonapp.com/yahoo-keykey-2/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>p+F/ivF5bAYcmuNuCMNHcRv123A6LHFpCBagFm7Adu8=</string>
 	<key>SUScheduledCheckInterval</key>


### PR DESCRIPTION
The marketing site moved KeyKey's Sparkle feed from `https://www.dragonapp.com/keykey/appcast.xml` to `https://www.dragonapp.com/yahoo-keykey-2/appcast.xml` (matching the repo name). This updates the app's `SUFeedURL` so new builds check the live feed.

Already-shipped builds keep the old baked-in URL, which no longer serves a feed — an accepted break (GitHub Pages can't redirect an `.xml`; no release CI exists for KeyKey).

`SUPublicEDKey` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)