### PR TITLE
feat: complete §5A IME app menu (Settings… + Uninstall…); v1.7.0

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.7.0</string>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>ComponentInputModeDict</key>
 	<dict>
 		<key>tsInputModeListKey</key>

--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -68,11 +68,12 @@ final class InputController: IMKInputController {
     //   1. quick-toggles zone (輸出簡體字 / 全形標點 / 聯想字詞), checkmarks reflect live prefs;
     //   2. 候選字大小 (candidate size) flat choices;
     //   3. any settings specific to the active input method (none for Cangjie/Simplex today);
-    //   4. App menu grouping — About Yahoo! KeyKey 2 + 檢查更新… (stateless "open window" actions).
+    //   4. App menu grouping (§5A) — About Yahoo! KeyKey 2 · 檢查更新… · 設定… · — · 解除安裝….
     //      Per §5A the IME app menu omits Quit (an IME is system-managed; quitting only makes
-    //      typing unresponsive until macOS relaunches it). Settings… and Uninstall… are omitted
-    //      this pass — there is no Settings window today, and a correct IME uninstaller needs TIS
-    //      deselect/unregister + logout; both are out of scope for a menu-structure pass.
+    //      typing unresponsive until macOS relaunches it). All items are TOP-LEVEL: the macOS
+    //      input menu only routes top-level selections back to the controller, so a "⋯ Yahoo!
+    //      KeyKey 2" submenu would render but never fire — the flat grouping is the correct
+    //      IMK adaptation of the shared App-menu spec.
     override func menu() -> NSMenu! {
         let menu = NSMenu()
 
@@ -116,8 +117,8 @@ final class InputController: IMKInputController {
             methodItems.forEach(menu.addItem)
         }
 
-        // 4. App menu grouping (§5A): About + Check for updates (stateless "open" actions).
-        // Quit omitted by design (system-managed IME); Settings… / Uninstall… omitted this pass.
+        // 4. App menu grouping (§5A): About · Check for updates · Settings · — · Uninstall.
+        // Quit omitted by design (system-managed IME). All top-level so IMK routes them.
         menu.addItem(.separator())
         let about = NSMenuItem(title: "關於 Yahoo! KeyKey 2…", action: #selector(openAbout), keyEquivalent: "")
         about.target = self
@@ -125,6 +126,13 @@ final class InputController: IMKInputController {
         let update = NSMenuItem(title: "檢查更新…", action: #selector(checkForUpdates), keyEquivalent: "")
         update.target = self
         menu.addItem(update)
+        let settings = NSMenuItem(title: "設定…", action: #selector(openSettings), keyEquivalent: ",")
+        settings.target = self
+        menu.addItem(settings)
+        menu.addItem(.separator())
+        let uninstall = NSMenuItem(title: "解除安裝 Yahoo! KeyKey 2…", action: #selector(uninstall), keyEquivalent: "")
+        uninstall.target = self
+        menu.addItem(uninstall)
         return menu
     }
 
@@ -160,6 +168,14 @@ final class InputController: IMKInputController {
 
     @objc private func openAbout() {
         AboutWindowController.shared.show()
+    }
+
+    @objc private func openSettings() {
+        SettingsWindowController.shared.show()
+    }
+
+    @objc private func uninstall() {
+        Uninstaller.run()
     }
 
     // IMK calls this when the user selects one of our input modes (Info.plist

--- a/App/SettingsWindow.swift
+++ b/App/SettingsWindow.swift
@@ -1,0 +1,186 @@
+import Cocoa
+
+// The net-new Settings window, opened from the input menu's 設定… item. A small, native
+// AppKit NSWindowController mirroring AboutWindowController: a single shared instance whose
+// show() activates the LSUIElement agent so the window actually comes forward.
+//
+// IA follows the shared per-app spec: 一般 (the three real input toggles) · 外觀 (candidate
+// font size with a live preview) · 輸入方式 (read-only mode status + a deep link to System
+// Settings) · 更新 (Sparkle auto-check toggle + manual check). Controls bind directly to
+// Preferences / the Sparkle updater, which the engine and candidate window read live — so a
+// change here applies on the next composition without restarting the IME.
+final class SettingsWindowController: NSWindowController {
+    static let shared = SettingsWindowController()
+
+    // Live preview label in the 外觀 tab; re-rendered as the size slider moves.
+    private let fontPreview = NSTextField(labelWithString: "")
+    private let fontValueLabel = NSTextField(labelWithString: "")
+
+    private init() {
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 460, height: 320),
+                              styleMask: [.titled, .closable],
+                              backing: .buffered, defer: false)
+        window.title = "Yahoo! KeyKey 2 設定"
+        super.init(window: window)
+        buildUI()
+        window.center()
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func buildUI() {
+        guard let content = window?.contentView else { return }
+
+        let tabView = NSTabView()
+        tabView.translatesAutoresizingMaskIntoConstraints = false
+        tabView.addTabViewItem(makeTab("一般", view: generalView()))
+        tabView.addTabViewItem(makeTab("外觀", view: appearanceView()))
+        tabView.addTabViewItem(makeTab("輸入方式", view: inputMethodsView()))
+        tabView.addTabViewItem(makeTab("更新", view: updatesView()))
+
+        content.addSubview(tabView)
+        NSLayoutConstraint.activate([
+            tabView.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: 16),
+            tabView.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -16),
+            tabView.topAnchor.constraint(equalTo: content.topAnchor, constant: 16),
+            tabView.bottomAnchor.constraint(equalTo: content.bottomAnchor, constant: -16),
+        ])
+    }
+
+    private func makeTab(_ label: String, view: NSView) -> NSTabViewItem {
+        let item = NSTabViewItem(identifier: label)
+        item.label = label
+        item.view = view
+        return item
+    }
+
+    // Wrap a tab's controls in a leading-aligned vertical stack pinned to the tab's top.
+    private func tabContainer(_ views: [NSView], spacing: CGFloat = 14) -> NSView {
+        let stack = NSStackView(views: views)
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = spacing
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        let container = NSView()
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 20),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -20),
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: 20),
+        ])
+        return container
+    }
+
+    // MARK: - 一般 (the three real input toggles, same set as the input menu)
+
+    private func generalView() -> NSView {
+        let simplified = makeCheckbox("輸出簡體字", state: Preferences.outputSimplifiedEnabled,
+                                      action: #selector(toggleSimplified))
+        let fullWidth = makeCheckbox("全形標點", state: Preferences.fullWidthPunctuationEnabled,
+                                     action: #selector(toggleFullWidth))
+        let associated = makeCheckbox("聯想字詞", state: Preferences.associatedPhrasesEnabled,
+                                      action: #selector(toggleAssociated))
+        return tabContainer([simplified, fullWidth, associated])
+    }
+
+    private func makeCheckbox(_ title: String, state: Bool, action: Selector) -> NSButton {
+        let button = NSButton(checkboxWithTitle: title, target: self, action: action)
+        button.state = state ? .on : .off
+        return button
+    }
+
+    @objc private func toggleSimplified(_ sender: NSButton) {
+        Preferences.outputSimplifiedEnabled = (sender.state == .on)
+    }
+    @objc private func toggleFullWidth(_ sender: NSButton) {
+        Preferences.fullWidthPunctuationEnabled = (sender.state == .on)
+    }
+    @objc private func toggleAssociated(_ sender: NSButton) {
+        Preferences.associatedPhrasesEnabled = (sender.state == .on)
+    }
+
+    // MARK: - 外觀 (candidate-window font size, clamped 14–28, with a live preview)
+
+    private func appearanceView() -> NSView {
+        let heading = NSTextField(labelWithString: "候選字大小")
+
+        let slider = NSSlider(value: Double(Preferences.candidateFontSize),
+                              minValue: Double(Preferences.minFontSize),
+                              maxValue: Double(Preferences.maxFontSize),
+                              target: self, action: #selector(fontSizeChanged))
+        slider.numberOfTickMarks = Int(Preferences.maxFontSize - Preferences.minFontSize) + 1
+        slider.allowsTickMarkValuesOnly = true
+        slider.translatesAutoresizingMaskIntoConstraints = false
+        slider.widthAnchor.constraint(equalToConstant: 240).isActive = true
+
+        fontValueLabel.textColor = .secondaryLabelColor
+        let sliderRow = NSStackView(views: [slider, fontValueLabel])
+        sliderRow.orientation = .horizontal
+        sliderRow.spacing = 10
+
+        fontPreview.textColor = .labelColor
+        refreshFontPreview()
+
+        return tabContainer([heading, sliderRow, fontPreview])
+    }
+
+    @objc private func fontSizeChanged(_ sender: NSSlider) {
+        Preferences.candidateFontSize = CGFloat(sender.doubleValue)
+        refreshFontPreview()
+    }
+
+    private func refreshFontPreview() {
+        let size = Preferences.candidateFontSize
+        fontValueLabel.stringValue = "\(Int(size)) pt"
+        fontPreview.stringValue = "1 字　2 詞　3 例"
+        fontPreview.font = NSFont.systemFont(ofSize: size)
+    }
+
+    // MARK: - 輸入方式 (read-only status + deep link; modes switch via the system switcher)
+
+    private func inputMethodsView() -> NSView {
+        let status = NSTextField(wrappingLabelWithString: "已安裝的輸入模式：倉頡、速成\n切換輸入模式請使用系統的輸入來源切換器。")
+        status.textColor = .secondaryLabelColor
+
+        let openButton = NSButton(title: "打開系統設定 ▸ 鍵盤 ▸ 輸入來源",
+                                  target: self, action: #selector(openInputSourceSettings))
+        return tabContainer([status, openButton])
+    }
+
+    @objc private func openInputSourceSettings() {
+        // Deep link to the Input Sources pane; opens System Settings if the anchored URL is
+        // not honored on this macOS version.
+        if let url = URL(string: "x-apple.systempreferences:com.apple.Keyboard-Settings.extension?InputSources") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    // MARK: - 更新 (Sparkle: auto-check toggle + manual check)
+
+    private func updatesView() -> NSView {
+        let auto = NSButton(checkboxWithTitle: "自動檢查更新",
+                            target: self, action: #selector(toggleAutoUpdate))
+        auto.state = Updater.shared.automaticallyChecksForUpdates ? .on : .off
+
+        let checkNow = NSButton(title: "立即檢查更新…", target: self, action: #selector(checkForUpdatesNow))
+        return tabContainer([auto, checkNow])
+    }
+
+    @objc private func toggleAutoUpdate(_ sender: NSButton) {
+        Updater.shared.automaticallyChecksForUpdates = (sender.state == .on)
+    }
+    @objc private func checkForUpdatesNow() {
+        Updater.shared.checkForUpdates()
+    }
+
+    // MARK: - Presentation
+
+    func show() {
+        // LSUIElement background app: activate (ignoringOtherApps) so the window comes forward
+        // when picked from the input menu. Mirrors AboutWindowController.show().
+        NSApp.activate(ignoringOtherApps: true)
+        showWindow(nil)
+        window?.level = .floating
+        window?.makeKeyAndOrderFront(nil)
+    }
+}

--- a/App/Uninstaller.swift
+++ b/App/Uninstaller.swift
@@ -1,0 +1,94 @@
+import Cocoa
+import Carbon
+
+// The net-new uninstall flow, opened from the input menu's 解除安裝… item. An IME is a
+// system-managed agent, so ordering matters: we DESELECT/disable the TIS input sources FIRST
+// (so macOS stops routing keystrokes to a bundle we're about to delete), then remove our
+// on-disk footprint, then move the bundle itself to the Trash and quit.
+//
+// Honesty (per the shared spec): macOS caches a registered input source until logout, so even
+// a clean removal needs a logout/login to fully clear it — the confirmation and the final
+// notice say so. We own no helper, XPC service, or login item, so there is nothing else to
+// tear down.
+enum Uninstaller {
+
+    // Present the destructive confirmation, then perform the uninstall if confirmed.
+    // Button layout (spec): Uninstall on the LEFT, Cancel on the RIGHT as the default — so
+    // Return/Esc both land on the safe choice. NSAlert lays buttons out right-to-left in the
+    // order added, so Cancel is added first (rightmost + default).
+    static func run() {
+        NSApp.activate(ignoringOtherApps: true)
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "解除安裝 Yahoo! KeyKey 2？"
+        alert.informativeText = """
+        這將會：
+        • 從輸入來源中停用倉頡與速成
+        • 刪除使用者學習資料與偏好設定
+        • 將 Yahoo! KeyKey 2 移到垃圾桶
+
+        macOS 會將已註冊的輸入法快取到登出為止，完成後可能需要登出再登入才能完全清除。
+        """
+
+        let cancel = alert.addButton(withTitle: "取消")       // rightmost + default (Return/Esc)
+        let uninstall = alert.addButton(withTitle: "解除安裝") // to the left, destructive
+        uninstall.hasDestructiveAction = true
+        cancel.keyEquivalent = "\r"
+
+        guard alert.runModal() == .alertSecondButtonReturn else { return }
+
+        perform()
+    }
+
+    private static func perform() {
+        let bundleID = Bundle.main.bundleIdentifier ?? "com.github.teddychan.inputmethod.YahooKeyKey2"
+
+        // 1. Deselect/disable our TIS input sources FIRST.
+        disableInputSources(bundleIDPrefix: bundleID)
+
+        // 2. Remove the Application Support directory (user-frequency.json lives here).
+        if let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            let dir = appSupport.appendingPathComponent("YahooKeyKey2")
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        // 3. Clear preferences: the in-process domain plus the on-disk plist (Sparkle keys
+        //    live in this same domain).
+        UserDefaults.standard.removePersistentDomain(forName: bundleID)
+        let prefsPlist = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent("Library/Preferences/\(bundleID).plist")
+        try? FileManager.default.removeItem(at: prefsPlist)
+
+        // 4. Move the (running) bundle to the Trash, then tell the user what remains and quit.
+        //    NSWorkspace.recycle works on a running bundle.
+        let bundleURL = Bundle.main.bundleURL
+        NSWorkspace.shared.recycle([bundleURL]) { _, _ in
+            DispatchQueue.main.async { finish() }
+        }
+    }
+
+    // Disable every enabled input source whose id is prefixed by our bundle id (covers the
+    // parent source and the Cangjie/Simplex mode ids). Disabling an active source makes macOS
+    // fall back to another input source.
+    private static func disableInputSources(bundleIDPrefix: String) {
+        guard let list = TISCreateInputSourceList(nil, true)?.takeRetainedValue() as? [TISInputSource] else { return }
+        for source in list {
+            guard let ptr = TISGetInputSourceProperty(source, kTISPropertyInputSourceID) else { continue }
+            let sourceID = Unmanaged<CFString>.fromOpaque(ptr).takeUnretainedValue() as String
+            if sourceID.hasPrefix(bundleIDPrefix) {
+                TISDisableInputSource(source)
+            }
+        }
+    }
+
+    private static func finish() {
+        let done = NSAlert()
+        done.alertStyle = .informational
+        done.messageText = "Yahoo! KeyKey 2 已解除安裝"
+        done.informativeText = "已移到垃圾桶。如輸入來源清單仍顯示倉頡／速成，請登出再登入即可完全清除。"
+        done.addButton(withTitle: "結束")
+        done.runModal()
+        NSApp.terminate(nil)
+    }
+}

--- a/App/Updater.swift
+++ b/App/Updater.swift
@@ -36,6 +36,13 @@ final class Updater: NSObject, SPUStandardUserDriverDelegate {
         )
     }
 
+    /// Auto-check preference, surfaced in the Settings 更新 pane. Backed by Sparkle (persisted
+    /// in the same UserDefaults domain). No-op when the updater is disabled (missing SUPublicEDKey).
+    var automaticallyChecksForUpdates: Bool {
+        get { controller?.updater.automaticallyChecksForUpdates ?? false }
+        set { controller?.updater.automaticallyChecksForUpdates = newValue }
+    }
+
     /// Manual check, wired to the "檢查更新…" input-menu item.
     func checkForUpdates() {
         // Background agent: bring the app forward so the check/result window is visible.

--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -60,7 +60,7 @@ swiftc \
   -framework InputMethodKit -framework Cocoa \
   -F "$SPARKLE_CACHE" -framework Sparkle \
   -Xlinker -rpath -Xlinker @executable_path/../Frameworks \
-  "$APP_SRC"/main.swift "$APP_SRC"/InputController.swift "$APP_SRC"/SharedResources.swift "$APP_SRC"/InputEngine.swift "$APP_SRC"/InputMethodModule.swift "$APP_SRC"/CandidateWindow.swift "$APP_SRC"/Preferences.swift "$APP_SRC"/AboutWindow.swift "$APP_SRC"/Updater.swift
+  "$APP_SRC"/main.swift "$APP_SRC"/InputController.swift "$APP_SRC"/SharedResources.swift "$APP_SRC"/InputEngine.swift "$APP_SRC"/InputMethodModule.swift "$APP_SRC"/CandidateWindow.swift "$APP_SRC"/Preferences.swift "$APP_SRC"/AboutWindow.swift "$APP_SRC"/SettingsWindow.swift "$APP_SRC"/Uninstaller.swift "$APP_SRC"/Updater.swift
 
 echo "==> Assembling Info.plist (resolving \${EXECUTABLE_NAME})"
 sed "s/\${EXECUTABLE_NAME}/$EXECUTABLE_NAME/g" "$APP_SRC/Info.plist" > "$APP/Contents/Info.plist"


### PR DESCRIPTION
Completes the two items deferred in #24 so the input menu's App-menu group matches the shared Dragon-App spec (liquid-glass-macos §5A) for an IME.

## Menu (App/InputController.swift)
App-menu group is now the full 5-item §5A set, all top-level (IMK only routes top-level selections, so a "⋯" submenu would render but never fire):

> 關於 Yahoo! KeyKey 2… · 檢查更新… · **設定… (⌘,)** · — · **解除安裝 Yahoo! KeyKey 2…**

Quit stays omitted by design (system-managed IME).

## New files
- **App/SettingsWindow.swift** — AppKit `NSWindowController` mirroring `AboutWindow`; tabs 一般 (3 input toggles) · 外觀 (candidate font size + live preview) · 輸入方式 (read-only mode status + deep link to System Settings ▸ Keyboard ▸ Input Sources) · 更新 (Sparkle auto-check toggle + manual check).
- **App/Uninstaller.swift** — IME-correct teardown: disable TIS sources first → remove `~/Library/Application Support/YahooKeyKey2/` → clear prefs domain + plist → trash the running bundle → quit. Destructive confirmation with Uninstall-left / Cancel-default-right and honesty copy about TIS caching needing a logout.

## Other
- App/Updater.swift: expose `automaticallyChecksForUpdates` for the 更新 pane.
- tools/build-app.sh: compile the two new files.
- Version → **1.7.0** (build 15).

No bundle-id / `TISInputSourceID` rebrand; no www.dragonapp.com changes.

## Verification
`tools/build-app.sh` compiles the engine + app clean (Info.plist lint OK, binary produced, new selectors present). LM build + notarized release run in CI on the `v1.7.0` tag. Runtime (Settings window, destructive uninstall) not exercised locally — worth a manual smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)