### PR TITLE
chore: rebrand bundle id to com.dragonapp.yahoo-keykey (v1.7.1)

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -11,20 +11,20 @@
 	<key>CFBundleIconFile</key>
 	<string>AppIcon</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.github.teddychan.inputmethod.YahooKeyKey2</string>
+	<string>com.dragonapp.yahoo-keykey</string>
 	<key>CFBundleName</key>
 	<string>Yahoo KeyKey 2</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.0</string>
+	<string>1.7.1</string>
 	<key>CFBundleVersion</key>
-	<string>15</string>
+	<string>16</string>
 	<key>ComponentInputModeDict</key>
 	<dict>
 		<key>tsInputModeListKey</key>
 		<dict>
-			<key>com.github.teddychan.inputmethod.YahooKeyKey2.Cangjie</key>
+			<key>com.dragonapp.yahoo-keykey.Cangjie</key>
 			<dict>
 				<key>TISIntendedLanguage</key>
 				<string>zh-Hant</string>
@@ -43,7 +43,7 @@
 				<key>tsInputModeScriptKey</key>
 				<string>smTradChinese</string>
 			</dict>
-			<key>com.github.teddychan.inputmethod.YahooKeyKey2.Simplex</key>
+			<key>com.dragonapp.yahoo-keykey.Simplex</key>
 			<dict>
 				<key>TISIntendedLanguage</key>
 				<string>zh-Hant</string>
@@ -65,14 +65,14 @@
 		</dict>
 		<key>tsVisibleInputModeOrderedArrayKey</key>
 		<array>
-			<string>com.github.teddychan.inputmethod.YahooKeyKey2.Cangjie</string>
-			<string>com.github.teddychan.inputmethod.YahooKeyKey2.Simplex</string>
+			<string>com.dragonapp.yahoo-keykey.Cangjie</string>
+			<string>com.dragonapp.yahoo-keykey.Simplex</string>
 		</array>
 		<key>tsInputMethodIconFileKey</key>
 		<string>YahooKeyKey.tiff</string>
 	</dict>
 	<key>InputMethodConnectionName</key>
-	<string>com.github.teddychan.inputmethod.YahooKeyKey2_Connection</string>
+	<string>com.dragonapp.yahoo-keykey_Connection</string>
 	<key>InputMethodServerControllerClass</key>
 	<string>InputController</string>
 	<key>InputMethodServerDelegateClass</key>
@@ -92,7 +92,7 @@
 	<key>SUScheduledCheckInterval</key>
 	<integer>86400</integer>
 	<key>TISInputSourceID</key>
-	<string>com.github.teddychan.inputmethod.YahooKeyKey2</string>
+	<string>com.dragonapp.yahoo-keykey</string>
 	<key>TISIntendedLanguage</key>
 	<string>zh-Hant</string>
 	<key>tsInputMethodCharacterRepertoireKey</key>

