### PR TITLE
feat(cangjie): z-code punctuation + 聯想 continuation-only option (v2.2.0)

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.0</string>
+	<string>2.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>21</string>
+	<string>22</string>
 	<key>ComponentInputModeDict</key>
 	<dict>
 		<key>tsInputModeListKey</key>

--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -421,8 +421,14 @@ final class InputController: IMKInputController {
             // Guard against a stale candidatePage pointing past the end (would trap on slice).
             if candidatePage * size >= cands.count { candidatePage = 0 }
             let start = candidatePage * size
+            // In association mode, optionally show only the continuation after the committed
+            // character (係／心／於) instead of the whole word (關係) — the classic Yahoo display.
+            // Selection still indexes `associations` (unchanged) and inserts the dropFirst suffix.
+            let continuationOnly = !associations.isEmpty && Preferences.associationContinuationOnly
             // Convert only the displayed strings (WYSIWYG); selection still indexes `cands`.
-            let page = cands[start..<min(start + size, cands.count)].map(applyHanConvert)
+            let page = cands[start..<min(start + size, cands.count)].map { item -> String in
+                applyHanConvert(continuationOnly ? String(item.dropFirst()) : item)
+            }
             var rect = NSRect.zero
             client.attributes(forCharacterIndex: 0, lineHeightRectangle: &rect)
             candidateWindow.show(page, page: candidatePage, pageCount: pageCount,

--- a/App/Preferences.swift
+++ b/App/Preferences.swift
@@ -17,6 +17,7 @@ enum Preferences {
         static let fullWidthPunctuationEnabled = "fullWidthPunctuationEnabled"
         static let outputSimplifiedEnabled = "outputSimplifiedEnabled"
         static let cangjieVersion = "cangjieVersion"
+        static let associationContinuationOnly = "associationContinuationOnly"
     }
 
     static let minFontSize: CGFloat = 14
@@ -31,6 +32,7 @@ enum Preferences {
             Key.fullWidthPunctuationEnabled: true,
             Key.outputSimplifiedEnabled: false,
             Key.cangjieVersion: CangjieVersion.v5.rawValue,
+            Key.associationContinuationOnly: false,
         ])
     }
 
@@ -64,5 +66,13 @@ enum Preferences {
     static var cangjieVersion: CangjieVersion {
         get { CangjieVersion(rawValue: UserDefaults.standard.string(forKey: Key.cangjieVersion) ?? "") ?? .v5 }
         set { UserDefaults.standard.set(newValue.rawValue, forKey: Key.cangjieVersion) }
+    }
+
+    // When true, the 聯想 (associated-phrase) candidate window shows only the continuation
+    // after the just-committed character (係／心／於) instead of the whole word (關係／關心／
+    // 關於) — the classic Yahoo! KeyKey display. Off by default (shows the whole word).
+    static var associationContinuationOnly: Bool {
+        get { UserDefaults.standard.bool(forKey: Key.associationContinuationOnly) }
+        set { UserDefaults.standard.set(newValue, forKey: Key.associationContinuationOnly) }
     }
 }

