### PR TITLE
fix: IME bundle id must contain 'inputmethod' (v2.0.1)

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -11,20 +11,20 @@
 	<key>CFBundleIconFile</key>
 	<string>AppIcon</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.dragonapp.yahoo-keykey</string>
+	<string>com.dragonapp.inputmethod.yahoo-keykey</string>
 	<key>CFBundleName</key>
 	<string>Yahoo KeyKey 2</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>2.0.1</string>
 	<key>CFBundleVersion</key>
-	<string>18</string>
+	<string>19</string>
 	<key>ComponentInputModeDict</key>
 	<dict>
 		<key>tsInputModeListKey</key>
 		<dict>
-			<key>com.dragonapp.yahoo-keykey.Cangjie</key>
+			<key>com.dragonapp.inputmethod.yahoo-keykey.Cangjie</key>
 			<dict>
 				<key>TISIntendedLanguage</key>
 				<string>zh-Hant</string>
@@ -43,7 +43,7 @@
 				<key>tsInputModeScriptKey</key>
 				<string>smTradChinese</string>
 			</dict>
-			<key>com.dragonapp.yahoo-keykey.Simplex</key>
+			<key>com.dragonapp.inputmethod.yahoo-keykey.Simplex</key>
 			<dict>
 				<key>TISIntendedLanguage</key>
 				<string>zh-Hant</string>
@@ -65,14 +65,14 @@
 		</dict>
 		<key>tsVisibleInputModeOrderedArrayKey</key>
 		<array>
-			<string>com.dragonapp.yahoo-keykey.Cangjie</string>
-			<string>com.dragonapp.yahoo-keykey.Simplex</string>
+			<string>com.dragonapp.inputmethod.yahoo-keykey.Cangjie</string>
+			<string>com.dragonapp.inputmethod.yahoo-keykey.Simplex</string>
 		</array>
 		<key>tsInputMethodIconFileKey</key>
 		<string>YahooKeyKey.tiff</string>
 	</dict>
 	<key>InputMethodConnectionName</key>
-	<string>com.dragonapp.yahoo-keykey_Connection</string>
+	<string>com.dragonapp.inputmethod.yahoo-keykey_Connection</string>
 	<key>InputMethodServerControllerClass</key>
 	<string>InputController</string>
 	<key>InputMethodServerDelegateClass</key>
@@ -92,7 +92,7 @@
 	<key>SUScheduledCheckInterval</key>
 	<integer>86400</integer>
 	<key>TISInputSourceID</key>
-	<string>com.dragonapp.yahoo-keykey</string>
+	<string>com.dragonapp.inputmethod.yahoo-keykey</string>
 	<key>TISIntendedLanguage</key>
 	<string>zh-Hant</string>
 	<key>tsInputMethodCharacterRepertoireKey</key>

