### PR TITLE
fix: sync Settings window with quick menu (v2.0.2)

### DIFF
--- a/App/AboutWindow.swift
+++ b/App/AboutWindow.swift
@@ -7,11 +7,17 @@ import Cocoa
 final class AboutWindowController: NSWindowController {
     static let shared = AboutWindowController()
 
+    // Local ad-hoc debug builds re-id the bundle to <release-id>.debug (see tools/build-app.sh).
+    // Detect that at runtime and append " Debug" to the shown name/title so a test build is
+    // never mistaken for the installed release. Release builds have no suffix, so this is a no-op.
+    private static let isDebugBuild = Bundle.main.bundleIdentifier?.hasSuffix(".debug") ?? false
+    private static let appName = "Yahoo! KeyKey 2" + (isDebugBuild ? " Debug" : "")
+
     private init() {
         let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 460, height: 380),
                               styleMask: [.titled, .closable],
                               backing: .buffered, defer: false)
-        window.title = "關於 Yahoo! KeyKey 2"
+        window.title = "關於 \(Self.appName)"
         super.init(window: window)
         buildUI()
         window.center()
@@ -24,7 +30,7 @@ final class AboutWindowController: NSWindowController {
 
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
 
-        let nameLabel = NSTextField(labelWithString: "Yahoo! KeyKey 2")
+        let nameLabel = NSTextField(labelWithString: Self.appName)
         nameLabel.font = NSFont.systemFont(ofSize: 18, weight: .semibold)
 
         let versionLabel = NSTextField(labelWithString: "版本 \(version)")

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.1</string>
+	<string>2.0.2</string>
 	<key>CFBundleVersion</key>
-	<string>19</string>
+	<string>20</string>
 	<key>ComponentInputModeDict</key>
 	<dict>
 		<key>tsInputModeListKey</key>

--- a/App/SettingsWindow.swift
+++ b/App/SettingsWindow.swift
@@ -16,6 +16,15 @@ final class SettingsWindowController: NSWindowController {
     private let fontPreview = NSTextField(labelWithString: "")
     private let fontValueLabel = NSTextField(labelWithString: "")
 
+    // Controls whose state mirrors Preferences/Updater. Retained so show() can re-read the
+    // live values into them — the window is a long-lived singleton built once, but the same
+    // settings are also changed from the input menu, so its controls would otherwise go stale.
+    private var simplifiedCheckbox: NSButton!
+    private var fullWidthCheckbox: NSButton!
+    private var associatedCheckbox: NSButton!
+    private var fontSizeSlider: NSSlider!
+    private var autoUpdateCheckbox: NSButton!
+
     private init() {
         let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 460, height: 320),
                               styleMask: [.titled, .closable],
@@ -74,13 +83,13 @@ final class SettingsWindowController: NSWindowController {
     // MARK: - 一般 (the three real input toggles, same set as the input menu)
 
     private func generalView() -> NSView {
-        let simplified = makeCheckbox("輸出簡體字", state: Preferences.outputSimplifiedEnabled,
-                                      action: #selector(toggleSimplified))
-        let fullWidth = makeCheckbox("全形標點", state: Preferences.fullWidthPunctuationEnabled,
-                                     action: #selector(toggleFullWidth))
-        let associated = makeCheckbox("聯想字詞", state: Preferences.associatedPhrasesEnabled,
-                                      action: #selector(toggleAssociated))
-        return tabContainer([simplified, fullWidth, associated])
+        simplifiedCheckbox = makeCheckbox("輸出簡體字", state: Preferences.outputSimplifiedEnabled,
+                                          action: #selector(toggleSimplified))
+        fullWidthCheckbox = makeCheckbox("全形標點", state: Preferences.fullWidthPunctuationEnabled,
+                                         action: #selector(toggleFullWidth))
+        associatedCheckbox = makeCheckbox("聯想字詞", state: Preferences.associatedPhrasesEnabled,
+                                          action: #selector(toggleAssociated))
+        return tabContainer([simplifiedCheckbox, fullWidthCheckbox, associatedCheckbox])
     }
 
     private func makeCheckbox(_ title: String, state: Bool, action: Selector) -> NSButton {
@@ -112,6 +121,7 @@ final class SettingsWindowController: NSWindowController {
         slider.allowsTickMarkValuesOnly = true
         slider.translatesAutoresizingMaskIntoConstraints = false
         slider.widthAnchor.constraint(equalToConstant: 240).isActive = true
+        fontSizeSlider = slider
 
         fontValueLabel.textColor = .secondaryLabelColor
         let sliderRow = NSStackView(views: [slider, fontValueLabel])
@@ -158,12 +168,12 @@ final class SettingsWindowController: NSWindowController {
     // MARK: - 更新 (Sparkle: auto-check toggle + manual check)
 
     private func updatesView() -> NSView {
-        let auto = NSButton(checkboxWithTitle: "自動檢查更新",
-                            target: self, action: #selector(toggleAutoUpdate))
-        auto.state = Updater.shared.automaticallyChecksForUpdates ? .on : .off
+        autoUpdateCheckbox = NSButton(checkboxWithTitle: "自動檢查更新",
+                                      target: self, action: #selector(toggleAutoUpdate))
+        autoUpdateCheckbox.state = Updater.shared.automaticallyChecksForUpdates ? .on : .off
 
         let checkNow = NSButton(title: "立即檢查更新…", target: self, action: #selector(checkForUpdatesNow))
-        return tabContainer([auto, checkNow])
+        return tabContainer([autoUpdateCheckbox, checkNow])
     }
 
     @objc private func toggleAutoUpdate(_ sender: NSButton) {
@@ -175,7 +185,23 @@ final class SettingsWindowController: NSWindowController {
 
     // MARK: - Presentation
 
+    // Re-read the live Preferences/Updater values into the retained controls. The window is
+    // built once and kept alive, while the same settings are also toggled from the input menu,
+    // so without this the controls would show whatever they held when the window was first
+    // built — the reported "設定 window not in sync with the quick menu" bug.
+    private func refreshControls() {
+        simplifiedCheckbox.state = Preferences.outputSimplifiedEnabled ? .on : .off
+        fullWidthCheckbox.state = Preferences.fullWidthPunctuationEnabled ? .on : .off
+        associatedCheckbox.state = Preferences.associatedPhrasesEnabled ? .on : .off
+        fontSizeSlider.doubleValue = Double(Preferences.candidateFontSize)
+        refreshFontPreview()
+        autoUpdateCheckbox.state = Updater.shared.automaticallyChecksForUpdates ? .on : .off
+    }
+
     func show() {
+        // Sync controls to the current values before presenting — they may have changed via
+        // the input menu since the window was built.
+        refreshControls()
         // LSUIElement background app: activate (ignoringOtherApps) so the window comes forward
         // when picked from the input menu. Mirrors AboutWindowController.show().
         NSApp.activate(ignoringOtherApps: true)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 A plain-language list of changes in each version, newest first.
 
+## 2.0.2
+
+- **Fixed: the Settings window now matches the quick menu.** Toggling **輸出簡體字**, **全形標點**, **聯想字詞**, or the **候選字大小** from the menu-bar input menu changed the behaviour correctly, but the checkboxes and slider in **設定…** still showed their old values. The Settings window now re-reads the current values each time it opens, so it always reflects what you set in the menu.
+
 ## 2.0.1
 
 - **Fixed: Yahoo KeyKey 2 now appears in System Settings → Keyboard → Input Sources again.** Version 2.0.0 could be installed but never showed up as an input method you could add, because the rebrand accidentally changed the app's identifier to a form macOS does not recognise as an input method. The identifier now includes the required `inputmethod` component, so the input method registers correctly. If you had 2.0.0, install 2.0.1 and add **Yahoo KeyKey 2** under **Chinese, Traditional**.

--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -153,12 +153,18 @@ chmod -R u+w "$APP/Contents/Frameworks/Sparkle.framework"
 echo "==> Code-signing Sparkle inside-out, then the app (ad-hoc)"
 SPARKLE_FW="$APP/Contents/Frameworks/Sparkle.framework"
 SPARKLE_V="$(/bin/ls -d "$SPARKLE_FW"/Versions/* | grep -v '/Current$' | head -1)"
+# Hardened runtime is required for notarized RELEASE builds. For a local ad-hoc DEBUG build it
+# must be OMITTED: ad-hoc code carries no Team ID, and the hardened runtime's Library Validation
+# then refuses to load the (also ad-hoc) Sparkle.framework — the app dies on launch with a dyld
+# "different Team IDs" error, so the IME never registers its menu. A local debug build doesn't
+# need the hardened runtime. Unquoted on purpose: empty string must expand to no argument.
+if [[ "${KEYKEY_DEBUG_ID:-}" == "1" ]]; then RUNTIME_OPT=""; else RUNTIME_OPT="--options runtime"; fi
 for item in "$SPARKLE_V"/XPCServices/*.xpc "$SPARKLE_V/Autoupdate" "$SPARKLE_V/Updater.app"; do
-  [ -e "$item" ] && codesign --force --options runtime -s - "$item"
+  [ -e "$item" ] && codesign --force $RUNTIME_OPT -s - "$item"
 done
-codesign --force --options runtime -s - "$SPARKLE_FW"
+codesign --force $RUNTIME_OPT -s - "$SPARKLE_FW"
 # Sign the app last. No --deep: nested code (Sparkle) is already signed above.
-codesign --force --options runtime --entitlements "$ENTITLEMENTS" -s - "$APP"
+codesign --force $RUNTIME_OPT --entitlements "$ENTITLEMENTS" -s - "$APP"
 codesign -dv "$APP"
 
 echo "==> Done: $APP"


### PR DESCRIPTION
## Summary
Fixes the reported bug: settings toggled in the menu-bar input menu were **not reflected** in the **設定…** (Settings) window, even though the behaviour changed correctly.

**Root cause:** `SettingsWindowController` is a long-lived singleton whose controls are built once at `init()`, snapshotting `Preferences`. `show()` never re-read them, so the window stayed stale. The input menu is always correct because IMK rebuilds it on every open.

**Fix:** retain the mutable controls and add `refreshControls()`, called from `show()` before presenting, re-reading live `Preferences`/`Updater` values. Affects all shared settings: 輸出簡體字 / 全形標點 / 聯想字詞 (一般 checkboxes), 候選字大小 (外觀 slider + preview), 自動檢查更新 (更新).

## Also included
- **`tools/build-app.sh`** — local ad-hoc **debug** builds now sign *without* the hardened runtime. With it, Library Validation refused to load the ad-hoc (no Team ID) `Sparkle.framework` and the debug IME crashed on launch (`dyld: ... different Team IDs`). Release signing (hardened runtime) is unchanged.
- **`AboutWindow`** — appends " Debug" to the shown name/title when the bundle id ends in `.debug`, so a local test build isn't mistaken for the release.

## Verification
- Full app compiles (release + debug modes); release build keeps hardened runtime, debug drops it and launches cleanly.
- Isolated test reproduces the bug (checkbox stale without refresh) and confirms the fix in both directions (menu-on → synced-on, menu-off → synced-off).
- Version bumped to **2.0.2** (build 20); CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)