### PR TITLE
release: v2.0.0 (align major with 'Yahoo! KeyKey 2')

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.2</string>
+	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>17</string>
+	<string>18</string>
 	<key>ComponentInputModeDict</key>
 	<dict>
 		<key>tsInputModeListKey</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 A plain-language list of changes in each version, newest first.
 
+## 2.0.0
+
+- Version numbers now start at **2.x** to match the product name, **Yahoo! KeyKey 2**. No functional change from 1.7.2.
+
 ## 1.7.2
 
 - The About window now links to the Yahoo! KeyKey 2 website (dragonapp.com/keykey) and to GitHub Issues for support, alongside the existing homage to the original Yahoo! KeyKey.


### PR DESCRIPTION
Bumps the version to **2.0.0** so the major matches the product name 'Yahoo! KeyKey 2'. No functional change from 1.7.2. Build verified (tools/build-app.sh → 2.0.0). No marketing-site change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)