### PR TITLE
test: add App-logic test suite + engine coverage top-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 Packages/KeyKeyEngine/.build/
+Packages/KeyKeyApp/.build/
 
 Resources/data.txt
 .lm-build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 A plain-language list of changes in each version, newest first.
 
+## Unreleased
+
+- **More automated tests, no behavior change.** Added 32 test cases (bringing the total to 209),
+  raising region test coverage of the input engine to **92%** and adding a new **91%**-covered
+  test suite for the app's settings and screen-content logic. New coverage includes: candidate
+  font-size clamping and preference persistence (`Preferences`), the 速成 (Simplex) quick-code
+  table loader, user-frequency file handling and save-failure safety, the 反查／拆碼提示
+  reverse-lookup index, best-path walker edge cases, the input-method engine protocol contract,
+  and the About / What's New content. Nothing you type changes — this only guards against future
+  regressions.
+
 ## 2.6.4
 
 - **Starts up even faster and lighter.** At launch, Yahoo KeyKey 2 now reads its dictionary file

--- a/Packages/KeyKeyApp/Package.resolved
+++ b/Packages/KeyKeyApp/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "c1793bbc1ebba8ffd64047357e2c12f03677d026367c2c5fee64546bd1e950cb",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Packages/KeyKeyApp/Package.swift
+++ b/Packages/KeyKeyApp/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:6.2
+import PackageDescription
+
+// Test-only harness for the App's dependency-light, non-UI logic (Preferences, the
+// InputEngine protocol conformances, and the About/What's New content builders). The files
+// under Sources/KeyKeyApp are SYMLINKS to the real App/ sources (SwiftPM cannot reference a
+// path outside the package root), so there is no copy to drift. The release app is still
+// built by tools/build-app.sh with swiftc; this package is never part of that path.
+let package = Package(
+    name: "KeyKeyApp",
+    platforms: [.macOS(.v26)],
+    products: [.library(name: "KeyKeyApp", targets: ["KeyKeyApp"])],
+    dependencies: [
+        .package(path: "../KeyKeyEngine"),
+        .package(path: "../../vendor/dragon-kit"),
+    ],
+    targets: [
+        .target(
+            name: "KeyKeyApp",
+            dependencies: [
+                "KeyKeyEngine",
+                .product(name: "DragonKit", package: "dragon-kit"),
+            ]
+        ),
+        .testTarget(name: "KeyKeyAppTests", dependencies: ["KeyKeyApp"]),
+    ],
+    swiftLanguageModes: [.v5]
+)

--- a/Packages/KeyKeyApp/Sources/KeyKeyApp/AboutConfig.swift
+++ b/Packages/KeyKeyApp/Sources/KeyKeyApp/AboutConfig.swift
@@ -1,0 +1,1 @@
+../../../../App/AboutConfig.swift

--- a/Packages/KeyKeyApp/Sources/KeyKeyApp/InputEngine.swift
+++ b/Packages/KeyKeyApp/Sources/KeyKeyApp/InputEngine.swift
@@ -1,0 +1,1 @@
+../../../../App/InputEngine.swift

--- a/Packages/KeyKeyApp/Sources/KeyKeyApp/Preferences.swift
+++ b/Packages/KeyKeyApp/Sources/KeyKeyApp/Preferences.swift
@@ -1,0 +1,1 @@
+../../../../App/Preferences.swift

