### PR TITLE
fix(about): mark the version line as Debug in debug builds

### DIFF
--- a/App/AboutWindow.swift
+++ b/App/AboutWindow.swift
@@ -33,7 +33,8 @@ final class AboutWindowController: NSWindowController {
         let nameLabel = NSTextField(labelWithString: Self.appName)
         nameLabel.font = NSFont.systemFont(ofSize: 18, weight: .semibold)
 
-        let versionLabel = NSTextField(labelWithString: "版本 \(version)")
+        // Mark the version line too (not just the name/title) so a debug build is unmistakable.
+        let versionLabel = NSTextField(labelWithString: "版本 \(version)" + (Self.isDebugBuild ? " (Debug)" : ""))
         versionLabel.textColor = .secondaryLabelColor
 
         let descriptionLabel = NSTextField(labelWithString: "倉頡／簡易 輸入法")


### PR DESCRIPTION
Debug-only cosmetic follow-up to #31. The About window already showed **"Yahoo! KeyKey 2 Debug"** in the name and title for local `.debug` builds, but the **版本** line still showed only the release version number. Now it appends **" (Debug)"** on the version line too, so a debug build is unmistakable on the version page.

- Renders only when `Bundle.main.bundleIdentifier` ends in `.debug`; **release builds are unchanged** — no new user-facing release needed.
- Type-checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)