### PR TITLE
ci: grant contents: write to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,12 @@ on:
       - 'v*'
   workflow_dispatch: {}
 
+# The reusable release workflow creates the GitHub Release and uploads assets,
+# which needs contents: write. Declare it explicitly here so the release does not
+# depend on this repo's default workflow-token setting being read/write.
+permissions:
+  contents: write
+
 jobs:
   release:
     uses: teddychan/dragon-release-ci/.github/workflows/release-macos.yml@v1


### PR DESCRIPTION
## What

Add an explicit top-level `permissions: contents: write` block to the release workflow caller.

## Why

The thin caller delegates to the shared `dragon-release-ci` reusable pipeline, which creates the GitHub Release and uploads assets — operations that require `contents: write` on the `GITHUB_TOKEN`. Today this only works because this repo's *default* workflow-token setting happens to be read/write (a mutable Settings toggle, not version-controlled). If that toggle ever flips to read-only, the release would be **rejected at startup**.

This makes the grant explicit, matching [ice-2's release workflow](https://github.com/teddychan/ice-2/blob/main/.github/workflows/release.yml) and the shared release SOP — so the release no longer depends on a repo setting.

## Change

One block added between `on:` and `jobs:`:

```yaml
permissions:
  contents: write
```

No behavior change to the build/sign/notarize/publish steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)