### PR TITLE
fix: remove 候選字大小 from input menu — v2.6.2

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.1</string>
+	<string>2.6.2</string>
 	<key>CFBundleVersion</key>
 	<string>23</string>
 	<key>ComponentInputModeDict</key>

--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -100,9 +100,10 @@ final class InputController: IMKInputController {
     // IMK input-menu (the menu shown in the input-method menu-bar item), organized to the
     // shared Dragon-App app-menu standard (liquid-glass-macos SKILL §5A) for an IME:
     //   1. quick-toggles zone (輸出簡體字 / 全形標點 / 聯想字詞), checkmarks reflect live prefs;
-    //   2. 候選字大小 (candidate size) flat choices;
-    //   3. any settings specific to the active input method (none for Cangjie/Simplex today);
-    //   4. App menu grouping (§5A) — About Yahoo! KeyKey 2 · 檢查更新… · 設定… · — · 解除安裝….
+    //   2. any settings specific to the active input method (none for Cangjie/Simplex today);
+    //   3. App menu grouping (§5A) — About Yahoo! KeyKey 2 · 檢查更新… · 設定… · — · 解除安裝….
+    //      Candidate-window font size (候選字大小) is no longer offered here — the coarse
+    //      小/中/大 choices were superseded by the fine-grained slider in 設定….
     //      Per §5A the IME app menu omits Quit (an IME is system-managed; quitting only makes
     //      typing unresponsive until macOS relaunches it). All items are TOP-LEVEL: the macOS
     //      input menu only routes top-level selections back to the controller, so a "⋯ Yahoo!
@@ -132,23 +133,7 @@ final class InputController: IMKInputController {
         codeHint.state = Preferences.codeHintEnabled ? .on : .off
         menu.addItem(codeHint)
 
-        // 2. Candidate-window font size (候選字大小). The macOS input menu routes only
-        // TOP-LEVEL item selections back to the controller — items nested in a submenu
-        // are shown but never fire — so the sizes are flat items under a disabled
-        // header. The chosen size is read live by CandidateWindow on the next
-        // composition; the checkmark marks the active size.
-        let fontHeader = NSMenuItem(title: "候選字大小", action: nil, keyEquivalent: "")
-        fontHeader.isEnabled = false
-        menu.addItem(fontHeader)
-        let currentFontSize = Preferences.candidateFontSize
-        for (title, size, action) in Self.candidateFontSizeChoices {
-            let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
-            item.target = self
-            item.state = (currentFontSize == size) ? .on : .off
-            menu.addItem(item)
-        }
-
-        // 3. Settings specific to the active input method (grouped with their method).
+        // 2. Settings specific to the active input method (grouped with their method).
         // Empty for Cangjie/Simplex today; future methods supply items via methodMenuItems.
         let methodItems = currentModule.methodMenuItems()
         if !methodItems.isEmpty {
@@ -156,7 +141,7 @@ final class InputController: IMKInputController {
             methodItems.forEach(menu.addItem)
         }
 
-        // 4. App menu grouping (§5A): About · Check for updates · Settings · — · Uninstall.
+        // 3. App menu grouping (§5A): About · Check for updates · Settings · — · Uninstall.
         // Quit omitted by design (system-managed IME). All top-level so IMK routes them.
         // Titles resolve via DragonKit's L() so they follow the picked language; IMK pulls
         // menu() fresh each time the input menu opens, so no cached menu to rebuild on change.
@@ -197,20 +182,6 @@ final class InputController: IMKInputController {
     @objc private func toggleCodeHint() {
         Preferences.codeHintEnabled.toggle()
     }
-
-    // Named candidate-window font sizes (display title → point size → menu action),
-    // all within the Preferences clamp (14–28); the default 18 is "中". Each size has
-    // its own no-argument selector so it dispatches exactly like the toggles above —
-    // the input menu's cross-process routing doesn't preserve a shared handler's tag.
-    private static let candidateFontSizeChoices: [(title: String, size: CGFloat, action: Selector)] = [
-        ("小", 14, #selector(setCandidateFontSizeSmall)),
-        ("中", 18, #selector(setCandidateFontSizeMedium)),
-        ("大", 24, #selector(setCandidateFontSizeLarge)),
-    ]
-
-    @objc private func setCandidateFontSizeSmall() { Preferences.candidateFontSize = 14 }
-    @objc private func setCandidateFontSizeMedium() { Preferences.candidateFontSize = 18 }
-    @objc private func setCandidateFontSizeLarge() { Preferences.candidateFontSize = 24 }
 
     // IMK invokes these input-menu selectors on the main thread, so entering the main actor
     // to reach the (main-actor) shared settings window controller is safe.

--- a/App/SettingsModel.swift
+++ b/App/SettingsModel.swift
@@ -79,10 +79,9 @@ final class SettingsModel {
 
     // Re-seed the observation-tracked mirror properties (currently just candidateFontSize) from
     // the live Preferences. The computed forwarders above re-read Preferences on every access, so
-    // they always reflect changes made elsewhere; a stored property does not. Since the candidate
-    // size is ALSO settable outside Settings — the menu-bar 候選字大小 (小/中/大) items write
-    // Preferences directly — call this before showing the window so the slider matches the quick
-    // menu (the 2.0.2 behaviour). No-op when already in sync (the didSet guard skips the write).
+    // they always reflect changes made elsewhere; a stored property does not. Call this before
+    // showing the window so the slider matches whatever value Preferences currently holds (e.g. a
+    // value migrated from an older build). No-op when already in sync (the didSet guard skips the write).
     func syncFromPreferences() {
         candidateFontSize = Double(Preferences.candidateFontSize)
     }

--- a/App/WhatsNewConfig.swift
+++ b/App/WhatsNewConfig.swift
@@ -1,23 +1,19 @@
 import Foundation
 import DragonKit
 
-// "What's New" content for the current release (2.6.1). Leads with the new 拼音 (Pinyin)
-// input method — added in 2.6.0 but never surfaced in this pane — plus the two 2.6.1 fixes
-// (direct number-key selection, pinyin code hint). Keep in sync with CHANGELOG.md on release.
+// "What's New" content for the current release (2.6.2). A small tidy-up: the coarse 候選字大小
+// (小／中／大) shortcuts were removed from the input menu now that Settings has a fine-grained
+// size slider. Keep in sync with CHANGELOG.md on release.
 enum WhatsNewConfig {
     @MainActor
     static var content: WhatsNewContent {
         WhatsNewContent(
-            version: "2.6.1",
+            version: "2.6.2",
             date: "2026-07-08",
             summary: L("keykey.whatsNew.summary"),
             sections: [
-                ChangeSection(kind: .added, entries: [
-                    L("keykey.whatsNew.pinyin"),
-                ]),
-                ChangeSection(kind: .fixed, entries: [
-                    L("keykey.whatsNew.pinyinNumberSelect"),
-                    L("keykey.whatsNew.pinyinHint"),
+                ChangeSection(kind: .changed, entries: [
+                    L("keykey.whatsNew.candidateSizeMenu"),
                 ]),
             ]
         )

--- a/App/en.lproj/Localizable.strings
+++ b/App/en.lproj/Localizable.strings
@@ -30,11 +30,9 @@
 "keykey.about.cangjieTable" = "Cangjie table";
 "keykey.about.hanConversion" = "Han conversion";
 
-/* What's New pane (2.6.1) */
-"keykey.whatsNew.summary" = "Yahoo KeyKey 2 now includes a new 拼音 (Pinyin) input method — type whole phrases in pinyin. This update also lets you pick candidates with the number keys and shows a pinyin hint.";
-"keykey.whatsNew.pinyin" = "New input method: 拼音 (Pinyin). Alongside 倉頡 and 速成, type pinyin (no tone marks needed) to compose whole phrases. Space commits; 1–9 pick a candidate; ←/→ move between syllables; use an apostrophe to split ambiguous syllables (e.g. xi'an → 西安). Add it in System Settings ▸ Keyboard ▸ Input Sources.";
-"keykey.whatsNew.pinyinNumberSelect" = "拼音: the number keys 1–9 now select a candidate directly. A single syllable commits right away (like 倉頡／速成); in a phrase they pick that syllable and move to the next. Space still commits the whole phrase at once.";
-"keykey.whatsNew.pinyinHint" = "拼音: with the 反查／拆碼提示 hint turned on, candidates now show their pinyin reading (e.g. wo, ni hao) instead of the 倉頡 code.";
+/* What's New pane (2.6.2) */
+"keykey.whatsNew.summary" = "This update removes the 候選字大小 (small/medium/large) shortcuts from the input menu — candidate text size is now set with the finer-grained slider under 設定… ▸ 一般.";
+"keykey.whatsNew.candidateSizeMenu" = "Removed 候選字大小 (small/medium/large) from the input menu. Candidate text size is now set with the slider under 設定… ▸ 一般, which lets you pick any size in the supported range instead of just three fixed steps. Your current size is unchanged.";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "Disable Cangjie and Simplex from Input Sources";

--- a/App/zh-Hant.lproj/Localizable.strings
+++ b/App/zh-Hant.lproj/Localizable.strings
@@ -30,11 +30,9 @@
 "keykey.about.cangjieTable" = "倉頡碼表";
 "keykey.about.hanConversion" = "漢字轉換";
 
-/* What's New pane (2.6.1) */
-"keykey.whatsNew.summary" = "Yahoo KeyKey 2 新增「拼音」輸入法——可用拼音輸入整個詞句。本次更新也可用數字鍵直接選字，並顯示拼音提示。";
-"keykey.whatsNew.pinyin" = "新增輸入法：拼音。除了倉頡與速成，現在可輸入拼音（免打聲調）來組成整個詞句。空白鍵送出；1–9 選字；←／→ 在音節間移動；用單引號分隔易混淆的音節（例：xi'an → 西安）。請於「系統設定 ▸ 鍵盤 ▸ 輸入來源」加入。";
-"keykey.whatsNew.pinyinNumberSelect" = "拼音：數字鍵 1–9 現在可直接選字。單一音節會立即送出（如倉頡／速成）；在詞句中則選取該音節並移到下一個。空白鍵仍可一次送出整個詞句。";
-"keykey.whatsNew.pinyinHint" = "拼音：開啟「反查／拆碼提示」後，候選字現在會顯示其拼音（例：wo、ni hao），而非倉頡碼。";
+/* What's New pane (2.6.2) */
+"keykey.whatsNew.summary" = "本次更新移除了輸入選單中的「候選字大小」（小／中／大）捷徑，改用「設定… ▸ 一般」裡更精細的字級滑桿來調整。";
+"keykey.whatsNew.candidateSizeMenu" = "已從輸入選單移除「候選字大小」（小／中／大）。候選字字級現在改由「設定… ▸ 一般」的滑桿調整，可在支援範圍內選擇任意大小，不再只有三段固定值。您目前的字級維持不變。";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "從輸入來源中停用倉頡與速成";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 A plain-language list of changes in each version, newest first.
 
+## 2.6.2
+
+- **Removed 候選字大小 from the input menu.** The coarse **小／中／大** shortcuts in the
+  input-method menu-bar item are gone — candidate text size is now set with the fine-grained
+  slider under **設定… ▸ 一般**, which lets you pick any size in the supported range instead of
+  just three fixed steps. Your current size is unchanged.
+
 ## 2.6.1
 
 - **拼音: number keys now pick a candidate directly.** While typing Pinyin, pressing **1–9**


### PR DESCRIPTION
## What & why

The quick input-method menu offered a **候選字大小** (candidate text size) section with three coarse **小／中／大** shortcuts. Since v2.5.0 the Settings page (**設定… ▸ 一般**) has a fine-grained size slider covering the full supported range, so the menu shortcuts are redundant and create two competing UIs for the same preference. This removes them from the menu; the slider is now the single place to set candidate size.

## Changes

- **`InputController.menu()`** — remove the `候選字大小` header + `小／中／大` items, plus the now-unused `candidateFontSizeChoices` array and `setCandidateFontSize{Small,Medium,Large}` selectors. Menu section comments renumbered (font size was section 2).
- **`SettingsModel`** — candidate size is now written only from Settings; updated `syncFromPreferences()`'s comment (it no longer claims a menu-bar writer). Function kept — still called before showing each pane.
- **`WhatsNewConfig` + `Localizable.strings` (en, zh-Hant)** — 2.6.2 What's New note (a `.changed` entry); retired the orphaned 2.6.1 pinyin whatsNew strings.
- **Version** — `CFBundleShortVersionString` 2.6.1 → 2.6.2; `CHANGELOG.md` entry.

## Verification

- `tools/build-app.sh` — clean build, no errors/warnings.
- `swift test` (KeyKeyEngine) — 159 tests pass.
- Menu code path compiles with the section removed; the Settings slider (`GeneralPane`) still binds to `model.candidateFontSize` and remains the sole writer of `Preferences.candidateFontSize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