--- a/Packages/KeyKeyApp/Sources/KeyKeyApp/WhatsNewConfig.swift
+++ b/Packages/KeyKeyApp/Sources/KeyKeyApp/WhatsNewConfig.swift
@@ -1,0 +1,1 @@
+../../../../App/WhatsNewConfig.swift

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+import DragonKit
+@testable import KeyKeyApp
+
+// Covers the About-pane and What's-New content builders. These assemble DragonKit content
+// structs from static data; the tests assert the structure (names, links, credits, version,
+// change sections) rather than localized strings, which vary with the runtime bundle.
+final class ConfigContentTests: XCTestCase {
+
+    // MARK: AboutConfig
+
+    @MainActor
+    func testAboutAppNameIsReleaseNameOutsideDebugBuild() {
+        // The test bundle id does not end in ".debug", so no " Debug" suffix is appended.
+        XCTAssertEqual(AboutConfig.appName, "Yahoo! KeyKey 2")
+    }
+
+    @MainActor
+    func testAboutVersionStringIsFormatted() {
+        XCTAssertTrue(AboutConfig.versionString.hasPrefix("v"))
+    }
+
+    @MainActor
+    func testAboutContentStructure() {
+        let content = AboutConfig.content
+        XCTAssertEqual(content.appName, "Yahoo! KeyKey 2")
+        XCTAssertEqual(content.copyright, "倉頡／簡易 輸入法")
+        XCTAssertEqual(content.links.count, 3)
+        XCTAssertEqual(content.credits.count, 4)
+        // Every link carries a resolvable https URL and an SF Symbol name.
+        for link in content.links {
+            XCTAssertEqual(link.url.scheme, "https")
+            XCTAssertFalse(link.systemImage.isEmpty)
+        }
+        XCTAssertEqual(content.links.map(\.detail),
+                       ["www.dragonapp.com/keykey", "teddychan/yahoo-keykey-2", "ninjapanda/YahooKeyKey"])
+    }
+
+    // MARK: WhatsNewConfig
+
+    @MainActor
+    func testWhatsNewVersionMatchesCurrentRelease() {
+        let content = WhatsNewConfig.content
+        XCTAssertEqual(content.version, "2.6.4")
+        XCTAssertEqual(content.date, "2026-07-10")
+    }
+
+    @MainActor
+    func testWhatsNewHasSingleChangedSectionWithTwoEntries() {
+        let content = WhatsNewConfig.content
+        XCTAssertEqual(content.sections.count, 1)
+        let section = content.sections[0]
+        XCTAssertEqual(section.kind, .changed)
+        XCTAssertEqual(section.entries.count, 2)
+    }
+}

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/InputEngineConformanceTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/InputEngineConformanceTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import KeyKeyEngine
+@testable import KeyKeyApp
+
+// Locks the App-internal InputEngine / PhraseComposingEngine contract that InputController's
+// handle() relies on: which concrete engines conform, and that driving them purely through the
+// protocol surface (handleKey → candidates → selectCandidate → commit, plus cursor movement)
+// behaves as the controller expects.
+final class InputEngineConformanceTests: XCTestCase {
+    // a=日, ab=明 — enough to exercise multi-key accumulation and candidate selection.
+    private func makeCangjie() -> CangjieEngine {
+        CangjieEngine(table: CangjieTable(text: """
+        a\t日
+        a\t曰
+        ab\t明
+        """))
+    }
+
+    private func makePinyin() -> PinyinEngine {
+        let table = PinyinSyllableTable(text: """
+        ni\tㄋㄧ
+        hao\tㄏㄠ
+        wo\tㄨㄛ
+        """)
+        let index = TonelessLanguageModelIndex(text: """
+        ㄋㄧ 你 -3.0
+        ㄏㄠ 好 -3.0
+        ㄋㄧ-ㄏㄠ 你好 -5.0
+        ㄨㄛ 我 -3.0
+        """)
+        return PinyinEngine(syllableTable: table, index: index)
+    }
+
+    func testConcreteEnginesConformToInputEngine() {
+        XCTAssertTrue((makeCangjie() as Any) is InputEngine)
+        XCTAssertTrue((SimplexEngine(table: SimplexTable(text: "a\t日\n")) as Any) is InputEngine)
+        XCTAssertTrue((makePinyin() as Any) is InputEngine)
+    }
+
+    func testOnlyPinyinIsPhraseComposing() {
+        XCTAssertTrue((makePinyin() as Any) is PhraseComposingEngine)
+        XCTAssertFalse((makeCangjie() as Any) is PhraseComposingEngine)
+        XCTAssertFalse((SimplexEngine(table: SimplexTable(text: "a\t日\n")) as Any) is PhraseComposingEngine)
+    }
+
+    func testDrivingCangjieThroughProtocol() {
+        let engine: InputEngine = makeCangjie()
+        XCTAssertTrue(engine.handleKey("a"))
+        XCTAssertTrue(engine.handleKey("b"))
+        XCTAssertEqual(engine.composingText, "日月")
+        XCTAssertEqual(engine.candidates, ["明"])
+        engine.selectCandidate(0)
+        XCTAssertEqual(engine.commit(), "明")
+        // commit() resets composition
+        XCTAssertEqual(engine.composingText, "")
+    }
+
+    func testProtocolBackspaceAndOutOfRangeSelectAreSafe() {
+        let engine: InputEngine = makeCangjie()
+        _ = engine.handleKey("a")
+        _ = engine.handleKey("b")
+        engine.selectCandidate(999)          // out of range: no-op, no crash
+        engine.backspace()                   // deletes within composition
+        XCTAssertEqual(engine.composingText, "日")
+    }
+
+    func testDrivingPinyinThroughPhraseComposingProtocol() {
+        let engine: PhraseComposingEngine = makePinyin()
+        // "woni" segments into two single-char nodes (我 你); there is no 我你 phrase to merge them.
+        for c in "woni" { _ = engine.handleKey(c) }
+        XCTAssertEqual(engine.composingText, "我你")
+        // Cursor starts on the first node; left is a no-op, right advances to the second node.
+        XCTAssertEqual(engine.cursorReading, "wo")
+        XCTAssertFalse(engine.moveCursorLeft())      // already at first node
+        XCTAssertTrue(engine.moveCursorRight())
+        XCTAssertEqual(engine.cursorReading, "ni")
+        XCTAssertFalse(engine.moveCursorRight())     // already at last node
+        XCTAssertEqual(engine.commit(), "我你")
+    }
+}

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/PreferencesTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/PreferencesTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+@testable import KeyKeyApp
+
+// Covers Preferences (typed UserDefaults accessors + clamping) and the CangjieVersion enum.
+// Each test writes explicit values into UserDefaults.standard (the domain Preferences reads),
+// so ordering between tests does not matter.
+final class PreferencesTests: XCTestCase {
+    private let defaults = UserDefaults.standard
+
+    override func tearDown() {
+        for key in ["candidateFontSize", "associatedPhrasesEnabled", "fullWidthPunctuationEnabled",
+                    "outputSimplifiedEnabled", "cangjieVersion", "associationContinuationOnly",
+                    "codeHintEnabled"] {
+            defaults.removeObject(forKey: key)
+        }
+        super.tearDown()
+    }
+
+    // MARK: candidateFontSize clamping
+
+    func testFontSizeGetterClampsBelowMin() {
+        defaults.set(5.0, forKey: "candidateFontSize")       // raw, below min
+        XCTAssertEqual(Preferences.candidateFontSize, 14)    // clamped up to minFontSize
+    }
+
+    func testFontSizeGetterClampsAboveMax() {
+        defaults.set(40.0, forKey: "candidateFontSize")      // raw, above max
+        XCTAssertEqual(Preferences.candidateFontSize, 28)    // clamped down to maxFontSize
+    }
+
+    func testFontSizeGetterPreservesInRange() {
+        defaults.set(20.0, forKey: "candidateFontSize")
+        XCTAssertEqual(Preferences.candidateFontSize, 20)
+    }
+
+    func testFontSizeSetterClampsBothEnds() {
+        Preferences.candidateFontSize = 100                  // setter clamps before storing
+        XCTAssertEqual(defaults.double(forKey: "candidateFontSize"), 28)
+        Preferences.candidateFontSize = 1
+        XCTAssertEqual(defaults.double(forKey: "candidateFontSize"), 14)
+    }
+
+    func testFontSizeConstants() {
+        XCTAssertEqual(Preferences.minFontSize, 14)
+        XCTAssertEqual(Preferences.maxFontSize, 28)
+        XCTAssertEqual(Preferences.defaultFontSize, 18)
+    }
+
+    // MARK: bool accessors round-trip
+
+    func testBoolAccessorsRoundTrip() {
+        Preferences.associatedPhrasesEnabled = true
+        XCTAssertTrue(Preferences.associatedPhrasesEnabled)
+        Preferences.associatedPhrasesEnabled = false
+        XCTAssertFalse(Preferences.associatedPhrasesEnabled)
+
+        Preferences.fullWidthPunctuationEnabled = true
+        XCTAssertTrue(Preferences.fullWidthPunctuationEnabled)
+        Preferences.fullWidthPunctuationEnabled = false
+        XCTAssertFalse(Preferences.fullWidthPunctuationEnabled)
+
+        Preferences.outputSimplifiedEnabled = true
+        XCTAssertTrue(Preferences.outputSimplifiedEnabled)
+        Preferences.outputSimplifiedEnabled = false
+        XCTAssertFalse(Preferences.outputSimplifiedEnabled)
+
+        Preferences.associationContinuationOnly = true
+        XCTAssertTrue(Preferences.associationContinuationOnly)
+        Preferences.associationContinuationOnly = false
+        XCTAssertFalse(Preferences.associationContinuationOnly)
+
+        Preferences.codeHintEnabled = true
+        XCTAssertTrue(Preferences.codeHintEnabled)
+        Preferences.codeHintEnabled = false
+        XCTAssertFalse(Preferences.codeHintEnabled)
+    }
+
+    // MARK: cangjieVersion
+
+    func testCangjieVersionRoundTrip() {
+        Preferences.cangjieVersion = .v3
+        XCTAssertEqual(Preferences.cangjieVersion, .v3)
+        Preferences.cangjieVersion = .v5
+        XCTAssertEqual(Preferences.cangjieVersion, .v5)
+    }
+
+    func testCangjieVersionUnknownRawFallsBackToV5() {
+        defaults.set("99", forKey: "cangjieVersion")         // not a valid case
+        XCTAssertEqual(Preferences.cangjieVersion, .v5)
+    }
+
+    func testCangjieVersionAbsentFallsBackToV5() {
+        defaults.removeObject(forKey: "cangjieVersion")
+        XCTAssertEqual(Preferences.cangjieVersion, .v5)
+    }
+
+    // MARK: registerDefaults
+
+    func testRegisterDefaultsSuppliesSensibleFirstLaunchValues() {
+        for key in ["candidateFontSize", "associatedPhrasesEnabled", "fullWidthPunctuationEnabled",
+                    "outputSimplifiedEnabled", "cangjieVersion", "associationContinuationOnly",
+                    "codeHintEnabled"] {
+            defaults.removeObject(forKey: key)
+        }
+        Preferences.registerDefaults()
+        XCTAssertTrue(Preferences.associatedPhrasesEnabled)
+        XCTAssertTrue(Preferences.fullWidthPunctuationEnabled)
+        XCTAssertFalse(Preferences.outputSimplifiedEnabled)
+        XCTAssertFalse(Preferences.associationContinuationOnly)
+        XCTAssertFalse(Preferences.codeHintEnabled)
+        XCTAssertEqual(Preferences.cangjieVersion, .v5)
+        XCTAssertEqual(Preferences.candidateFontSize, 18)    // defaultFontSize
+    }
+
+    // MARK: CangjieVersion enum
+
+    func testCangjieVersionRawValues() {
+        XCTAssertEqual(CangjieVersion.v5.rawValue, "5")
+        XCTAssertEqual(CangjieVersion.v3.rawValue, "3")
+    }
+
+    func testCangjieVersionInitFromRawValue() {
+        XCTAssertEqual(CangjieVersion(rawValue: "5"), .v5)
+        XCTAssertEqual(CangjieVersion(rawValue: "3"), .v3)
+        XCTAssertNil(CangjieVersion(rawValue: "x"))
+    }
+}

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/CangjieCodeIndexTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/CangjieCodeIndexTests.swift
@@ -33,6 +33,18 @@ final class CangjieCodeIndexTests: XCTestCase {
         XCTAssertEqual(Self.index.codeGlyphs(for: "倉"), "人口竹口")
     }
 