--- a/App/Uninstaller.swift
+++ b/App/Uninstaller.swift
@@ -42,7 +42,7 @@ enum Uninstaller {
     }
 
     private static func perform() {
-        let bundleID = Bundle.main.bundleIdentifier ?? "com.dragonapp.yahoo-keykey"
+        let bundleID = Bundle.main.bundleIdentifier ?? "com.dragonapp.inputmethod.yahoo-keykey"
 
         // 1. Deselect/disable our TIS input sources FIRST.
         disableInputSources(bundleIDPrefix: bundleID)

--- a/App/en.lproj/InfoPlist.strings
+++ b/App/en.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
 CFBundleName = "Yahoo KeyKey 2";
 CFBundleDisplayName = "Yahoo KeyKey 2";
-"com.dragonapp.yahoo-keykey.Cangjie" = "倉頡";
-"com.dragonapp.yahoo-keykey.Simplex" = "速成";
+"com.dragonapp.inputmethod.yahoo-keykey.Cangjie" = "倉頡";
+"com.dragonapp.inputmethod.yahoo-keykey.Simplex" = "速成";

--- a/App/zh-Hant.lproj/InfoPlist.strings
+++ b/App/zh-Hant.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
 CFBundleName = "Yahoo KeyKey 2";
 CFBundleDisplayName = "Yahoo KeyKey 2";
-"com.dragonapp.yahoo-keykey.Cangjie" = "倉頡";
-"com.dragonapp.yahoo-keykey.Simplex" = "速成";
+"com.dragonapp.inputmethod.yahoo-keykey.Cangjie" = "倉頡";
+"com.dragonapp.inputmethod.yahoo-keykey.Simplex" = "速成";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 A plain-language list of changes in each version, newest first.
 
+## 2.0.1
+
+- **Fixed: Yahoo KeyKey 2 now appears in System Settings → Keyboard → Input Sources again.** Version 2.0.0 could be installed but never showed up as an input method you could add, because the rebrand accidentally changed the app's identifier to a form macOS does not recognise as an input method. The identifier now includes the required `inputmethod` component, so the input method registers correctly. If you had 2.0.0, install 2.0.1 and add **Yahoo KeyKey 2** under **Chinese, Traditional**.
+
 ## 2.0.0
 
 - Version numbers now start at **2.x** to match the product name, **Yahoo! KeyKey 2**. No functional change from 1.7.2.

--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -12,7 +12,19 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BUILD="$ROOT/build"
-APP="$BUILD/YahooKeyKey2.app"
+# Debug identity (opt-in via KEYKEY_DEBUG_ID=1): build a SEPARATE input method named
+# "Yahoo KeyKey 2 Debug" with bundle id com.dragonapp.inputmethod.yahoo-keykey.debug, so a local test
+# build never collides with / shadows the installed RELEASE IME. (Two bundles sharing the
+# release id register as duplicates in Launch Services and hide the real input source from
+# the Input Sources picker.) Release/CI builds leave KEYKEY_DEBUG_ID unset and are unaffected.
+RELEASE_BUNDLE_ID="com.dragonapp.inputmethod.yahoo-keykey"
+if [[ "${KEYKEY_DEBUG_ID:-}" == "1" ]]; then
+  APP_BUNDLE_NAME="Yahoo KeyKey 2 Debug"
+  DEBUG_BUNDLE_ID="${RELEASE_BUNDLE_ID}.debug"
+else
+  APP_BUNDLE_NAME="YahooKeyKey2"
+fi
+APP="$BUILD/${APP_BUNDLE_NAME}.app"
 ENGINE_SRC="$ROOT/Packages/KeyKeyEngine/Sources/KeyKeyEngine"
 APP_SRC="$ROOT/App"
 MODULE_DIR="$BUILD/modules"
@@ -107,6 +119,30 @@ echo "==> Copying localized strings (.lproj)"
 for lproj in "$APP_SRC"/*.lproj; do
   [ -d "$lproj" ] && cp -R "$lproj" "$APP/Contents/Resources/"
 done
+
+if [[ "${KEYKEY_DEBUG_ID:-}" == "1" ]]; then
+  echo "==> Applying debug identity ($DEBUG_BUNDLE_ID / \"$APP_BUNDLE_NAME\")"
+  PLIST="$APP/Contents/Info.plist"
+  # Single pass moves every release-id occurrence into the .debug namespace: CFBundleIdentifier,
+  # TISInputSourceID, InputMethodConnectionName, and the two ComponentInputModeDict mode ids
+  # (...Cangjie / ...Simplex). InputController matches modes by the ".Cangjie"/".Simplex" SUFFIX,
+  # which is preserved, so mode switching keeps working. SUFeedURL/SUPublicEDKey don't contain
+  # the base id, so they're untouched.
+  sed -i '' "s|${RELEASE_BUNDLE_ID}|${DEBUG_BUNDLE_ID}|g" "$PLIST"
+  # Distinct name in the menu bar / Input Sources picker.
+  sed -i '' "s|<string>Yahoo KeyKey 2</string>|<string>Yahoo KeyKey 2 Debug</string>|g" "$PLIST"
+  # A throwaway local build must not offer to auto-update itself off the release appcast.
+  plutil -replace SUEnableAutomaticChecks -bool false "$PLIST"
+  # Re-key the localized input-mode display names (倉頡 / 速成) to the .debug mode ids, and
+  # re-label the localized app name so the picker/menu show "Yahoo KeyKey 2 Debug" (the
+  # localized CFBundleDisplayName here would otherwise override the Info.plist value above).
+  for sf in "$APP/Contents/Resources"/*.lproj/InfoPlist.strings; do
+    [ -f "$sf" ] || continue
+    sed -i '' "s|${RELEASE_BUNDLE_ID}|${DEBUG_BUNDLE_ID}|g" "$sf"
+    sed -i '' 's|"Yahoo KeyKey 2"|"Yahoo KeyKey 2 Debug"|g' "$sf"
+  done
+  plutil -lint "$PLIST"
+fi
 
 echo "==> Embedding Sparkle.framework"
 mkdir -p "$APP/Contents/Frameworks"

--- a/tools/run-debug.sh
+++ b/tools/run-debug.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Build + install + launch a LOCAL DEBUG build of Yahoo KeyKey 2.
+#
+# It registers as a SEPARATE input method — "Yahoo KeyKey 2 Debug", bundle id
+# com.dragonapp.inputmethod.yahoo-keykey.debug — so it never collides with or shadows the installed
+# RELEASE IME (com.dragonapp.inputmethod.yahoo-keykey). Two bundles sharing the release id register as
+# duplicates in Launch Services and hide the real input source from the Input Sources picker.
+#
+# Safe to run alongside the App Store / GitHub release install. Any extra args are forwarded
+# to build-app.sh (e.g. --build-lm to regenerate data.txt first).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEBUG_NAME="Yahoo KeyKey 2 Debug"
+SRC="$ROOT/build/${DEBUG_NAME}.app"
+DST="$HOME/Library/Input Methods/${DEBUG_NAME}.app"
+LSREG="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+
+echo "==> Building debug-id app"
+KEYKEY_DEBUG_ID=1 "$ROOT/tools/build-app.sh" "$@"
+
+echo "==> Installing to ~/Library/Input Methods"
+pkill -f "${DEBUG_NAME}.app/Contents/MacOS" 2>/dev/null || true
+sleep 1
+rm -rf "$DST"
+mkdir -p "$HOME/Library/Input Methods"
+cp -R "$SRC" "$DST"
+
+echo "==> Registering + launching"
+"$LSREG" -f "$DST" 2>/dev/null || true
+open "$DST"
+
+cat <<EOF
+
+Debug IME installed: $DST
+Add it in System Settings -> Keyboard -> Input Sources -> + -> Chinese, Traditional ->
+"Yahoo KeyKey 2 Debug". If it doesn't appear, log out/in once (it registers separately
+from the release IME).
+EOF


### PR DESCRIPTION
## Problem
Released **v2.0.0** can be installed but never appears in **System Settings → Keyboard → Input Sources** — it cannot be added as an input method on any Mac.

## Root cause
macOS InputMethodKit only recognises a bundle as an input method when its **bundle identifier contains `inputmethod` as a dot-separated component**. The v1.7.1 rebrand changed the id from `com.github.teddychan.inputmethod.YahooKeyKey2` (worked) to `com.dragonapp.yahoo-keykey` (no `inputmethod` → never registers; `TISRegisterInputSource` returns success but does nothing, no log).

## Fix
Bundle id → **`com.dragonapp.inputmethod.yahoo-keykey`** everywhere it's the app identity: `Info.plist` (`CFBundleIdentifier`, `TISInputSourceID`, `InputMethodConnectionName`, the two `ComponentInputModeDict` mode ids), both `InfoPlist.strings`, and the `Uninstaller` fallback. `InputController` matches modes by the `.Cangjie`/`.Simplex` suffix, which is preserved. Bumped to **v2.0.1**.

Also adds an opt-in debug-id local build (`tools/run-debug.sh` + `KEYKEY_DEBUG_ID` in `build-app.sh`) so local test builds use `…​.debug` and never shadow the installed release IME in Launch Services.

## Verification
On a clean machine, with the corrected id, `TISRegisterInputSource` registers the source and **Yahoo KeyKey 2** appears in the picker under Chinese, Traditional. `plutil -lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)