### PR TITLE
ci: bump actions/checkout to v7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     # macOS 26 image: same runner the release build targets (macOS 26 SDK, Swift 6.2).
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Swift version
         run: swift --version


### PR DESCRIPTION
Bumps `actions/checkout` from `v4` to **`v7`** (current latest release) in `tests.yml`.

Also clears the "Node.js 20 is deprecated" annotation that `v4` produced on the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)