--- a/App/Uninstaller.swift
+++ b/App/Uninstaller.swift
@@ -42,7 +42,7 @@ enum Uninstaller {
     }
 
     private static func perform() {
-        let bundleID = Bundle.main.bundleIdentifier ?? "com.github.teddychan.inputmethod.YahooKeyKey2"
+        let bundleID = Bundle.main.bundleIdentifier ?? "com.dragonapp.yahoo-keykey"
 
         // 1. Deselect/disable our TIS input sources FIRST.
         disableInputSources(bundleIDPrefix: bundleID)

--- a/App/en.lproj/InfoPlist.strings
+++ b/App/en.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
 CFBundleName = "Yahoo KeyKey 2";
 CFBundleDisplayName = "Yahoo KeyKey 2";
-"com.github.teddychan.inputmethod.YahooKeyKey2.Cangjie" = "倉頡";
-"com.github.teddychan.inputmethod.YahooKeyKey2.Simplex" = "速成";
+"com.dragonapp.yahoo-keykey.Cangjie" = "倉頡";
+"com.dragonapp.yahoo-keykey.Simplex" = "速成";

--- a/App/zh-Hant.lproj/InfoPlist.strings
+++ b/App/zh-Hant.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
 CFBundleName = "Yahoo KeyKey 2";
 CFBundleDisplayName = "Yahoo KeyKey 2";
-"com.github.teddychan.inputmethod.YahooKeyKey2.Cangjie" = "倉頡";
-"com.github.teddychan.inputmethod.YahooKeyKey2.Simplex" = "速成";
+"com.dragonapp.yahoo-keykey.Cangjie" = "倉頡";
+"com.dragonapp.yahoo-keykey.Simplex" = "速成";

--- a/installer/distribution.xml.template
+++ b/installer/distribution.xml.template
@@ -26,16 +26,16 @@
 
     <choices-outline>
         <line choice="default">
-            <line choice="com.github.teddychan.inputmethod.YahooKeyKey2.pkg"/>
+            <line choice="com.dragonapp.yahoo-keykey.pkg"/>
         </line>
     </choices-outline>
 
     <choice id="default"/>
-    <choice id="com.github.teddychan.inputmethod.YahooKeyKey2.pkg" visible="false">
-        <pkg-ref id="com.github.teddychan.inputmethod.YahooKeyKey2.pkg"/>
+    <choice id="com.dragonapp.yahoo-keykey.pkg" visible="false">
+        <pkg-ref id="com.dragonapp.yahoo-keykey.pkg"/>
     </choice>
 
-    <pkg-ref id="com.github.teddychan.inputmethod.YahooKeyKey2.pkg"
+    <pkg-ref id="com.dragonapp.yahoo-keykey.pkg"
              version="__VERSION__"
              onConclusion="RequireLogout">__COMPONENT_PKG__</pkg-ref>
 </installer-gui-script>

--- a/tools/package-installer.sh
+++ b/tools/package-installer.sh
@@ -30,7 +30,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BUILD="$ROOT/build"
 APP="$BUILD/YahooKeyKey2.app"
 INSTALLER_SRC="$ROOT/installer"
-PKG_IDENTIFIER="com.github.teddychan.inputmethod.YahooKeyKey2.pkg"
+PKG_IDENTIFIER="com.dragonapp.yahoo-keykey.pkg"
 
 # --- 1. Build the .app (signed/notarized if env set, else ad-hoc) -----------
 if [ -n "${DEVELOPER_ID_APP:-}" ]; then


### PR DESCRIPTION
Rebrands Yahoo! KeyKey 2's identifiers to the Dragon-App scheme, per owner request.

- Bundle id + `TISInputSourceID`: `com.github.teddychan.inputmethod.YahooKeyKey2` → **`com.dragonapp.yahoo-keykey`**
- Input-mode ids: `…Cangjie` / `…Simplex` → `com.dragonapp.yahoo-keykey.Cangjie` / `.Simplex` (and matching `InfoPlist.strings` keys, so 倉頡/速成 still localize)
- `InputMethodConnectionName` → `com.dragonapp.yahoo-keykey_Connection` (read dynamically by `IMKServer` in `main.swift` — consistent)
- Installer PKG id, Uninstaller fallback id updated. App/executable name + install path (`YahooKeyKey2.app`) unchanged.
- Version → 1.7.1 (build 16).

**Breaking (owner-accepted):** macOS treats the new `TISInputSourceID` as a new input source — after updating, users must re-add "Yahoo! KeyKey 2" in System Settings ▸ Keyboard ▸ Input Sources (logout may be required); the old source id lingers until removed. No MAS listing exists.

## Verification
- `./tools/build-app.sh --build-lm` ✅ (codesign `Identifier=com.dragonapp.yahoo-keykey`) · KeyKeyEngine `swift test` ✅ 109 tests.
- `git grep com.github.teddychan.inputmethod.YahooKeyKey2` → nothing remains.
- ⚠️ Input-source re-registration is runtime-unverified headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)