+    func testMultiCharacterCandidatesAreSkipped() {
+        // A code mapping to a multi-character string (a phrase) is not a single-glyph entry,
+        // so it must be ignored — only single characters get a 反查 code.
+        let t = CangjieTable(text: """
+        a\t日
+        abc\t你好
+        """)
+        let idx = CangjieCodeIndex(table: t)
+        XCTAssertEqual(idx.codeGlyphs(for: "日"), "日")   // single char indexed
+        XCTAssertNil(idx.codeGlyphs(for: "你"))           // phrase entry skipped entirely
+    }
+
     func testTieBreakIsLexicographicForEqualLength() {
         // Two equal-length codes for the same char: the lexicographically smaller wins.
         let t = CangjieTable(text: """

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/SimplexTableTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/SimplexTableTests.swift
@@ -58,4 +58,56 @@ final class SimplexTableTests: XCTestCase {
         """)
         XCTAssertEqual(t.characters(forCode: "ab"), ["明"])
     }
+
+    // MARK: quickCodeText (Yahoo! 速成 table — codes already quick, native order kept)
+
+    func testQuickCodeTextKeepsNativeCodeAndOrder() {
+        // Codes are used verbatim (no first+last re-derivation) and per-code order is preserved.
+        let t = SimplexTable(quickCodeText: """
+        ab\t明
+        ab\t昌
+        a\t日
+        """)
+        XCTAssertEqual(t.characters(forCode: "ab"), ["明", "昌"])
+        XCTAssertEqual(t.characters(forCode: "a"), ["日"])
+    }
+
+    func testQuickCodeTextSkipsCommentsBlankAndMalformedLines() {
+        let t = SimplexTable(quickCodeText: """
+        # a comment line
+
+        ab\t明
+        malformed-no-tab
+        \t孤
+        ac\t冒
+        """)
+        XCTAssertEqual(t.characters(forCode: "ab"), ["明"])
+        XCTAssertEqual(t.characters(forCode: "ac"), ["冒"])
+        // The empty-code row ("\t孤") is dropped.
+        XCTAssertEqual(t.characters(forCode: ""), [])
+    }
+
+    func testInitFromQuickCodeContentsOfURL() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("SimplexTableTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("simplex-ext.cin")
+        try "ab\t明\nab\t昌\n".write(to: url, atomically: true, encoding: .utf8)
+
+        let t = try SimplexTable(quickCodeContentsOf: url)
+        XCTAssertEqual(t.characters(forCode: "ab"), ["明", "昌"])
+    }
+
+    func testInitFromTextSkipsCommentsBlankAndMalformedLines() {
+        let t = SimplexTable(text: """
+        # comment
+
+        ab\t明
+        no-tab-here
+        abc\t冒
+        """)
+        XCTAssertEqual(t.characters(forCode: "ab"), ["明"])
+        XCTAssertEqual(t.characters(forCode: "ac"), ["冒"])
+    }
 }

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/UserFrequencyTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/UserFrequencyTests.swift
@@ -147,6 +147,22 @@ final class UserFrequencyTests: XCTestCase {
         XCTAssertEqual(perms, 0o700)
     }
 
