### PR TITLE
ci: run engine + App-logic tests on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: Tests
+
+# Runs the unit-test suites on every PR to main (and pushes to main). Build/release stays in
+# release.yml — this job never signs, notarizes, or releases anything.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    # macOS 26 image: same runner the release build targets (macOS 26 SDK, Swift 6.2).
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Swift version
+        run: swift --version
+
+      # KeyKeyEngine has no external dependencies — it tests standalone.
+      - name: Engine tests (KeyKeyEngine)
+        run: swift test --package-path Packages/KeyKeyEngine
+
+      # The App-logic package depends on the pinned DragonKit checkout (vendor/ is gitignored,
+      # cloned on demand). Read the SAME tag build-app.sh pins so CI never drifts from release.
+      - name: Vendor DragonKit
+        run: |
+          TAG=$(grep -oE 'DRAGONKIT_TAG="[^"]+"' tools/build-app.sh | head -1 | cut -d'"' -f2)
+          echo "Cloning DragonKit $TAG"
+          git clone --depth 1 --branch "$TAG" https://github.com/teddychan/dragon-kit vendor/dragon-kit
+
+      - name: App-logic tests (KeyKeyApp)
+        run: swift test --package-path Packages/KeyKeyApp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ A plain-language list of changes in each version, newest first.
   font-size clamping and preference persistence (`Preferences`), the 速成 (Simplex) quick-code
   table loader, user-frequency file handling and save-failure safety, the 反查／拆碼提示
   reverse-lookup index, best-path walker edge cases, the input-method engine protocol contract,
-  and the About / What's New content. Nothing you type changes — this only guards against future
-  regressions.
+  and the About / What's New content. Both test suites now run automatically in CI on every
+  pull request. Nothing you type changes — this only guards against future regressions.
 
 ## 2.6.4
 


### PR DESCRIPTION
## Summary
Adds a CI test workflow so the unit suites run automatically — the repo previously had no test job (only `release.yml` on tag).

`.github/workflows/tests.yml` runs on **PRs to `main`** (and pushes to `main`, plus manual dispatch) on the `macos-26` runner:
1. `swift test` for **KeyKeyEngine** (no external deps).
2. Clones the **pinned DragonKit tag read from `tools/build-app.sh`** (so CI never drifts from the release build), then `swift test` for **KeyKeyApp**.

No signing, notarization, or release — that stays in `release.yml`. CHANGELOG's Unreleased note now mentions the suites run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)