--- a/App/SettingsWindow.swift
+++ b/App/SettingsWindow.swift
@@ -22,6 +22,7 @@ final class SettingsWindowController: NSWindowController {
     private var simplifiedCheckbox: NSButton!
     private var fullWidthCheckbox: NSButton!
     private var associatedCheckbox: NSButton!
+    private var associationContinuationCheckbox: NSButton!
     private var fontSizeSlider: NSSlider!
     private var autoUpdateCheckbox: NSButton!
     private var cangjieVersionPopup: NSPopUpButton!
@@ -95,7 +96,11 @@ final class SettingsWindowController: NSWindowController {
                                          action: #selector(toggleFullWidth))
         associatedCheckbox = makeCheckbox("聯想字詞", state: Preferences.associatedPhrasesEnabled,
                                           action: #selector(toggleAssociated))
-        return tabContainer([simplifiedCheckbox, fullWidthCheckbox, associatedCheckbox])
+        associationContinuationCheckbox = makeCheckbox("聯想只顯示接續字（如「係／心／於」而非「關係」）",
+                                                       state: Preferences.associationContinuationOnly,
+                                                       action: #selector(toggleAssociationContinuation))
+        return tabContainer([simplifiedCheckbox, fullWidthCheckbox, associatedCheckbox,
+                             associationContinuationCheckbox])
     }
 
     private func makeCheckbox(_ title: String, state: Bool, action: Selector) -> NSButton {
@@ -112,6 +117,9 @@ final class SettingsWindowController: NSWindowController {
     }
     @objc private func toggleAssociated(_ sender: NSButton) {
         Preferences.associatedPhrasesEnabled = (sender.state == .on)
+    }
+    @objc private func toggleAssociationContinuation(_ sender: NSButton) {
+        Preferences.associationContinuationOnly = (sender.state == .on)
     }
 
     // MARK: - 外觀 (candidate-window font size, clamped 14–28, with a live preview)
@@ -220,6 +228,7 @@ final class SettingsWindowController: NSWindowController {
         simplifiedCheckbox.state = Preferences.outputSimplifiedEnabled ? .on : .off
         fullWidthCheckbox.state = Preferences.fullWidthPunctuationEnabled ? .on : .off
         associatedCheckbox.state = Preferences.associatedPhrasesEnabled ? .on : .off
+        associationContinuationCheckbox.state = Preferences.associationContinuationOnly ? .on : .off
         fontSizeSlider.doubleValue = Double(Preferences.candidateFontSize)
         refreshFontPreview()
         autoUpdateCheckbox.state = Updater.shared.automaticallyChecksForUpdates ? .on : .off

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 A plain-language list of changes in each version, newest first.
 
+## 2.2.0
+
+- **New: z-code punctuation in 三代倉頡.** In the **三代倉頡（Yahoo KeyKey 相容）** mode you can now type punctuation with the classic Yahoo `z` codes — e.g. `zxcd` → 「, `zxce` → 」, `zxab` → ，, `zxbe` → （. These were part of the original Yahoo table and are available again.
+- **New: 聯想只顯示接續字 option.** A new checkbox in **設定… ▸ 一般** makes the associated-phrase (聯想) window show only the continuation after the character you just typed — e.g. after 關 it shows 係／心／於 instead of the full words 關係／關心／關於, like the classic Yahoo! KeyKey. Off by default; what you commit is unchanged either way.
+
 ## 2.1.0
 
 - **New: choose your 倉頡版本 (Cangjie generation).** In **設定… ▸ 輸入方式** you can now switch between **五代倉頡** (the standard 5th-generation table, the default) and **三代倉頡（Yahoo KeyKey 相容）**. The 三代 option uses the original Yahoo! KeyKey code table and its candidate order, so characters like 面 (`一田卜中`), 鬼 (`竹戈`), and 樓 (`木中田女`) take the codes long-time Yahoo users remember instead of the 5th-generation forms (`一田尸中`, `竹山戈`, `木中中女`). The choice applies to both 倉頡 and 速成 and takes effect immediately — no need to re-select the input method. The default stays 五代 so existing users are unaffected until they opt in.

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/CangjieTable.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/CangjieTable.swift
@@ -31,15 +31,20 @@ public struct CangjieTable {
         }
     }
 
-    /// True only for single-scalar characters in the commonly-renderable CJK ranges.
-    /// Drops Private Use Areas and supplementary-plane ideographs (Ext-B and beyond),
-    /// which render as tofu/`[?]` on most systems.
+    /// True only for single-scalar characters we can render safely: the common CJK
+    /// ideograph ranges, plus the CJK punctuation/full-width ranges used by the Yahoo
+    /// table's `z`-code punctuation (e.g. `zxcd`→「, `zxab`→，). Drops Private Use Areas
+    /// and supplementary-plane ideographs (Ext-B and beyond), which render as tofu.
     static func isRenderableCJK(_ ch: Character) -> Bool {
         let scalars = ch.unicodeScalars
         guard scalars.count == 1, let v = scalars.first?.value else { return false }
         return (0x4E00...0x9FFF).contains(v)   // CJK Unified Ideographs
             || (0x3400...0x4DBF).contains(v)   // CJK Extension A
             || (0xF900...0xFAFF).contains(v)   // CJK Compatibility Ideographs
+            || (0x3000...0x303F).contains(v)   // CJK Symbols and Punctuation (、。「」『』…)
+            || (0xFE30...0xFE4F).contains(v)   // CJK Compatibility Forms (vertical ︰﹁ etc.)
+            || (0xFF00...0xFFEF).contains(v)   // Halfwidth & Fullwidth Forms (，（）：？！)
+            || (0x2010...0x2027).contains(v)   // General punctuation used by z-codes (–—‥…)
     }
 
     public init(contentsOf url: URL) throws {

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/YahooCangjieTableTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/YahooCangjieTableTests.swift
@@ -49,6 +49,22 @@ final class YahooCangjieTableTests: XCTestCase {
         XCTAssertEqual(engine.candidates.first, "我")
     }
 
+    // The Yahoo table's z-code punctuation loads (was previously dropped by the CJK-only
+    // filter): zxcd→「, zxce→」, zxab→，. Confirms both the data and the broadened filter.
+    func testYahooZCodePunctuationLoads() throws {
+        guard let v3URL = resourceURL("cangjie-yahoo.txt") else {
+            throw XCTSkip("cangjie-yahoo.txt not present")
+        }
+        let v3 = try CangjieTable(contentsOf: v3URL)
+        XCTAssertEqual(v3.characters(forCode: "zxcd"), ["「"])
+        XCTAssertEqual(v3.characters(forCode: "zxce"), ["」"])
+        XCTAssertTrue(v3.characters(forCode: "zxab").contains("，"))
+        // And the engine composes it end-to-end (type z,x,c,d → first candidate 「).
+        let engine = CangjieEngine(table: v3, characterRank: [:])
+        for key in "zxcd" { _ = engine.handleKey(key) }
+        XCTAssertEqual(engine.candidates.first, "「")
+    }
+
     // The Yahoo 速成 table loads via the quick-code initializer and preserves native order.
     func testYahooSimplexLoadsAndPreservesOrder() throws {
         guard let url = resourceURL("simplex-yahoo.txt") else {


### PR DESCRIPTION
Follow-ups from [#30](https://github.com/teddychan/yahoo-keykey-2/issues/30), requested by reporter **ukbenchan** after they confirmed 三代倉頡 lets them switch off Yahoo.

## ① z-code punctuation in 三代倉頡
The Yahoo `cj-ext.cin` table already carries 90 `zx…` punctuation entries (`zxcd`→「, `zxce`→」, `zxab`→，, `zxbe`→（) — but `CangjieTable.isRenderableCJK` dropped them because punctuation isn't in the CJK **ideograph** ranges. Broaden the filter to also accept CJK Symbols/Punctuation (U+3000–303F), Compatibility Forms (U+FE30–FE4F), Halfwidth/Fullwidth Forms (U+FF00–FFEF), and the dash/ellipsis range (U+2010–2027). **No data change** — the entries were already bundled in `cangjie-yahoo.txt`.

## ② 聯想只顯示接續字 option
New checkbox in **設定… ▸ 一般** (`Preferences.associationContinuationOnly`, default **off**). When on, the 聯想 window shows the continuation after the committed char (係／心／於) instead of the full word (關係／關心／關於), like classic Yahoo! KeyKey. Selection/insertion behaviour is unchanged.

## Verification
- 113 engine tests pass, incl. new `testYahooZCodePunctuationLoads` (`zxcd`→「 end-to-end).
- Clean `build-app.sh` build, no warnings; version 2.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)