+    func testDefaultFileURLPointsAtAppSupport() {
+        let url = UserFrequency.defaultFileURL()
+        XCTAssertEqual(url.lastPathComponent, "user-frequency.json")
+        XCTAssertEqual(url.deletingLastPathComponent().lastPathComponent, "YahooKeyKey2")
+    }
+
+    func testFlushToUnwritableLocationDoesNotCrash() {
+        // A path under a regular file (not a directory) can't have its parent dir created, so
+        // save() hits its catch branch. The failure must be swallowed — no crash, no throw.
+        let unwritable = URL(fileURLWithPath: "/dev/null/nope/user-frequency.json")
+        let uf = UserFrequency(fileURL: unwritable)   // load also fails safe -> empty
+        uf.record("好")
+        uf.flush()                                    // save fails internally; logged, not fatal
+        XCTAssertGreaterThan(uf.bonus(for: "好"), 0)   // in-memory count still intact
+    }
+
     func testSingleCountIsCapped() {
         // bonus saturates: recording past the cap doesn't keep growing the count.
         let uf = UserFrequency(fileURL: fileURL)

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/WalkerTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/WalkerTests.swift
@@ -66,6 +66,25 @@ final class WalkerTests: XCTestCase {
 }
 
 extension WalkerTests {
+    // MARK: WalkNode.chosenText
+
+    func testChosenTextReturnsSelectedCandidate() {
+        let node = WalkNode(readingRange: 0..<1, candidates: ["你", "泥"], chosenIndex: 1)
+        XCTAssertEqual(node.chosenText, "泥")
+    }
+
+    func testChosenTextFallsBackToFirstWhenIndexOutOfRange() {
+        let high = WalkNode(readingRange: 0..<1, candidates: ["你", "泥"], chosenIndex: 5)
+        XCTAssertEqual(high.chosenText, "你")     // out of upper bound -> first
+        let negative = WalkNode(readingRange: 0..<1, candidates: ["你", "泥"], chosenIndex: -1)
+        XCTAssertEqual(negative.chosenText, "你")  // negative -> first
+    }
+
+    func testChosenTextIsEmptyWhenNoCandidates() {
+        let node = WalkNode(readingRange: 0..<1, candidates: [], chosenIndex: 0)
+        XCTAssertEqual(node.chosenText, "")
+    }
+
     func testLongInputCompletesQuickly() {
         let walker = Walker(index: index())
         let readings = Array(repeating: "ㄋㄧ", count: 24)


### PR DESCRIPTION
## Summary
Increases automated test coverage. No behavior change, no release.

- **Test cases:** 177 → **209** (+32: 10 engine, 22 new App-logic).
- **Coverage (region):**
  - `KeyKeyEngine`: 90.93% → **92.44%**
  - New `KeyKeyApp` test package: **91.30%**

## What changed
- **New `Packages/KeyKeyApp` test-only package** compiling the dependency-light App logic via **symlinks** to the real `App/` sources (SwiftPM can't reference paths outside a package root), so there's no copy to drift. The release build (`tools/build-app.sh`, plain `swiftc`) is untouched.
  - `PreferencesTests` (font-size clamping, preference persistence, `CangjieVersion` fallback, `registerDefaults`)
  - `InputEngineConformanceTests` (protocol conformances + driving engines through the protocol)
  - `ConfigContentTests` (About / What's New content)
- **Engine top-ups** in existing suites: `Walker` (`WalkNode.chosenText` edges), `SimplexTable` (untested `quickCodeText:`/`quickCodeContentsOf:` inits + guards), `UserFrequency` (`defaultFileURL()` + save-failure path), `CangjieCodeIndex` (multi-char candidate skip).
- CHANGELOG **Unreleased** section documents the additions; `.gitignore` covers the new package's `.build/`.

## Notes
- The `KeyKeyApp` test package depends on the vendored `DragonKit` checkout (`vendor/`, gitignored, cloned by `build-app.sh`), so `swift test` there needs that present.
- There is no CI test job in this repo (only `release.yml` on tag); tests run via `swift test` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)