### PR TITLE
chore: bump DragonKit to 1.3.0, adopt DragonAbout.versionString() — v2.4.1

### DIFF
--- a/App/AboutConfig.swift
+++ b/App/AboutConfig.swift
@@ -9,9 +9,7 @@ enum AboutConfig {
     static let appName = "Yahoo! KeyKey 2" + (isDebugBuild ? " Debug" : "")
 
     static var versionString: String {
-        let short = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "2.2.0"
-        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "1"
-        return "\(short) (\(build))" + (isDebugBuild ? " Debug" : "")
+        return DragonAbout.versionString() + (isDebugBuild ? " Debug" : "")
     }
 
     @MainActor

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.0</string>
+	<string>2.4.1</string>
 	<key>CFBundleVersion</key>
 	<string>23</string>
 	<key>ComponentInputModeDict</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 A plain-language list of changes in each version, newest first.
 
+## 2.4.1
+
+- **Changed: clearer "already up to date" message.** When you check for updates and you're
+  already on the latest version, the confirmation dialog now reads more naturally.
+- **Changed: About now shows the build time.** The version line in **About** now reads like
+  `v2.4.1 (24) · 2026-Jul-06 13:34:56 UTC`, adding the exact UTC build time alongside the
+  version and build number.
+
 ## 2.4.0
 
 - **New: 反查／拆碼提示 (Cangjie code hint).** Turn on **反查提示** — from the input menu or

--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -73,7 +73,7 @@ echo "==> Building DragonKit (SwiftPM, release) in pinned checkout"
 # package's own tools version (6.1) — a separate compilation from the app's -swift-version 5.
 # Clone the pinned tag on first use (e.g. a fresh CI checkout); vendor/ is gitignored, never
 # committed. Idempotent: an existing checkout (local dev) is reused as-is.
-DRAGONKIT_TAG="v1.2.1"
+DRAGONKIT_TAG="v1.3.0"
 if [ ! -d "$KIT_DIR" ]; then
   echo "==> Cloning DragonKit $DRAGONKIT_TAG into vendor/ (not committed)"
   git clone --depth 1 --branch "$DRAGONKIT_TAG" https://github.com/teddychan/dragon-kit "$KIT_DIR"


### PR DESCRIPTION
## v2.4.1 — DragonKit 1.3.0 bump

A small bugfix release that pulls in DragonKit **v1.3.0** and adopts its new
shared version-string helper. No engine changes.

### DragonKit 1.3.0
- `tools/build-app.sh`: pin `DRAGONKIT_TAG` **v1.2.1 → v1.3.0** (vendor-built with `swift build`; the vendor/ checkout is gitignored and re-cloned fresh).
- **Reworded "already up to date" update dialog** — inherited automatically from DragonKit 1.3.0's Sparkle strings; no app-side change needed.

### About version adoption
- `App/AboutConfig.swift`: `versionString` now returns `DragonAbout.versionString()` (+ the existing ` Debug` suffix for debug-id builds) instead of hand-assembling `CFBundleShortVersionString (CFBundleVersion)`. The About pane now shows the exact UTC build time too, e.g. `v2.4.1 (140) · 2026-Jul-06 13:25:31 UTC`. Every Dragon app now formats its version identically.

### Version bump
- `App/Info.plist`: `CFBundleShortVersionString` **2.4.0 → 2.4.1** (bugfix). `CFBundleVersion` is left for `build-app.sh` to stamp from the git commit count (CI asserts tag == plist).
- CHANGELOG: new `## 2.4.1` section (reworded update dialog; About build-time line).

### Verification
- `bash tools/build-app.sh` succeeds end-to-end: clones DragonKit **v1.3.0**, compiles the app + engine, assembles/ad-hoc-signs `build/YahooKeyKey2.app`. Built `Info.plist` reports **2.4.1 (140)**.
- About string the build produces: `v2.4.1 (140) · 2026-Jul-06 13:25:31 UTC`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)