### PR TITLE
fix: candidate text size slider updates live while dragging (v2.5.0)

### DIFF
--- a/App/AppMenuController.swift
+++ b/App/AppMenuController.swift
@@ -83,22 +83,26 @@ final class AppMenuController {
 
     func openSettings() {
         selection.paneID = "general"
+        model.syncFromPreferences()
         settingsController.show()
     }
 
     func openAbout() {
         selection.paneID = "about"
+        model.syncFromPreferences()
         settingsController.show()
     }
 
     func checkForUpdates() {
         selection.paneID = "updates"
+        model.syncFromPreferences()
         settingsController.show()
         updater.checkForUpdates()
     }
 
     func openUninstall() {
         selection.paneID = "uninstall"
+        model.syncFromPreferences()
         settingsController.show()
     }
 

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.1</string>
+	<string>2.5.0</string>
 	<key>CFBundleVersion</key>
 	<string>23</string>
 	<key>ComponentInputModeDict</key>

--- a/App/SettingsModel.swift
+++ b/App/SettingsModel.swift
@@ -47,9 +47,17 @@ final class SettingsModel {
         set { Preferences.codeHintEnabled = newValue }
     }
 
-    var candidateFontSize: Double {
-        get { Double(Preferences.candidateFontSize) }
-        set { Preferences.candidateFontSize = CGFloat(newValue) }
+    // Candidate text size. Like `cangjieVersion` below, this is a STORED, observation-tracked
+    // property (seeded from Preferences at init) — NOT a computed forwarder. An @Observable
+    // *computed* property bound to a Slider never registers an observation dependency in its
+    // getter, so SwiftUI drops the change: the slider (and its "N pt" label) appear frozen while
+    // dragging. A stored property is tracked, so the value updates live. `didSet` writes through
+    // to Preferences, which the candidate window reads directly on the next composition.
+    var candidateFontSize: Double = Double(Preferences.candidateFontSize) {
+        didSet {
+            guard candidateFontSize != oldValue else { return }
+            Preferences.candidateFontSize = CGFloat(candidateFontSize)
+        }
     }
 
     // 倉頡版本 (Cangjie table). This is a STORED, observation-tracked property (seeded from
@@ -68,4 +76,14 @@ final class SettingsModel {
 
     var minFontSize: Double { Double(Preferences.minFontSize) }
     var maxFontSize: Double { Double(Preferences.maxFontSize) }
+
+    // Re-seed the observation-tracked mirror properties (currently just candidateFontSize) from
+    // the live Preferences. The computed forwarders above re-read Preferences on every access, so
+    // they always reflect changes made elsewhere; a stored property does not. Since the candidate
+    // size is ALSO settable outside Settings — the menu-bar 候選字大小 (小/中/大) items write
+    // Preferences directly — call this before showing the window so the slider matches the quick
+    // menu (the 2.0.2 behaviour). No-op when already in sync (the didSet guard skips the write).
+    func syncFromPreferences() {
+        candidateFontSize = Double(Preferences.candidateFontSize)
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 A plain-language list of changes in each version, newest first.
 
+## 2.5.0
+
+- **Fixed: the candidate text size slider now updates as you drag.** In **設定… ▸ 一般**,
+  dragging the **候選字大小 (Candidate text size)** slider left the shown value (e.g. `19 pt`)
+  and the slider stuck in place, even though the size did change. The slider and its label now
+  track your dragging live.
+
 ## 2.4.1
 
 - **Changed: clearer "already up to date" message.** When you check for updates and you're


### PR DESCRIPTION
## What & why

The **候選字大小 (Candidate text size)** slider in **設定… ▸ 一般** appeared frozen while dragging — the `N pt` label and the thumb didn't move, even though the size was actually changing.

**Root cause:** `SettingsModel.candidateFontSize` was an `@Observable` *computed* property forwarding to `Preferences`. A computed getter never registers an observation dependency, so SwiftUI dropped the change during drag. This is the same class of bug already fixed for the 倉頡版本 picker (see the `cangjieVersion` note in `SettingsModel`).

## Fix

- Convert `candidateFontSize` to a **stored, observation-tracked** property with a `didSet` write-through to `Preferences`, mirroring `cangjieVersion`.
- Because the menu-bar **候選字大小 (小/中/大)** items write `Preferences` directly (bypassing `SettingsModel`), add `SettingsModel.syncFromPreferences()` and call it before showing the settings window — so the slider still matches the quick menu (preserving the 2.0.2 "Settings matches the quick menu" behaviour).
- Bump version to **2.5.0** and add the CHANGELOG entry.

## Verification

- `tools/build-app.sh` compiles the app cleanly (fails only at the `data.txt` copy step, expected in a clean checkout — the LM is regenerated in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
