### PR TITLE
docs: fix install guide — releases ship .zip, not .pkg (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ A plain-language list of changes in each version, newest first.
 
 ## Unreleased
 
+- **Corrected the install instructions.** Releases ship a `.zip` (not a `.pkg`), so the
+  README and the `Install.txt` inside the download now tell you to unzip and move
+  `YahooKeyKey2.app` into `~/Library/Input Methods/` yourself — or just use Homebrew.
+  No app behavior changes; documentation only.
 - **More automated tests, no behavior change.** Added 32 test cases (bringing the total to 209),
   raising region test coverage of the input engine to **92%** and adding a new **91%**-covered
   test suite for the app's settings and screen-content logic. New coverage includes: candidate

--- a/README.md
+++ b/README.md
@@ -56,22 +56,24 @@ never open-sourced — so associations use Yahoo KeyKey 2's own ordering in both
 
 ## Install
 
-### Installer (`.pkg`)
-
-1. Download `YahooKeyKey2.pkg` from the [latest release](https://github.com/teddychan/yahoo-keykey-2/releases/latest)
-   and double-click it. It installs to `~/Library/Input Methods` without admin rights.
-2. Log out and back in when prompted.
-3. Add the input source: **System Settings ▸ Keyboard ▸ Input Sources ▸ + ▸ Traditional Chinese**
-   → add **倉頡** and/or **速成**.
-4. Press **Ctrl-Space** to switch to Yahoo KeyKey 2 and start typing.
-
-### Homebrew
+### Homebrew (recommended)
 
 ```sh
 brew install --cask teddychan/tap/yahoo-keykey-2
 ```
 
-Then log out and back in to load the input method.
+Then log out and back in to load the input method, and continue from step 4 below.
+
+### Manual (`.zip`)
+
+1. Download `YahooKeyKey2-<version>.zip` from the [latest release](https://github.com/teddychan/yahoo-keykey-2/releases/latest)
+   and unzip it.
+2. Move `YahooKeyKey2.app` into `~/Library/Input Methods/` (create the folder if it
+   does not exist). No admin rights needed.
+3. Log out and back in — macOS only scans input methods at login.
+4. Add the input source: **System Settings ▸ Keyboard ▸ Input Sources ▸ + ▸ Traditional Chinese**
+   → add **倉頡** and/or **速成**.
+5. Press **Ctrl-Space** to switch to Yahoo KeyKey 2 and start typing.
 
 ## Credits
 

--- a/tools/package-release.sh
+++ b/tools/package-release.sh
@@ -103,7 +103,7 @@ fi
 # Stage a clean directory holding the app and a plain-text install guide, then
 # zip its CONTENTS at the archive root. The same zip is BOTH the user download
 # and the Sparkle update payload — Sparkle locates YahooKeyKey2.app inside it,
-# the extra Install.txt is ignored. (No DMG: the release ships .pkg + .zip only.)
+# the extra Install.txt is ignored. (No DMG/.pkg: the release ships the .zip only.)
 echo "==> Staging zip contents (app + Install.txt)"
 STAGE="$BUILD/zip-stage"
 rm -rf "$STAGE"
@@ -113,12 +113,11 @@ cp -R "$APP" "$STAGE/$APP_NAME"
 cat > "$STAGE/Install.txt" <<EOF
 Yahoo KeyKey 2 — Install
 
-The easiest way is the .pkg installer (double-click and click through; no admin
-password). To install from this zip manually instead:
+Install from this zip by copying the app into your Input Methods folder:
 
 1. Copy "YahooKeyKey2.app" into your Input Methods folder:
        ~/Library/Input Methods/
-   (Create the folder if it does not exist.)
+   (Create the folder if it does not exist. No admin password needed.)
 
 2. Log out and log back in. macOS only scans input methods at login.
 


### PR DESCRIPTION
## Summary

Fixes #54. Releases ship a `.zip` (containing `YahooKeyKey2.app` + `Install.txt`) only — the legacy `.pkg` installer is no longer produced or uploaded (confirmed: v2.6.4 ships only `YahooKeyKey2-2.6.4.zip`). The install docs still told users to download and double-click a `.pkg`.

Fixed with the reporter's **option 1** (align docs with the zip-only release design), since Homebrew and Sparkle both consume the `.zip`.

## Changes

- **README.md** — replaced the `Installer (.pkg)` section with **Homebrew (recommended)** + a **Manual (`.zip`)** flow: unzip → move `YahooKeyKey2.app` into `~/Library/Input Methods/` → log out/in → add input source.
- **tools/package-release.sh** — dropped the "easiest way is the .pkg" line from the local-build `Install.txt`; corrected a stale "ships .pkg + .zip" comment.
- **CHANGELOG.md** — noted the doc correction under *Unreleased*.

## Companion change (separate repo)

The `Install.txt` that actually ships inside the release zip is generated by CI in **`teddychan/dragon-release-ci`** (`release-macos.yml`). That "easiest way is the .pkg installer" line is fixed in a separate PR there — without it, the next release zip would still carry the wrong instructions.

## Out of scope

`docs/RELEASE.md` and `tools/package-installer.sh` still document a legacy local `.pkg` build flow. That tooling still works locally, so it was left as-is (per issue scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)