### PR TITLE
fix: candidate text-size menu now persists; v1.4.1

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.0</string>
+	<string>1.4.1</string>
 	<key>CFBundleVersion</key>
-	<string>11</string>
+	<string>12</string>
 	<key>ComponentInputModeDict</key>
 	<dict>
 		<key>tsInputModeListKey</key>

--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -95,21 +95,21 @@ final class InputController: IMKInputController {
         convert.state = Preferences.outputSimplifiedEnabled ? .on : .off
         menu.addItem(convert)
 
-        // Candidate-window font size (候選字大小): a submenu of named sizes. The chosen
-        // size is read live by CandidateWindow on the next composition; the checkmark
-        // marks the active size.
-        let fontSize = NSMenuItem(title: "候選字大小", action: nil, keyEquivalent: "")
-        let fontSubmenu = NSMenu()
+        // Candidate-window font size (候選字大小). The macOS input menu routes only
+        // TOP-LEVEL item selections back to the controller — items nested in a submenu
+        // are shown but never fire — so the sizes are flat items under a disabled
+        // header. The chosen size is read live by CandidateWindow on the next
+        // composition; the checkmark marks the active size.
+        let fontHeader = NSMenuItem(title: "候選字大小", action: nil, keyEquivalent: "")
+        fontHeader.isEnabled = false
+        menu.addItem(fontHeader)
         let currentFontSize = Preferences.candidateFontSize
-        for (title, size) in Self.candidateFontSizeChoices {
-            let item = NSMenuItem(title: title, action: #selector(setCandidateFontSize(_:)), keyEquivalent: "")
+        for (title, size, action) in Self.candidateFontSizeChoices {
+            let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
             item.target = self
-            item.tag = Int(size)
             item.state = (currentFontSize == size) ? .on : .off
-            fontSubmenu.addItem(item)
+            menu.addItem(item)
         }
-        fontSize.submenu = fontSubmenu
-        menu.addItem(fontSize)
 
         // 2. Settings specific to the active input method (grouped with their method).
         // Empty for Cangjie/Simplex today; future methods supply items via methodMenuItems.
@@ -142,15 +142,19 @@ final class InputController: IMKInputController {
         Preferences.outputSimplifiedEnabled.toggle()
     }
 
-    // Named candidate-window font sizes (display title → point size), all within the
-    // Preferences clamp (14–28); the default 18 is "中".
-    private static let candidateFontSizeChoices: [(String, CGFloat)] = [
-        ("小", 14), ("中", 18), ("大", 24),
+    // Named candidate-window font sizes (display title → point size → menu action),
+    // all within the Preferences clamp (14–28); the default 18 is "中". Each size has
+    // its own no-argument selector so it dispatches exactly like the toggles above —
+    // the input menu's cross-process routing doesn't preserve a shared handler's tag.
+    private static let candidateFontSizeChoices: [(title: String, size: CGFloat, action: Selector)] = [
+        ("小", 14, #selector(setCandidateFontSizeSmall)),
+        ("中", 18, #selector(setCandidateFontSizeMedium)),
+        ("大", 24, #selector(setCandidateFontSizeLarge)),
     ]
 
-    @objc private func setCandidateFontSize(_ sender: NSMenuItem) {
-        Preferences.candidateFontSize = CGFloat(sender.tag)
-    }
+    @objc private func setCandidateFontSizeSmall() { Preferences.candidateFontSize = 14 }
+    @objc private func setCandidateFontSizeMedium() { Preferences.candidateFontSize = 18 }
+    @objc private func setCandidateFontSizeLarge() { Preferences.candidateFontSize = 24 }
 
     @objc private func checkForUpdates() {
         Updater.shared.checkForUpdates()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 A plain-language list of changes in each version, newest first.
 
+## 1.4.1
+
+- **Fixed: the candidate text size now sticks.** Picking 小 / 中 / 大 from the
+  **「候選字大小」** menu had no effect — your choice was never saved. It now applies
+  and is remembered, the way it was meant to.
+
 ## 1.4.0
 
 - **Choose your candidate text size.** The input menu now has a new


### PR DESCRIPTION
## Problem
Picking a candidate text size (小/中/大) from the **候選字大小** menu did nothing — the choice was never saved, no matter which size was selected.

## Root cause
The size choices were the only menu items nested inside a **submenu**. The macOS input menu routes only **top-level** item selections back to the `IMKInputController`; submenu selections are displayed but their action never fires. So `Preferences.candidateFontSize` was never written. The persistence layer and the working top-level toggles were never broken.

## Fix
- Flatten 小/中/大 into **top-level** items under a disabled **候選字大小** header — the same dispatch path the working toggles use.
- Give each size its own no-argument selector (`setCandidateFontSizeSmall/Medium/Large`) instead of a shared `sender.tag` handler, since the input menu's cross-process routing doesn't preserve a menu item's `tag`.
- Bump 1.4.0 → 1.4.1 (CFBundleVersion 11 → 12) + CHANGELOG.

## Testing
Built locally, installed, and confirmed by the user: the sizes now appear as flat items, selecting one applies immediately, the checkmark moves, and the choice persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)