### PR TITLE
fix: pass ⌘/⌃ shortcuts through to the app instead of eating them (#56)

### DIFF
--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -233,6 +233,12 @@ final class InputController: IMKInputController {
     override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
         guard let event, event.type == .keyDown, let client = sender as? IMKTextInput else { return false }
 
+        // ⌘/⌃ combinations (⌘C copy, ⌘X cut, ⌘V paste, ⌃A …) are app/system shortcuts, never IME
+        // input, so hand them straight back to the app. Without this the engine would treat ⌘C's
+        // base letter "c" as the radical 金 and swallow the copy (issue #56); it also stops ⌘/⌃
+        // with Space/Return/arrows from being eaten by the paging/commit branches below.
+        if KeyEventPolicy.isSystemShortcut(event.modifierFlags) { return false }
+
         // 臨時英數 (quick English), classic Yahoo! KeyKey style: Shift + a letter (and no other
         // modifier) emits that English letter directly. Case follows CAPS LOCK, not Shift — Shift
         // is only the trigger — so it's lowercase with Caps off, uppercase with Caps on. Any

--- a/App/KeyEventPolicy.swift
+++ b/App/KeyEventPolicy.swift
@@ -1,0 +1,15 @@
+import AppKit
+
+// Pure key-event routing decisions for InputController, kept free of IMK/engine state so they
+// can be unit-tested. See InputController.handle(_:client:).
+enum KeyEventPolicy {
+    /// Whether a keyDown carrying these modifiers is an app/system shortcut the IME must not
+    /// touch. ⌘ and ⌃ combinations (⌘C copy, ⌘X cut, ⌘V paste, ⌃A line-start, …) belong to the
+    /// app: for a ⌘ combination `NSEvent.characters` is the plain base letter, so without this
+    /// guard the engine would treat ⌘C as the radical "c" and swallow the copy (issue #56).
+    /// ⇧ (臨時英數) and ⌥ stay with the IME — ⌥ combos produce non-a–z characters the engine
+    /// already rejects.
+    static func isSystemShortcut(_ flags: NSEvent.ModifierFlags) -> Bool {
+        !flags.intersection([.command, .control]).isEmpty
+    }
+}

--- a/Packages/KeyKeyApp/Sources/KeyKeyApp/KeyEventPolicy.swift
+++ b/Packages/KeyKeyApp/Sources/KeyKeyApp/KeyEventPolicy.swift
@@ -1,0 +1,1 @@
+../../../../App/KeyEventPolicy.swift

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/KeyEventPolicyTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/KeyEventPolicyTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+import AppKit
+@testable import KeyKeyApp
+
+// Locks issue #56: ⌘/⌃ combinations (⌘C copy, ⌘X cut, ⌘V paste, ⌃A …) are app/system
+// shortcuts, never IME input. InputController.handle() must let the app process them instead
+// of feeding the base letter to the engine (which would turn ⌘C into the radical "c" / 金 and
+// swallow the copy). KeyEventPolicy is the pure decision it consults.
+final class KeyEventPolicyTests: XCTestCase {
+    func testCommandCombinationsAreSystemShortcuts() {
+        XCTAssertTrue(KeyEventPolicy.isSystemShortcut([.command]))                 // ⌘C / ⌘X / ⌘V
+        XCTAssertTrue(KeyEventPolicy.isSystemShortcut([.command, .shift]))         // ⌘⇧S
+        XCTAssertTrue(KeyEventPolicy.isSystemShortcut([.command, .option]))        // ⌘⌥…
+    }
+
+    func testControlCombinationsAreSystemShortcuts() {
+        XCTAssertTrue(KeyEventPolicy.isSystemShortcut([.control]))                 // ⌃A / ⌃E …
+        XCTAssertTrue(KeyEventPolicy.isSystemShortcut([.control, .command]))
+    }
+
+    func testImeRelevantModifiersAreNotSystemShortcuts() {
+        // ⇧+letter (臨時英數) and plain/⌥ typing stay with the IME.
+        XCTAssertFalse(KeyEventPolicy.isSystemShortcut([]))
+        XCTAssertFalse(KeyEventPolicy.isSystemShortcut([.shift]))
+        XCTAssertFalse(KeyEventPolicy.isSystemShortcut([.capsLock]))
+        XCTAssertFalse(KeyEventPolicy.isSystemShortcut([.option]))
+        XCTAssertFalse(KeyEventPolicy.isSystemShortcut([.shift, .capsLock]))
+    }
+}

--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -103,7 +103,7 @@ swiftc \
   -framework InputMethodKit -framework Cocoa \
   -F "$SPARKLE_CACHE" -framework Sparkle \
   -Xlinker -rpath -Xlinker @executable_path/../Frameworks \
-  "$APP_SRC"/main.swift "$APP_SRC"/InputController.swift "$APP_SRC"/SharedResources.swift "$APP_SRC"/InputEngine.swift "$APP_SRC"/InputMethodModule.swift "$APP_SRC"/CandidateWindow.swift "$APP_SRC"/Preferences.swift "$APP_SRC"/SettingsModel.swift "$APP_SRC"/GeneralPane.swift "$APP_SRC"/AboutConfig.swift "$APP_SRC"/WhatsNewConfig.swift "$APP_SRC"/AppMenuController.swift
+  "$APP_SRC"/main.swift "$APP_SRC"/InputController.swift "$APP_SRC"/KeyEventPolicy.swift "$APP_SRC"/SharedResources.swift "$APP_SRC"/InputEngine.swift "$APP_SRC"/InputMethodModule.swift "$APP_SRC"/CandidateWindow.swift "$APP_SRC"/Preferences.swift "$APP_SRC"/SettingsModel.swift "$APP_SRC"/GeneralPane.swift "$APP_SRC"/AboutConfig.swift "$APP_SRC"/WhatsNewConfig.swift "$APP_SRC"/AppMenuController.swift
 
 echo "==> Assembling Info.plist (resolving \${EXECUTABLE_NAME})"
 sed "s/\${EXECUTABLE_NAME}/$EXECUTABLE_NAME/g" "$APP_SRC/Info.plist" > "$APP/Contents/Info.plist"


### PR DESCRIPTION
Fixes #56.

## Problem

With Yahoo! KeyKey selected, key combinations like ⌘C / ⌘X / ⌘V were intercepted by the IME. For a ⌘ combination `NSEvent.characters` returns the plain base letter, so `InputController.handle(_:client:)` fed `"c"` straight into the engine — ⌘C became the Cangjie radical `金`, and the copy was silently discarded.

## Fix

`handle(_:client:)` now returns `false` (hands the event back to the app) for any keyDown carrying **⌘ or ⌃**, before any engine/paging logic runs. This also stops ⌘/⌃ combined with Space/Return/arrows from being swallowed by the candidate paging/commit branches.

- ⇧+letter (臨時英數) is unaffected — that branch already excludes ⌘/⌃/⌥.
- ⌥ still reaches the IME; ⌥ combos produce non-a–z characters the engine already rejects.

The decision is extracted into a pure `KeyEventPolicy.isSystemShortcut(_:)` helper so it can be unit-tested (the same symlink-into-`KeyKeyApp` convention already used for `Preferences`, `InputEngine`, etc.). `tools/build-app.sh` now compiles the new source file.

## Tests

- New `KeyEventPolicyTests` (3 cases) lock the ⌘/⌃-pass-through, ⇧/⌥/plain-stays behaviour.
- Full suites green locally: **187 engine tests**, **25 App-logic tests**; the App target compiles with the new file wired in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)