### PR TITLE
feat: candidate text-size menu; Apple Silicon only (v1.4.0)

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.4</string>
+	<string>1.4.0</string>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>11</string>
 	<key>ComponentInputModeDict</key>
 	<dict>
 		<key>tsInputModeListKey</key>

--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -95,6 +95,22 @@ final class InputController: IMKInputController {
         convert.state = Preferences.outputSimplifiedEnabled ? .on : .off
         menu.addItem(convert)
 
+        // Candidate-window font size (候選字大小): a submenu of named sizes. The chosen
+        // size is read live by CandidateWindow on the next composition; the checkmark
+        // marks the active size.
+        let fontSize = NSMenuItem(title: "候選字大小", action: nil, keyEquivalent: "")
+        let fontSubmenu = NSMenu()
+        let currentFontSize = Preferences.candidateFontSize
+        for (title, size) in Self.candidateFontSizeChoices {
+            let item = NSMenuItem(title: title, action: #selector(setCandidateFontSize(_:)), keyEquivalent: "")
+            item.target = self
+            item.tag = Int(size)
+            item.state = (currentFontSize == size) ? .on : .off
+            fontSubmenu.addItem(item)
+        }
+        fontSize.submenu = fontSubmenu
+        menu.addItem(fontSize)
+
         // 2. Settings specific to the active input method (grouped with their method).
         // Empty for Cangjie/Simplex today; future methods supply items via methodMenuItems.
         let methodItems = currentModule.methodMenuItems()
@@ -124,6 +140,16 @@ final class InputController: IMKInputController {
 
     @objc private func toggleSimplified() {
         Preferences.outputSimplifiedEnabled.toggle()
+    }
+
+    // Named candidate-window font sizes (display title → point size), all within the
+    // Preferences clamp (14–28); the default 18 is "中".
+    private static let candidateFontSizeChoices: [(String, CGFloat)] = [
+        ("小", 14), ("中", 18), ("大", 24),
+    ]
+
+    @objc private func setCandidateFontSize(_ sender: NSMenuItem) {
+        Preferences.candidateFontSize = CGFloat(sender.tag)
     }
 
     @objc private func checkForUpdates() {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# What's New in Yahoo KeyKey 2
+
+A plain-language list of changes in each version, newest first.
+
+## 1.4.0
+
+- **Choose your candidate text size.** The input menu now has a new
+  **「候選字大小」(Candidate Text Size)** option with **小 / 中 / 大 (Small / Medium /
+  Large)**. Pick whichever is easiest on your eyes — the candidate list updates the
+  next time you type.
+- **Apple Silicon only.** Yahoo KeyKey 2 now runs exclusively on Apple Silicon Macs
+  (M1 and newer). Older Intel Macs are no longer supported. If you're on an Intel
+  Mac, stay on version 1.3.4. This keeps the app smaller and lets us focus on the
+  Macs people use today.
+
+## 1.3.4
+
+- Tidied up the candidate window by removing the fixed "SHIFT + NUM" header line,
+  so the list looks cleaner.
+
+## 1.3.3
+
+- Refreshed the candidate window to a classic, more familiar KeyKey style.
+
+## 1.3.0
+
+- Added automatic updates: from this version on, Yahoo KeyKey 2 can check for and
+  install new versions on its own (for the direct download — Homebrew users update
+  through Homebrew).

--- a/installer/distribution.xml.template
+++ b/installer/distribution.xml.template
@@ -21,7 +21,8 @@
     <conclusion file="conclusion.txt" mime-type="text/plain"/>
 
     <domains enable_currentUserHome="true" enable_anywhere="false" enable_localSystem="false"/>
-    <options customize="never" require-scripts="false" rootVolumeOnly="false"/>
+    <!-- Apple Silicon only: refuse to install on Intel Macs (no x86_64 slice shipped). -->
+    <options customize="never" require-scripts="false" rootVolumeOnly="false" hostArchitectures="arm64"/>
 
     <choices-outline>
         <line choice="default">

--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -21,7 +21,9 @@ ENTITLEMENTS="$APP_SRC/YahooKeyKey2.entitlements"
 SPARKLE_CACHE="$ROOT/build/sparkle"
 
 SDK="$(xcrun --show-sdk-path)"
-TARGET="$(uname -m)-apple-macosx12.0"
+# Apple Silicon only: pin the target to arm64 regardless of the build host's
+# architecture. Yahoo KeyKey 2 does not ship an Intel (x86_64) slice.
+TARGET="arm64-apple-macosx12.0"
 
 echo "==> Ensuring Sparkle is vendored"
 "$ROOT/tools/fetch-sparkle.sh"


### PR DESCRIPTION
## What & why

Minor feature release **v1.4.0**.

### New feature — Candidate Text Size
Adds a **「候選字大小」(Candidate Text Size)** submenu to the input menu with **小 / 中 / 大 (Small / Medium / Large)**. This wires up the already-existing `Preferences.candidateFontSize` (the candidate window read it live but there was no UI to change it). Surgical: reuses existing plumbing, no new persisted state.

### Cleanup — Apple Silicon only (remove Intel)
- `tools/build-app.sh`: pin the `swiftc` target to `arm64-apple-macosx12.0` (was the build host's arch via `uname -m`).
- `installer/distribution.xml.template`: add `hostArchitectures="arm64"` so the `.pkg` refuses to install on Intel Macs.
- README badge + Sparkle appcast were already Apple-Silicon-only.

### Version + changelog
- `CFBundleShortVersionString` 1.3.4 → 1.4.0, `CFBundleVersion` 10 → 11.
- New `CHANGELOG.md` with plain-language, non-engineer-friendly notes.

## Verification
- `tools/build-app.sh` compiles the engine + app cleanly (fails only at the expected missing `data.txt`, which CI builds at release time).
- Built binary confirmed **arm64-only** (`lipo -archs` → `arm64`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)