### PR TITLE
perf: single-pass LM load, lazy 速成/反查 tables, 拼音 input cap — v2.6.4

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.3</string>
+	<string>2.6.4</string>
 	<key>CFBundleVersion</key>
 	<string>23</string>
 	<key>ComponentInputModeDict</key>

--- a/App/SharedResources.swift
+++ b/App/SharedResources.swift
@@ -13,16 +13,12 @@ final class SharedResources {
     // wildcard matches surface common characters first. Computed once.
     let characterRank: [Character: Double]
     let associatedPhrases: AssociatedPhrases
-    // Cangjie/Simplex tables and the effective sort rank depend on the selected Cangjie
-    // version; rebuilt in place by reloadCangjieTables() when the user changes it.
+    // Cangjie table and the effective sort rank depend on the selected Cangjie version;
+    // rebuilt in place by reloadCangjieTables() when the user changes it.
     private(set) var cangjieTable: CangjieTable
-    private(set) var simplexTable: SimplexTable
     // Single-char rank the engines sort by: the LM `characterRank` for 五代, or empty for
     // 三代 so the Yahoo table's native line order is preserved. User-learning applies on top.
     private(set) var cangjieRank: [Character: Double]
-    // Reverse index (char → 倉頡 code) for the 反查/拆碼提示 hint; rebuilt with the tables so it
-    // always matches the selected 倉頡版本.
-    private(set) var cangjieCodeIndex: CangjieCodeIndex
     let hanConvertFilter: HanConvertFilter
     // One shared user-learning store across all controllers.
     let userFreq: UserFrequency
@@ -32,9 +28,24 @@ final class SharedResources {
     // Pinyin mode (ref-counted). Built lazily from data.txt on the first acquire.
     let pinyinIndexCache: RefCountedResource<TonelessLanguageModelIndex>
 
+    // Simplex (速成) table: only needed once a controller actually selects 速成, so it's built
+    // lazily on first access rather than eagerly at launch (building it arrays + sorts all
+    // Cangjie entries). Guarded by a lock, mirroring RefCountedResource, since SharedResources
+    // is prewarmed off-main and read from the input controller. Invalidated (not rebuilt) by
+    // loadCangjieTables() on a 倉頡版本 change; the next access rebuilds for the new version.
+    private let simplexLock = NSLock()
+    private var cachedSimplexTable: SimplexTable?
+
+    // Reverse index (char → 倉頡 code) for the 反查/拆碼提示 hint. Only read when
+    // Preferences.codeHintEnabled is true (off by default), so it's built lazily on first
+    // access rather than unconditionally at launch. Same locking approach as simplexTable.
+    private let codeIndexLock = NSLock()
+    private var cachedCodeIndex: CangjieCodeIndex?
+
     private init() {
-        // Read data.txt to a String ONCE, then build both the LM and the associated
-        // phrases from that same string (the previous code parsed data.txt twice).
+        // Read data.txt to a String ONCE, split it into lines ONCE, then build both the LM
+        // ranking and the associated phrases from that SAME line array (the previous code
+        // split and tokenized data.txt twice — once per consumer).
         let dataText: String?
         if let url = Bundle.main.url(forResource: "data", withExtension: "txt") {
             dataText = try? String(contentsOf: url, encoding: .utf8)
@@ -42,31 +53,25 @@ final class SharedResources {
             dataText = nil
         }
 
-        // Derive the character ranking straight from data.txt WITHOUT building the full LM:
-        // nothing at runtime needs the whole model, and streaming avoids the transient ~55–80 MB
-        // table (lower launch peak memory + faster startup).
         if let text = dataText {
-            characterRank = LanguageModel.characterScores(fromText: text)
+            let lines = text.split(separator: "\n", omittingEmptySubsequences: true)
+            // Derive the character ranking straight from the lines WITHOUT building the full
+            // LM: nothing at runtime needs the whole model, and streaming avoids the transient
+            // ~55–80 MB table (lower launch peak memory + faster startup).
+            characterRank = LanguageModel.characterScores(fromLines: lines)
+            associatedPhrases = AssociatedPhrases(lines: lines)
         } else {
             NSLog("YahooKeyKey: data.txt missing; running with empty character ranking")
             characterRank = [:]
-        }
-
-        // Build associated phrases from the SAME data.txt string; fail safe to empty if missing.
-        if let text = dataText {
-            associatedPhrases = AssociatedPhrases(text: text)
-        } else {
             NSLog("YahooKeyKey: data.txt missing; running with empty associated phrases")
             associatedPhrases = AssociatedPhrases(text: "")
         }
 
-        // Placeholder empties satisfy Swift's two-phase init; the real tables for the
-        // selected version are loaded by loadCangjieTables() at the end of init (once every
+        // Placeholder empties satisfy Swift's two-phase init; the real table for the
+        // selected version is loaded by loadCangjieTables() at the end of init (once every
         // stored property is set, so an instance method may be called).
         cangjieTable = CangjieTable(text: "")
-        simplexTable = SimplexTable(cangjie: cangjieTable)
         cangjieRank = characterRank
-        cangjieCodeIndex = CangjieCodeIndex(table: cangjieTable)
 
         // Load the bundled TC→SC table for the "輸出簡體字" toggle; fail safe to an empty
         // (pass-through) table if missing, so the toggle simply leaves text unchanged.
@@ -102,35 +107,72 @@ final class SharedResources {
             return TonelessLanguageModelIndex(text: "")
         }
 
-        // All stored properties are now set: load the real tables for the selected version.
+        // All stored properties are now set: load the real Cangjie table for the selected
+        // version. simplexTable/cangjieCodeIndex are lazy and build on first access.
         loadCangjieTables(version: Preferences.cangjieVersion)
     }
 
-    // Load the Cangjie table, derive/load the Simplex table, and set the effective sort
-    // rank for the given version. 五代 uses the bundled ibus table + LM ranking; 三代 uses
-    // the Yahoo! KeyKey tables (cj-ext / simplex-ext) with their native line order (empty
-    // rank → the engines' stable sort preserves it).
+    // Load the Cangjie table and set the effective sort rank for the given version. 五代 uses
+    // the bundled ibus table + LM ranking; 三代 uses the Yahoo! KeyKey table (cj-ext) with its
+    // native line order (empty rank → the engines' stable sort preserves it).
     private func loadCangjieTables(version: CangjieVersion) {
         switch version {
         case .v5:
             cangjieTable = Self.loadCangjie(resource: "cangjie")
-            simplexTable = SimplexTable(cangjie: cangjieTable)
             cangjieRank = characterRank
         case .v3:
             cangjieTable = Self.loadCangjie(resource: "cangjie-yahoo")
-            // Yahoo 速成 has its own native order; load it directly. Fail-safe: derive from
-            // the Cangjie table if simplex-yahoo.txt is missing.
-            if let url = Bundle.main.url(forResource: "simplex-yahoo", withExtension: "txt"),
-               let loaded = try? SimplexTable(quickCodeContentsOf: url) {
-                simplexTable = loaded
-            } else {
-                NSLog("YahooKeyKey: simplex-yahoo.txt missing; deriving Simplex from Cangjie")
-                simplexTable = SimplexTable(cangjie: cangjieTable)
-            }
             cangjieRank = [:]   // native table order
         }
-        // Rebuild the reverse index from whichever table we just loaded.
-        cangjieCodeIndex = CangjieCodeIndex(table: cangjieTable)
+        // Drop any cached simplexTable/cangjieCodeIndex: both are derived from cangjieTable
+        // (or the version), so they must rebuild against the table just loaded. Rebuilding is
+        // deferred to the next access rather than done eagerly here.
+        simplexLock.lock()
+        cachedSimplexTable = nil
+        simplexLock.unlock()
+        codeIndexLock.lock()
+        cachedCodeIndex = nil
+        codeIndexLock.unlock()
+    }
+
+    // Builds the Simplex table for `version`. 五代 derives it from the Cangjie table; 三代 loads
+    // the Yahoo 速成 table's own native order directly, falling back to deriving from Cangjie if
+    // simplex-yahoo.txt is missing.
+    private static func buildSimplexTable(version: CangjieVersion, cangjieTable: CangjieTable) -> SimplexTable {
+        switch version {
+        case .v5:
+            return SimplexTable(cangjie: cangjieTable)
+        case .v3:
+            if let url = Bundle.main.url(forResource: "simplex-yahoo", withExtension: "txt"),
+               let loaded = try? SimplexTable(quickCodeContentsOf: url) {
+                return loaded
+            }
+            NSLog("YahooKeyKey: simplex-yahoo.txt missing; deriving Simplex from Cangjie")
+            return SimplexTable(cangjie: cangjieTable)
+        }
+    }
+
+    // The Simplex (速成) table for the currently-selected 倉頡版本, built lazily on first access
+    // and cached until the version changes (see loadCangjieTables). Thread-safe via simplexLock.
+    var simplexTable: SimplexTable {
+        simplexLock.lock()
+        defer { simplexLock.unlock() }
+        if let cached = cachedSimplexTable { return cached }
+        let built = Self.buildSimplexTable(version: Preferences.cangjieVersion, cangjieTable: cangjieTable)
+        cachedSimplexTable = built
+        return built
+    }
+
+    // The reverse (char → 倉頡 code) index for the 反查/拆碼提示 hint, built lazily on first
+    // access (it's only read when Preferences.codeHintEnabled is true) and cached until the
+    // 倉頡版本 changes (see loadCangjieTables). Thread-safe via codeIndexLock.
+    var cangjieCodeIndex: CangjieCodeIndex {
+        codeIndexLock.lock()
+        defer { codeIndexLock.unlock() }
+        if let cached = cachedCodeIndex { return cached }
+        let built = CangjieCodeIndex(table: cangjieTable)
+        cachedCodeIndex = built
+        return built
     }
 
     // The currently-resident Pinyin index (non-nil while a controller holds Pinyin), or an empty
@@ -149,7 +191,7 @@ final class SharedResources {
         return CangjieTable(text: "")
     }
 
-    // Rebuild the tables/rank for the currently-selected version and notify controllers to
+    // Rebuild the table/rank for the currently-selected version and notify controllers to
     // rebuild their live engines. Called when the user changes 倉頡版本 in Settings.
     func reloadCangjieTables() {
         loadCangjieTables(version: Preferences.cangjieVersion)

--- a/App/WhatsNewConfig.swift
+++ b/App/WhatsNewConfig.swift
@@ -1,15 +1,15 @@
 import Foundation
 import DragonKit
 
-// "What's New" content for the current release (2.6.3). Performance-only: lower launch memory /
-// faster startup, and less per-keystroke work while typing 拼音. Keep in sync with CHANGELOG.md
-// on release.
+// "What's New" content for the current release (2.6.4). Performance + robustness: single-pass
+// dictionary load, lazily-built 速成 table / 反查 index, and a 拼音 composer that stays responsive
+// on unusual input. Keep in sync with CHANGELOG.md on release.
 enum WhatsNewConfig {
     @MainActor
     static var content: WhatsNewContent {
         WhatsNewContent(
-            version: "2.6.3",
-            date: "2026-07-09",
+            version: "2.6.4",
+            date: "2026-07-10",
             summary: L("keykey.whatsNew.summary"),
             sections: [
                 ChangeSection(kind: .changed, entries: [

--- a/App/en.lproj/Localizable.strings
+++ b/App/en.lproj/Localizable.strings
@@ -30,10 +30,10 @@
 "keykey.about.cangjieTable" = "Cangjie table";
 "keykey.about.hanConversion" = "Han conversion";
 
-/* What's New pane (2.6.3) */
-"keykey.whatsNew.summary" = "This update makes Yahoo KeyKey 2 lighter and faster: it starts up quicker, uses less memory, and does less work on each keystroke while you type 拼音.";
-"keykey.whatsNew.perfMemory" = "Faster startup and lower memory use. At launch the app no longer builds a large in-memory copy of its dictionary just to rank characters — it now reads only what it needs, so Yahoo KeyKey 2 starts up quicker and takes up less memory. Nothing you type changes.";
-"keykey.whatsNew.perfPinyin" = "拼音 typing is more efficient. While composing pinyin, the engine now avoids repeated sorting work on every keystroke — most noticeable with long phrases. The candidates you see, and their order, are exactly the same as before.";
+/* What's New pane (2.6.4) */
+"keykey.whatsNew.summary" = "This update trims startup and memory a little further, and keeps 拼音 responsive even on unusual input.";
+"keykey.whatsNew.perfMemory" = "Starts up even faster and lighter. At launch the app now reads its dictionary in a single pass instead of two, and it builds the 速成 (Simplex) table and the 反查／拆碼提示 reverse-lookup index only when you actually use them. If you type only 倉頡 or 拼音, that's less work and less memory at startup. What you type is unchanged.";
+"keykey.whatsNew.perfPinyin" = "拼音 stays responsive on unusual input. Typing a long run of letters that don't form valid syllables no longer makes the composer do more and more work on each keystroke.";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "Disable Cangjie and Simplex from Input Sources";

--- a/App/zh-Hant.lproj/Localizable.strings
+++ b/App/zh-Hant.lproj/Localizable.strings
@@ -30,10 +30,10 @@
 "keykey.about.cangjieTable" = "倉頡碼表";
 "keykey.about.hanConversion" = "漢字轉換";
 
-/* What's New pane (2.6.3) */
-"keykey.whatsNew.summary" = "本次更新讓 Yahoo KeyKey 2 更輕更快：啟動更迅速、佔用記憶體更少，輸入拼音時每次按鍵的運算也更精簡。";
-"keykey.whatsNew.perfMemory" = "啟動更快、記憶體用量更低。啟動時不再為了排序常用字而在記憶體中建立整份詞庫的複本，改為只讀取所需資料，因此 Yahoo KeyKey 2 啟動更迅速、佔用記憶體更少。您輸入的內容完全不受影響。";
-"keykey.whatsNew.perfPinyin" = "拼音輸入更有效率。組字時，引擎不再於每次按鍵重複進行排序運算，長詞句時尤其明顯。您看到的候選字與其排序，皆與先前完全相同。";
+/* What's New pane (2.6.4) */
+"keykey.whatsNew.summary" = "本次更新進一步縮減啟動時間與記憶體用量，並讓拼音在遇到異常輸入時仍保持流暢。";
+"keykey.whatsNew.perfMemory" = "啟動更快、更輕巧。啟動時，應用程式改以單次讀取詞庫（原本需讀取兩次），並僅在您實際使用時才建立速成碼表與反查／拆碼提示的反查索引。若您只使用倉頡或拼音，啟動時的運算與記憶體用量都更少。您輸入的內容完全不受影響。";
+"keykey.whatsNew.perfPinyin" = "拼音在異常輸入時依然流暢。連續輸入一長串無法組成有效音節的字母時，組字引擎不再於每次按鍵進行越來越多的運算。";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "從輸入來源中停用倉頡與速成";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 A plain-language list of changes in each version, newest first.
 
+## 2.6.4
+
+- **Starts up even faster and lighter.** At launch, Yahoo KeyKey 2 now reads its dictionary file
+  in a single pass instead of two, and it builds the **速成 (Simplex)** code table and the
+  **反查／拆碼提示** reverse-lookup index only when you actually use them. If you type only 倉頡 or
+  拼音, that's less work and less memory every time the app starts. Nothing you type changes.
+- **拼音 stays responsive on unusual input.** Typing a long run of letters that can't form valid
+  syllables no longer makes the pinyin composer do more and more work on every keystroke.
+- **Under the hood.** Added test coverage for the 拼音 and 速成 engines to match 倉頡 (user-learning
+  reranking, edge-case input handling, and real-dictionary checks), guarding against regressions.
+
 ## 2.6.3
 
 - **Faster startup and lower memory use.** At launch, Yahoo KeyKey 2 no longer builds a large

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/AssociatedPhrases.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/AssociatedPhrases.swift
@@ -7,9 +7,13 @@ public struct AssociatedPhrases {
 
     private var table: [Character: [String]] = [:]
 
-    public init(text: String) {
+    /// Builds from already-split LM lines. Callers that already have the file split into
+    /// lines (e.g. to also build `LanguageModel.characterScores` from the same lines) should
+    /// use this to avoid re-splitting the same multi-MB text.
+    public init(lines: [Substring]) {
         var scored: [Character: [(phrase: String, score: Double)]] = [:]
-        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: true) {
+        scored.reserveCapacity(6_000)
+        for rawLine in lines {
             let line = rawLine.trimmingCharacters(in: .whitespaces)
             if line.isEmpty || line.hasPrefix("#") { continue }
             let parts = line.split(separator: " ")
@@ -18,6 +22,7 @@ public struct AssociatedPhrases {
             guard phrase.count >= 2, let first = phrase.first else { continue }
             scored[first, default: []].append((phrase, score))
         }
+        table.reserveCapacity(scored.count)
         for (first, entries) in scored {
             var seen = Set<String>()
             var phrases: [String] = []
@@ -29,6 +34,10 @@ public struct AssociatedPhrases {
             }
             table[first] = phrases
         }
+    }
+
+    public init(text: String) {
+        self.init(lines: text.split(separator: "\n", omittingEmptySubsequences: true))
     }
 
     public init(contentsOf url: URL) throws {

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/CangjieTable.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/CangjieTable.swift
@@ -19,6 +19,7 @@ public struct CangjieTable {
     private let regexCache = RegexCache()
 
     public init(text: String) {
+        table.reserveCapacity(70_000)
         for rawLine in text.split(separator: "\n", omittingEmptySubsequences: true) {
             let line = rawLine.trimmingCharacters(in: .whitespaces)
             if line.isEmpty || line.hasPrefix("#") { continue }

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/LanguageModel.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/LanguageModel.swift
@@ -28,13 +28,14 @@ public struct LanguageModel {
     public func unigrams(forKey key: String) -> [Unigram] { table[key] ?? [] }
     public func hasKey(_ key: String) -> Bool { table[key] != nil }
 
-    /// Single-character max scores derived directly from the LM text, WITHOUT building the
-    /// full `[String: [Unigram]]` table. Streams each line once and keeps only single-character
-    /// values. Equivalent to `LanguageModel(text:).characterScores()`, but avoids the transient
-    /// ~55–80 MB table when only the character ranking is needed (the app's launch path).
-    public static func characterScores(fromText text: String) -> [Character: Double] {
+    /// Single-character max scores derived directly from already-split LM lines, WITHOUT
+    /// building the full `[String: [Unigram]]` table. Keeps only single-character values.
+    /// Callers that already have the file split into lines (e.g. to also build
+    /// `AssociatedPhrases` from the same lines) should use this to avoid re-splitting.
+    public static func characterScores(fromLines lines: [Substring]) -> [Character: Double] {
         var scores: [Character: Double] = [:]
-        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: true) {
+        scores.reserveCapacity(16_000)
+        for rawLine in lines {
             let line = rawLine.trimmingCharacters(in: .whitespaces)
             if line.isEmpty || line.hasPrefix("#") { continue }
             let parts = line.split(separator: " ")
@@ -45,6 +46,14 @@ public struct LanguageModel {
             else { scores[ch] = score }
         }
         return scores
+    }
+
+    /// Single-character max scores derived directly from the LM text, WITHOUT building the
+    /// full `[String: [Unigram]]` table. Streams each line once and keeps only single-character
+    /// values. Equivalent to `LanguageModel(text:).characterScores()`, but avoids the transient
+    /// ~55–80 MB table when only the character ranking is needed (the app's launch path).
+    public static func characterScores(fromText text: String) -> [Character: Double] {
+        characterScores(fromLines: text.split(separator: "\n", omittingEmptySubsequences: true))
     }
 
     /// Maps each single-character value to the MAX score seen for it across all

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/PinyinEngine.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/PinyinEngine.swift
@@ -7,6 +7,12 @@ import Foundation
 public final class PinyinEngine {
     /// Upper bound on syllables in one composition (keeps the per-keystroke walk cheap).
     public static let maxComposingSyllables = 24
+    /// Upper bound on the raw input length (letters + apostrophes), independent of the
+    /// syllable cap above: a run of invalid letters/apostrophes never grows `syllables`,
+    /// so without this `raw` (and the O(n) re-segment on every keystroke) would grow
+    /// unbounded. 6 is a generous per-syllable character allowance (longest real
+    /// syllable, e.g. "zhuang", is 6 letters).
+    public static let maxRawLength = maxComposingSyllables * 6
 
     private let syllableTable: PinyinSyllableTable
     private let index: TonelessLanguageModelIndex
@@ -35,6 +41,11 @@ public final class PinyinEngine {
     @discardableResult
     public func handleKey(_ key: Character) -> Bool {
         guard (key.isLetter && key.isASCII) || key == "'" else { return false }
+        // Cap: refuse further input once the raw string itself is long enough that it
+        // could not possibly still be under the syllable limit (cheap check, done before
+        // the O(n) segment below, so a run of invalid input can't keep re-segmenting an
+        // ever-growing string).
+        guard raw.count < Self.maxRawLength else { return true }
         // Cap: refuse further input once at the syllable limit (swallow the key).
         let seg = segmenter.segment(raw + String(key))
         if seg.syllables.count > Self.maxComposingSyllables { return true }
@@ -99,6 +110,7 @@ public final class PinyinEngine {
 
     // MARK: Testing hooks
     public var syllableCountForTesting: Int { nodes.reduce(0) { $0 + $1.readingRange.count } }
+    public var rawLengthForTesting: Int { raw.count }
 
     // MARK: Private
 

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/SimplexTable.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/SimplexTable.swift
@@ -14,6 +14,8 @@ public struct SimplexTable {
     /// Cangjie-code order so the grouped candidate lists are deterministic
     /// (forEachEntry's own order is unspecified).
     public init(cangjie: CangjieTable) {
+        table.reserveCapacity(700)
+        seen.reserveCapacity(700)
         var entries: [(String, [String])] = []
         cangjie.forEachEntry { code, chars in entries.append((code, chars)) }
         for (code, chars) in entries.sorted(by: { $0.0 < $1.0 }) {
@@ -28,6 +30,8 @@ public struct SimplexTable {
     /// Used for the Yahoo! KeyKey 速成 table (simplex-ext.cin), whose rows are already quick
     /// codes and whose line order is the intended candidate order.
     public init(quickCodeText: String) {
+        table.reserveCapacity(700)
+        seen.reserveCapacity(700)
         for rawLine in quickCodeText.split(separator: "\n", omittingEmptySubsequences: true) {
             let line = rawLine.trimmingCharacters(in: .whitespaces)
             if line.isEmpty || line.hasPrefix("#") { continue }
@@ -45,6 +49,8 @@ public struct SimplexTable {
 
     /// Builds the index directly from "<cangjieCode>\t<char>" lines (test fixtures).
     public init(text: String) {
+        table.reserveCapacity(700)
+        seen.reserveCapacity(700)
         for rawLine in text.split(separator: "\n", omittingEmptySubsequences: true) {
             let line = rawLine.trimmingCharacters(in: .whitespaces)
             if line.isEmpty || line.hasPrefix("#") { continue }

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/PinyinEngineTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/PinyinEngineTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import KeyKeyEngine
 
 final class PinyinEngineTests: XCTestCase {
-    private func makeEngine() -> PinyinEngine {
+    private func makeEngine(userRank: @escaping (Character) -> Double = { _ in 0 }) -> PinyinEngine {
         let table = PinyinSyllableTable(text: """
         ni\tㄋㄧ
         hao\tㄏㄠ
@@ -15,7 +15,7 @@ final class PinyinEngineTests: XCTestCase {
         ㄋㄧ-ㄏㄠ 你好 -5.0
         ㄨㄛ 我 -3.0
         """)
-        return PinyinEngine(syllableTable: table, index: index, userRank: { _ in 0 })
+        return PinyinEngine(syllableTable: table, index: index, userRank: userRank)
     }
 
     func testTypingComposesBestPath() {
@@ -94,5 +94,68 @@ final class PinyinEngineTests: XCTestCase {
         let e = makeEngine()
         for _ in 0..<50 { _ = e.handleKey("n"); _ = e.handleKey("i") }
         XCTAssertLessThanOrEqual(e.syllableCountForTesting, PinyinEngine.maxComposingSyllables)
+    }
+
+    func testRawLengthCappedOnInvalidInput() {
+        // 'x' never extends a syllable, so pre-fix this would grow `raw` (and the
+        // per-keystroke re-segment) unbounded; the guard should cap it.
+        let e = makeEngine()
+        for _ in 0..<500 { _ = e.handleKey("x") }
+        XCTAssertLessThanOrEqual(e.rawLengthForTesting, PinyinEngine.maxRawLength)
+    }
+
+    func testUserRankPromotesLearnedChar() {
+        // No userRank boost leaves 你 (-3.0) ahead of 泥 (-6.0, see testCandidatesAtCursor);
+        // boosting 泥 flips the order.
+        let e = makeEngine(userRank: { $0 == "泥" ? 10 : 0 })
+        _ = e.handleKey("n"); _ = e.handleKey("i")
+        XCTAssertEqual(e.candidates, ["泥", "你"])
+    }
+
+    func testZeroUserRankLeavesOrderUnchanged() {
+        let e = makeEngine(userRank: { _ in 0 })
+        _ = e.handleKey("n"); _ = e.handleKey("i")
+        XCTAssertEqual(e.candidates, ["你", "泥"])
+    }
+
+    func testNonLetterIgnored() {
+        let e = makeEngine()
+        XCTAssertFalse(e.handleKey("1"))
+        XCTAssertFalse(e.handleKey(" "))
+        // Audit note: unlike CangjieEngine/SimplexEngine (whose radical maps are
+        // lowercase-only), PinyinEngine's guard is `key.isLetter && key.isASCII`, which
+        // does not check case, so uppercase "A" IS accepted (returns true) -- it just
+        // never matches a syllable and surfaces in the tail.
+        XCTAssertTrue(e.handleKey("A"))
+        XCTAssertEqual(e.composingText, "A")
+    }
+
+    func testApostropheKeyAccepted() {
+        XCTAssertTrue(makeEngine().handleKey("'"))
+    }
+
+    func testSelectOutOfRangeIgnored() {
+        let e = makeEngine()
+        _ = e.handleKey("n"); _ = e.handleKey("i")
+        e.selectCandidate(9)
+        XCTAssertEqual(e.composingText, "你")
+    }
+
+    func testSelectWithNoNodeIsSafe() {
+        let e = makeEngine()
+        e.selectCandidate(0)                 // no composing nodes yet -- guarded no-op
+        XCTAssertEqual(e.composingText, "")
+    }
+
+    func testBackspaceOnEmptyIsSafe() {
+        let e = makeEngine()
+        e.backspace()
+        XCTAssertEqual(e.composingText, "")
+    }
+
+    func testCommitEmptyReturnsEmpty() {
+        let e = makeEngine()
+        XCTAssertEqual(e.commit(), "")
+        XCTAssertEqual(e.composingText, "")
     }
 }

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/PinyinSegmenterTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/PinyinSegmenterTests.swift
@@ -74,4 +74,50 @@ final class PinyinSegmenterTests: XCTestCase {
         // Both fang+an and fan+gan fully parse; longest-first from the left keeps fang+an.
         XCTAssertEqual(seg("fangan").syllables, ["fang", "an"])
     }
+
+    func testLeadingApostrophe() {
+        let r = seg("'nihao")
+        XCTAssertEqual(r.syllables, ["ni", "hao"])
+        XCTAssertEqual(r.tail, "")
+    }
+
+    func testTrailingApostrophe() {
+        let r = seg("nihao'")
+        XCTAssertEqual(r.syllables, ["ni", "hao"])
+        XCTAssertEqual(r.tail, "")
+    }
+
+    func testDoubledApostrophe() {
+        // Consecutive apostrophes behave like a single boundary (skipApostrophes
+        // advances past all of them), so "xi''an" segments exactly like "xi'an".
+        let r = seg("xi''an")
+        XCTAssertEqual(r.syllables, ["xi", "an"])
+        XCTAssertEqual(r.tail, "")
+    }
+
+    func testOnlyApostrophes() {
+        let r = seg("'''")
+        XCTAssertEqual(r.syllables, [])
+        XCTAssertEqual(r.tail, "")
+    }
+
+    func testApostropheOverridesGreedy() {
+        // Contrast with testAmbiguousStillPrefersLongestFirstWhenBothFullyParse: an
+        // explicit apostrophe forces the fan|gan boundary, blocking the "fang" reading
+        // that greedy left-to-right matching would otherwise pick for "fangan".
+        XCTAssertEqual(seg("fan'gan").syllables, ["fan", "gan"])
+    }
+
+    func testFullyInvalidInput() {
+        let r = seg("xyz")
+        XCTAssertEqual(r.syllables, [])
+        XCTAssertEqual(r.tail, "xyz")
+    }
+
+    func testVeryLongValidInputNoCrash() {
+        let long = String(repeating: "nihao", count: 16)   // 32 syllables
+        let r = seg(long)
+        XCTAssertEqual(r.syllables.count, 32)
+        XCTAssertEqual(r.tail, "")
+    }
 }

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/RealSimplexTableTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/RealSimplexTableTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import KeyKeyEngine
+
+// Runs only when Resources/cangjie.txt is present (the bundled real Cangjie 5 table).
+// The shipped Simplex table has no dedicated resource file -- like SharedResources.swift,
+// it's derived from the real Cangjie table via SimplexTable(cangjie:).
+final class RealSimplexTableTests: XCTestCase {
+    private func tableURL() -> URL? {
+        var dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        for _ in 0..<8 {
+            let candidate = dir.appendingPathComponent("Resources/cangjie.txt")
+            if FileManager.default.fileExists(atPath: candidate.path) { return candidate }
+            dir = dir.deletingLastPathComponent()
+        }
+        return nil
+    }
+
+    func testRealTableDerivesAndLooksUpCommonCharacters() throws {
+        guard let url = tableURL() else {
+            throw XCTSkip("Resources/cangjie.txt not present")
+        }
+        let cangjie = try CangjieTable(contentsOf: url)
+        let simplex = SimplexTable(cangjie: cangjie)
+        // 日 is encoded by a single "a" radical -> simplex "a"; 明 by "ab" (日月) -> simplex "ab".
+        XCTAssertTrue(simplex.characters(forCode: "a").contains("日"))
+        XCTAssertTrue(simplex.characters(forCode: "ab").contains("明"))
+    }
+}


### PR DESCRIPTION
## v2.6.4 — startup/memory trimming, 拼音 robustness, engine test parity

Performance and robustness follow-up to 2.6.3. No user-visible behavior change to what you type.

### Optimizations (O2)
- **Single-pass `data.txt` load.** Launch previously did two independent full tokenizing passes over the 7.2 MB / 163k-line LM (one for the character ranking, one for associated phrases). Now split once and feed both — new line-based entry points (`LanguageModel.characterScores(fromLines:)`, `AssociatedPhrases(lines:)`), with the old `fromText:`/`text:` APIs delegating so existing callers/tests are untouched.
- **Lazy `速成` (Simplex) table + `反查/拆碼提示` reverse index.** Both were built eagerly at launch; now built on first use behind an `NSLock` (mirroring `RefCountedResource`) and invalidated on a 倉頡版本 change. Cangjie-only / 拼音-only users no longer pay for either at startup.
- **`reserveCapacity`** on the large launch-built dictionaries, sized to measured key counts.

### Hardening (B3)
- **拼音 raw-input cap.** The composition cap only bounded valid syllables; a run of invalid letters grew `raw` unbounded and re-segmented O(n) every keystroke. Added `maxRawLength` guarded *before* the segment call.

### Tests (O4 + B3)
- 拼音 engine parity with 倉頡/速成: userRank reranking, non-letter/out-of-range/backspace-empty/commit-empty guards, apostrophe-key acceptance, raw-length cap.
- Apostrophe & ambiguous-segmentation edge cases (leading/trailing/doubled apostrophe, `fan'gan`, fully-invalid input, long input).
- New real-data Simplex table test.
- **177 engine tests pass** (was 159). `tools/build-app.sh` builds and signs cleanly at 2.6.4.

### Note
One audit prediction was corrected during implementation: `PinyinEngine.handleKey("A")` (uppercase) is *accepted*, not rejected — the guard is `key.isLetter && key.isASCII` with no case check. The test asserts the real behavior with an explanatory comment.

Not included (deferred by decision): F4 (restore 注音/Phonetic engines — were deliberately deleted) and O1 (Liquid Glass Settings polish — lives in shared DragonKit, affects all three apps). F5 needed no work (dead Yahoo backends were never ported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
