### PR TITLE
feat: configurable associated-phrase selection key (Number vs Shift+Number) (#52)

### DIFF
--- a/App/GeneralPane.swift
+++ b/App/GeneralPane.swift
@@ -25,6 +25,11 @@ private struct GeneralPaneView: View {
                 Toggle(L("keykey.general.associatedPhrases"), isOn: $model.associatedPhrases)
                 Toggle(L("keykey.general.associationContinuationOnly"), isOn: $model.associationContinuationOnly)
                     .dragonAnnotation(LocalizedStringKey(L("keykey.general.associationContinuationOnlyHint")))
+                Picker(L("keykey.general.associationTrigger"), selection: $model.associationTrigger) {
+                    Text(L("keykey.general.associationTriggerNumber")).tag(AssociationTrigger.number)
+                    Text(L("keykey.general.associationTriggerShift")).tag(AssociationTrigger.shift)
+                }
+                .dragonAnnotation(LocalizedStringKey(L("keykey.general.associationTriggerHint")))
                 Toggle(L("keykey.general.codeHint"), isOn: $model.codeHint)
                     .dragonAnnotation(LocalizedStringKey(L("keykey.general.codeHintHint")))
             }

--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -24,6 +24,12 @@ final class InputController: IMKInputController {
     // association mode. Paged with `candidatePage`, shown in the same numbered candidate window.
     private var associations: [String] = []
     private static let pageSize = 9
+    // Number-row key codes → digit (1–9). Layout-stable and Shift-independent, unlike
+    // `characters`/`charactersIgnoringModifiers`, which return the shifted symbol (7 → &).
+    // Used to detect Shift+digit for associated-phrase selection (issue #52).
+    private static let numberRowDigits: [UInt16: Int] = [
+        18: 1, 19: 2, 20: 3, 21: 4, 23: 5, 22: 6, 26: 7, 28: 8, 25: 9,
+    ]
 
     override init!(server: IMKServer!, delegate: Any!, client inputClient: Any!) {
         // All heavy resources are loaded ONCE in SharedResources and shared across every
@@ -280,9 +286,10 @@ final class InputController: IMKInputController {
             // Which digit (if any) selects an associated phrase depends on the configured
             // trigger (issue #52). In .number mode a plain 1–9 picks (Shift+digit yields a
             // symbol that Int() rejects, so it falls through and dismisses, as before). In
-            // .shift mode only Shift+1–9 with no ⌃⌥⌘ picks — read from the base key, since
-            // Shift+digit's `characters` is a symbol — and a bare digit is NOT a pick, so it
-            // falls through, dismisses, and the idle engine lets the app type the number.
+            // .shift mode only Shift+1–9 with no ⌃⌥⌘ picks — matched by physical key code,
+            // since `characters`/`charactersIgnoringModifiers` both apply Shift (7 → &) — and
+            // a bare digit is NOT a pick, so it falls through, dismisses, and the idle engine
+            // lets the app type the number.
             let selectionDigit: Int? = {
                 switch Preferences.associationSelectionTrigger {
                 case .number:
@@ -290,7 +297,7 @@ final class InputController: IMKInputController {
                 case .shift:
                     if event.modifierFlags.contains(.shift),
                        event.modifierFlags.intersection([.control, .option, .command]).isEmpty,
-                       let base = event.charactersIgnoringModifiers, let d = Int(base), (1...9).contains(d) { return d }
+                       let d = InputController.numberRowDigits[event.keyCode] { return d }
                 }
                 return nil
             }()

--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -277,7 +277,24 @@ final class InputController: IMKInputController {
                 refresh(client)
                 return true
             }
-            if let chars = event.characters, let d = Int(chars), (1...9).contains(d) {
+            // Which digit (if any) selects an associated phrase depends on the configured
+            // trigger (issue #52). In .number mode a plain 1–9 picks (Shift+digit yields a
+            // symbol that Int() rejects, so it falls through and dismisses, as before). In
+            // .shift mode only Shift+1–9 with no ⌃⌥⌘ picks — read from the base key, since
+            // Shift+digit's `characters` is a symbol — and a bare digit is NOT a pick, so it
+            // falls through, dismisses, and the idle engine lets the app type the number.
+            let selectionDigit: Int? = {
+                switch Preferences.associationSelectionTrigger {
+                case .number:
+                    if let chars = event.characters, let d = Int(chars), (1...9).contains(d) { return d }
+                case .shift:
+                    if event.modifierFlags.contains(.shift),
+                       event.modifierFlags.intersection([.control, .option, .command]).isEmpty,
+                       let base = event.charactersIgnoringModifiers, let d = Int(base), (1...9).contains(d) { return d }
+                }
+                return nil
+            }()
+            if let d = selectionDigit {
                 let index = candidatePage * InputController.pageSize + (d - 1)
                 if index < count {
                     // Associations are full phrases that START with the just-committed

--- a/App/Preferences.swift
+++ b/App/Preferences.swift
@@ -8,6 +8,14 @@ enum CangjieVersion: String {
     case v3 = "3"          // 三代倉頡 — Yahoo! KeyKey cj-ext table + native order
 }
 
+// Which key selects an associated phrase (聯想) in the numbered candidate window.
+// `.number` keeps the classic direct 1–9 pick; `.shift` requires Shift+1–9 so a bare
+// 1–9 types the digit instead — smoother when mixing numbers with Chinese (issue #52).
+enum AssociationTrigger: String {
+    case number = "number"   // default — plain 1–9 picks
+    case shift  = "shift"    // Shift+1–9 picks; plain 1–9 types the digit
+}
+
 // Typed accessors for the user-facing settings, persisted in the IME process's
 // standard UserDefaults. Read live (no caching) so changes apply without restarting.
 enum Preferences {
@@ -19,6 +27,7 @@ enum Preferences {
         static let cangjieVersion = "cangjieVersion"
         static let associationContinuationOnly = "associationContinuationOnly"
         static let codeHintEnabled = "codeHintEnabled"
+        static let associationSelectionTrigger = "associationSelectionTrigger"
     }
 
     static let minFontSize: CGFloat = 14
@@ -35,6 +44,7 @@ enum Preferences {
             Key.cangjieVersion: CangjieVersion.v5.rawValue,
             Key.associationContinuationOnly: false,
             Key.codeHintEnabled: false,
+            Key.associationSelectionTrigger: AssociationTrigger.number.rawValue,
         ])
     }
 
@@ -83,5 +93,11 @@ enum Preferences {
     static var codeHintEnabled: Bool {
         get { UserDefaults.standard.bool(forKey: Key.codeHintEnabled) }
         set { UserDefaults.standard.set(newValue, forKey: Key.codeHintEnabled) }
+    }
+
+    // Which key selects an associated phrase; unknown/absent falls back to plain number keys.
+    static var associationSelectionTrigger: AssociationTrigger {
+        get { AssociationTrigger(rawValue: UserDefaults.standard.string(forKey: Key.associationSelectionTrigger) ?? "") ?? .number }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: Key.associationSelectionTrigger) }
     }
 }

--- a/App/SettingsModel.swift
+++ b/App/SettingsModel.swift
@@ -74,6 +74,16 @@ final class SettingsModel {
         }
     }
 
+    // 聯想選字鍵 (issue #52). Stored + observation-tracked like `cangjieVersion` above so the
+    // menu-style Picker selection sticks (a computed forwarder would silently revert). `didSet`
+    // writes through to Preferences, which InputController reads live on the next composition.
+    var associationTrigger: AssociationTrigger = Preferences.associationSelectionTrigger {
+        didSet {
+            guard associationTrigger != oldValue else { return }
+            Preferences.associationSelectionTrigger = associationTrigger
+        }
+    }
+
     var minFontSize: Double { Double(Preferences.minFontSize) }
     var maxFontSize: Double { Double(Preferences.maxFontSize) }
 

--- a/App/en.lproj/Localizable.strings
+++ b/App/en.lproj/Localizable.strings
@@ -11,6 +11,10 @@
 "keykey.general.associatedPhrases" = "Associated phrases (聯想)";
 "keykey.general.associationContinuationOnly" = "Show only the continuation in associated phrases";
 "keykey.general.associationContinuationOnlyHint" = "Show 係／心／於 instead of 關係, like the original Yahoo! KeyKey. What you commit is unchanged.";
+"keykey.general.associationTrigger" = "Associated-phrase selection key";
+"keykey.general.associationTriggerNumber" = "Number key";
+"keykey.general.associationTriggerShift" = "Shift + Number";
+"keykey.general.associationTriggerHint" = "With “Shift + Number”, a plain number key types the digit instead of picking an associated phrase — handy for typing numbers right after a character (e.g. 這周有7天).";
 "keykey.general.codeHint" = "Show Cangjie code hint";
 "keykey.general.codeHintHint" = "Show each character's Cangjie code beside the candidate (e.g. 倉 → 人口竹口) to help you learn and verify its decomposition.";
 "keykey.general.appearance" = "Appearance";

--- a/App/zh-Hant.lproj/Localizable.strings
+++ b/App/zh-Hant.lproj/Localizable.strings
@@ -11,6 +11,10 @@
 "keykey.general.associatedPhrases" = "聯想字詞";
 "keykey.general.associationContinuationOnly" = "聯想只顯示接續字";
 "keykey.general.associationContinuationOnlyHint" = "顯示「係／心／於」而非「關係」，如原版 Yahoo! KeyKey。所提交的字不變。";
+"keykey.general.associationTrigger" = "聯想選字鍵";
+"keykey.general.associationTriggerNumber" = "數字鍵";
+"keykey.general.associationTriggerShift" = "Shift + 數字";
+"keykey.general.associationTriggerHint" = "選「Shift + 數字」時，直接按數字鍵會輸入該數字，而不會選取聯想詞，方便在字後接著打數字（例如「這周有7天」）。";
 "keykey.general.codeHint" = "反查提示";
 "keykey.general.codeHintHint" = "在候選字旁顯示該字的倉頡拆碼（例：倉 → 人口竹口），方便學習與核對。";
 "keykey.general.appearance" = "外觀";

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/PreferencesTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/PreferencesTests.swift
@@ -10,7 +10,7 @@ final class PreferencesTests: XCTestCase {
     override func tearDown() {
         for key in ["candidateFontSize", "associatedPhrasesEnabled", "fullWidthPunctuationEnabled",
                     "outputSimplifiedEnabled", "cangjieVersion", "associationContinuationOnly",
-                    "codeHintEnabled"] {
+                    "codeHintEnabled", "associationSelectionTrigger"] {
             defaults.removeObject(forKey: key)
         }
         super.tearDown()
@@ -94,12 +94,42 @@ final class PreferencesTests: XCTestCase {
         XCTAssertEqual(Preferences.cangjieVersion, .v5)
     }
 
+    // MARK: associationSelectionTrigger
+
+    func testAssociationTriggerRoundTrip() {
+        Preferences.associationSelectionTrigger = .shift
+        XCTAssertEqual(Preferences.associationSelectionTrigger, .shift)
+        Preferences.associationSelectionTrigger = .number
+        XCTAssertEqual(Preferences.associationSelectionTrigger, .number)
+    }
+
+    func testAssociationTriggerUnknownRawFallsBackToNumber() {
+        defaults.set("zzz", forKey: "associationSelectionTrigger")   // not a valid case
+        XCTAssertEqual(Preferences.associationSelectionTrigger, .number)
+    }
+
+    func testAssociationTriggerAbsentFallsBackToNumber() {
+        defaults.removeObject(forKey: "associationSelectionTrigger")
+        XCTAssertEqual(Preferences.associationSelectionTrigger, .number)
+    }
+
+    func testAssociationTriggerRawValues() {
+        XCTAssertEqual(AssociationTrigger.number.rawValue, "number")
+        XCTAssertEqual(AssociationTrigger.shift.rawValue, "shift")
+    }
+
+    func testAssociationTriggerInitFromRawValue() {
+        XCTAssertEqual(AssociationTrigger(rawValue: "number"), .number)
+        XCTAssertEqual(AssociationTrigger(rawValue: "shift"), .shift)
+        XCTAssertNil(AssociationTrigger(rawValue: "x"))
+    }
+
     // MARK: registerDefaults
 
     func testRegisterDefaultsSuppliesSensibleFirstLaunchValues() {
         for key in ["candidateFontSize", "associatedPhrasesEnabled", "fullWidthPunctuationEnabled",
                     "outputSimplifiedEnabled", "cangjieVersion", "associationContinuationOnly",
-                    "codeHintEnabled"] {
+                    "codeHintEnabled", "associationSelectionTrigger"] {
             defaults.removeObject(forKey: key)
         }
         Preferences.registerDefaults()
@@ -109,6 +139,7 @@ final class PreferencesTests: XCTestCase {
         XCTAssertFalse(Preferences.associationContinuationOnly)
         XCTAssertFalse(Preferences.codeHintEnabled)
         XCTAssertEqual(Preferences.cangjieVersion, .v5)
+        XCTAssertEqual(Preferences.associationSelectionTrigger, .number)
         XCTAssertEqual(Preferences.candidateFontSize, 18)    // defaultFontSize
     }
 

--- a/docs/superpowers/plans/2026-07-22-associated-phrase-selection-key.md
+++ b/docs/superpowers/plans/2026-07-22-associated-phrase-selection-key.md
@@ -234,6 +234,19 @@ git commit -m "feat: add associated-phrase selection-key picker to settings (#52
 - Consumes: `Preferences.associationSelectionTrigger`, `AssociationTrigger` (Task 1).
 - Produces: no new symbols; changes runtime behavior of the association digit branch.
 
+- [ ] **Step 0: Add the number-row key-code map**
+
+In `App/InputController.swift`, add this static constant immediately after `private static let pageSize = 9` (line 26):
+
+```swift
+    // Number-row key codes → digit (1–9). Layout-stable and Shift-independent, unlike
+    // `characters`/`charactersIgnoringModifiers`, which return the shifted symbol (7 → &).
+    // Used to detect Shift+digit for associated-phrase selection (issue #52).
+    private static let numberRowDigits: [UInt16: Int] = [
+        18: 1, 19: 2, 20: 3, 21: 4, 23: 5, 22: 6, 26: 7, 28: 8, 25: 9,
+    ]
+```
+
 - [ ] **Step 1: Replace the digit-selection block**
 
 In `App/InputController.swift`, inside `if !associations.isEmpty { … }`, replace this existing block:
@@ -264,9 +277,10 @@ with:
             // Which digit (if any) selects an associated phrase depends on the configured
             // trigger (issue #52). In .number mode a plain 1–9 picks (Shift+digit yields a
             // symbol that Int() rejects, so it falls through and dismisses, as before). In
-            // .shift mode only Shift+1–9 with no ⌃⌥⌘ picks — read from the base key, since
-            // Shift+digit's `characters` is a symbol — and a bare digit is NOT a pick, so it
-            // falls through, dismisses, and the idle engine lets the app type the number.
+            // .shift mode only Shift+1–9 with no ⌃⌥⌘ picks — matched by physical key code,
+            // since `characters`/`charactersIgnoringModifiers` both apply Shift (7 → &) — and
+            // a bare digit is NOT a pick, so it falls through, dismisses, and the idle engine
+            // lets the app type the number.
             let selectionDigit: Int? = {
                 switch Preferences.associationSelectionTrigger {
                 case .number:
@@ -274,7 +288,7 @@ with:
                 case .shift:
                     if event.modifierFlags.contains(.shift),
                        event.modifierFlags.intersection([.control, .option, .command]).isEmpty,
-                       let base = event.charactersIgnoringModifiers, let d = Int(base), (1...9).contains(d) { return d }
+                       let d = InputController.numberRowDigits[event.keyCode] { return d }
                 }
                 return nil
             }()

--- a/docs/superpowers/plans/2026-07-22-associated-phrase-selection-key.md
+++ b/docs/superpowers/plans/2026-07-22-associated-phrase-selection-key.md
@@ -1,0 +1,333 @@
+# Associated-Phrase Selection Key Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a user setting that chooses whether a plain number key or Shift+number selects an associated phrase (聯想), so digits can be typed smoothly after a Chinese character (issue #52).
+
+**Architecture:** A new string-backed `AssociationTrigger` enum + `Preferences` accessor (mirroring the existing `CangjieVersion` pattern), surfaced as a two-option `Picker` in the General settings pane via a stored `SettingsModel` property, and read live by `InputController` in the association-mode digit branch.
+
+**Tech Stack:** Swift, SwiftUI (DragonKit settings), IMKit, XCTest. App built headlessly with `tools/build-app.sh`; package tests via `swift test`.
+
+## Global Constraints
+
+- Default MUST be `.number` (plain 1–9 picks) — existing users see no behavior change.
+- Do NOT introduce a new UserDefaults suite; use the same `UserDefaults.standard` domain the other `Preferences` keys use.
+- Only two trigger options: Number and Shift+Number. No Control/Option.
+- Change is confined to association mode; regular Cangjie/Simplex/Pinyin candidate selection is untouched.
+- User-facing strings must be added to BOTH `App/en.lproj` and `App/zh-Hant.lproj` `Localizable.strings`.
+
+---
+
+### Task 1: `AssociationTrigger` preference (enum, default, accessor) + tests
+
+**Files:**
+- Modify: `App/Preferences.swift`
+- Test: `Packages/KeyKeyApp/Tests/KeyKeyAppTests/PreferencesTests.swift`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `enum AssociationTrigger: String { case number = "number"; case shift = "shift" }`
+  - `static var Preferences.associationSelectionTrigger: AssociationTrigger { get set }`
+  - Registered default `associationSelectionTrigger` = `"number"`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add the new key to the `tearDown` reset list in `Packages/KeyKeyApp/Tests/KeyKeyAppTests/PreferencesTests.swift` (both occurrences — `tearDown` at the top and the reset loop inside `testRegisterDefaultsSuppliesSensibleFirstLaunchValues`). Change each list from:
+
+```swift
+        for key in ["candidateFontSize", "associatedPhrasesEnabled", "fullWidthPunctuationEnabled",
+                    "outputSimplifiedEnabled", "cangjieVersion", "associationContinuationOnly",
+                    "codeHintEnabled"] {
+```
+
+to:
+
+```swift
+        for key in ["candidateFontSize", "associatedPhrasesEnabled", "fullWidthPunctuationEnabled",
+                    "outputSimplifiedEnabled", "cangjieVersion", "associationContinuationOnly",
+                    "codeHintEnabled", "associationSelectionTrigger"] {
+```
+
+Add this assertion inside `testRegisterDefaultsSuppliesSensibleFirstLaunchValues`, right after the `cangjieVersion` assertion:
+
+```swift
+        XCTAssertEqual(Preferences.associationSelectionTrigger, .number)
+```
+
+Add these new test methods (place them after `testCangjieVersionAbsentFallsBackToV5`):
+
+```swift
+    // MARK: associationSelectionTrigger
+
+    func testAssociationTriggerRoundTrip() {
+        Preferences.associationSelectionTrigger = .shift
+        XCTAssertEqual(Preferences.associationSelectionTrigger, .shift)
+        Preferences.associationSelectionTrigger = .number
+        XCTAssertEqual(Preferences.associationSelectionTrigger, .number)
+    }
+
+    func testAssociationTriggerUnknownRawFallsBackToNumber() {
+        defaults.set("zzz", forKey: "associationSelectionTrigger")   // not a valid case
+        XCTAssertEqual(Preferences.associationSelectionTrigger, .number)
+    }
+
+    func testAssociationTriggerAbsentFallsBackToNumber() {
+        defaults.removeObject(forKey: "associationSelectionTrigger")
+        XCTAssertEqual(Preferences.associationSelectionTrigger, .number)
+    }
+
+    func testAssociationTriggerRawValues() {
+        XCTAssertEqual(AssociationTrigger.number.rawValue, "number")
+        XCTAssertEqual(AssociationTrigger.shift.rawValue, "shift")
+    }
+
+    func testAssociationTriggerInitFromRawValue() {
+        XCTAssertEqual(AssociationTrigger(rawValue: "number"), .number)
+        XCTAssertEqual(AssociationTrigger(rawValue: "shift"), .shift)
+        XCTAssertNil(AssociationTrigger(rawValue: "x"))
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path Packages/KeyKeyApp --filter PreferencesTests`
+Expected: FAIL to compile with errors like "cannot find 'AssociationTrigger' in scope" / "value of type 'Preferences' has no member 'associationSelectionTrigger'".
+
+- [ ] **Step 3: Add the enum**
+
+In `App/Preferences.swift`, add this enum immediately after the `CangjieVersion` enum (before `enum Preferences {`):
+
+```swift
+// Which key selects an associated phrase (聯想) in the numbered candidate window.
+// `.number` keeps the classic direct 1–9 pick; `.shift` requires Shift+1–9 so a bare
+// 1–9 types the digit instead — smoother when mixing numbers with Chinese (issue #52).
+enum AssociationTrigger: String {
+    case number = "number"   // default — plain 1–9 picks
+    case shift  = "shift"    // Shift+1–9 picks; plain 1–9 types the digit
+}
+```
+
+- [ ] **Step 4: Add the key, default, and accessor**
+
+In `App/Preferences.swift`, add the key constant to the `private enum Key` block, after `codeHintEnabled`:
+
+```swift
+        static let associationSelectionTrigger = "associationSelectionTrigger"
+```
+
+Add the registered default inside `registerDefaults()`'s dictionary, after the `codeHintEnabled` entry:
+
+```swift
+            Key.associationSelectionTrigger: AssociationTrigger.number.rawValue,
+```
+
+Add the typed accessor after the `codeHintEnabled` computed property (end of the `Preferences` enum):
+
+```swift
+    // Which key selects an associated phrase; unknown/absent falls back to plain number keys.
+    static var associationSelectionTrigger: AssociationTrigger {
+        get { AssociationTrigger(rawValue: UserDefaults.standard.string(forKey: Key.associationSelectionTrigger) ?? "") ?? .number }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: Key.associationSelectionTrigger) }
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `swift test --package-path Packages/KeyKeyApp --filter PreferencesTests`
+Expected: PASS (all PreferencesTests green, including the 5 new tests and the updated registerDefaults test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add App/Preferences.swift Packages/KeyKeyApp/Tests/KeyKeyAppTests/PreferencesTests.swift
+git commit -m "feat: add AssociationTrigger preference (#52)"
+```
+
+---
+
+### Task 2: Settings UI — SettingsModel property, Picker, localized strings
+
+**Files:**
+- Modify: `App/SettingsModel.swift`
+- Modify: `App/GeneralPane.swift`
+- Modify: `App/en.lproj/Localizable.strings`
+- Modify: `App/zh-Hant.lproj/Localizable.strings`
+
+**Interfaces:**
+- Consumes: `AssociationTrigger`, `Preferences.associationSelectionTrigger` (Task 1).
+- Produces: `SettingsModel.associationTrigger: AssociationTrigger` (stored, writes through to `Preferences`); a `Picker` bound to it in the General pane.
+
+- [ ] **Step 1: Add the stored property to SettingsModel**
+
+In `App/SettingsModel.swift`, add this property immediately after the `cangjieVersion` stored property (after its closing `}` around line 75):
+
+```swift
+    // 聯想選字鍵 (issue #52). Stored + observation-tracked like `cangjieVersion` above so the
+    // menu-style Picker selection sticks (a computed forwarder would silently revert). `didSet`
+    // writes through to Preferences, which InputController reads live on the next composition.
+    var associationTrigger: AssociationTrigger = Preferences.associationSelectionTrigger {
+        didSet {
+            guard associationTrigger != oldValue else { return }
+            Preferences.associationSelectionTrigger = associationTrigger
+        }
+    }
+```
+
+- [ ] **Step 2: Add the Picker to the General pane**
+
+In `App/GeneralPane.swift`, inside the first `DragonSection` (`keykey.general.input`), insert the Picker between the `associationContinuationOnly` Toggle (with its `.dragonAnnotation`) and the `codeHint` Toggle:
+
+```swift
+                Toggle(L("keykey.general.associationContinuationOnly"), isOn: $model.associationContinuationOnly)
+                    .dragonAnnotation(LocalizedStringKey(L("keykey.general.associationContinuationOnlyHint")))
+                Picker(L("keykey.general.associationTrigger"), selection: $model.associationTrigger) {
+                    Text(L("keykey.general.associationTriggerNumber")).tag(AssociationTrigger.number)
+                    Text(L("keykey.general.associationTriggerShift")).tag(AssociationTrigger.shift)
+                }
+                .dragonAnnotation(LocalizedStringKey(L("keykey.general.associationTriggerHint")))
+                Toggle(L("keykey.general.codeHint"), isOn: $model.codeHint)
+```
+
+- [ ] **Step 3: Add English strings**
+
+In `App/en.lproj/Localizable.strings`, add these lines after the `keykey.general.associationContinuationOnlyHint` line:
+
+```
+"keykey.general.associationTrigger" = "Associated-phrase selection key";
+"keykey.general.associationTriggerNumber" = "Number key";
+"keykey.general.associationTriggerShift" = "Shift + Number";
+"keykey.general.associationTriggerHint" = "With “Shift + Number”, a plain number key types the digit instead of picking an associated phrase — handy for typing numbers right after a character (e.g. 這周有7天).";
+```
+
+- [ ] **Step 4: Add Traditional Chinese strings**
+
+In `App/zh-Hant.lproj/Localizable.strings`, add these lines after the `keykey.general.associationContinuationOnlyHint` line:
+
+```
+"keykey.general.associationTrigger" = "聯想選字鍵";
+"keykey.general.associationTriggerNumber" = "數字鍵";
+"keykey.general.associationTriggerShift" = "Shift + 數字";
+"keykey.general.associationTriggerHint" = "選「Shift + 數字」時，直接按數字鍵會輸入該數字，而不會選取聯想詞，方便在字後接著打數字（例如「這周有7天」）。";
+```
+
+- [ ] **Step 5: Build the app to verify it compiles**
+
+Run: `tools/build-app.sh`
+Expected: builds successfully, ending with the produced `./build/YahooKeyKey2.app` (no swiftc errors). This is the only compile check for `SettingsModel.swift` / `GeneralPane.swift`, which are not part of the Swift package.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add App/SettingsModel.swift App/GeneralPane.swift App/en.lproj/Localizable.strings App/zh-Hant.lproj/Localizable.strings
+git commit -m "feat: add associated-phrase selection-key picker to settings (#52)"
+```
+
+---
+
+### Task 3: Trigger-aware selection in InputController
+
+**Files:**
+- Modify: `App/InputController.swift` (association-mode digit branch, ~lines 280–297)
+
+**Interfaces:**
+- Consumes: `Preferences.associationSelectionTrigger`, `AssociationTrigger` (Task 1).
+- Produces: no new symbols; changes runtime behavior of the association digit branch.
+
+- [ ] **Step 1: Replace the digit-selection block**
+
+In `App/InputController.swift`, inside `if !associations.isEmpty { … }`, replace this existing block:
+
+```swift
+            if let chars = event.characters, let d = Int(chars), (1...9).contains(d) {
+                let index = candidatePage * InputController.pageSize + (d - 1)
+                if index < count {
+                    // Associations are full phrases that START with the just-committed
+                    // character (already in the document), so insert only the remainder
+                    // after it (好 + association "好像" -> insert "像", giving 好像).
+                    let suffix = String(associations[index].dropFirst())
+                    clearAssociations()
+                    if !suffix.isEmpty {
+                        client.insertText(applyHanConvert(suffix), replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
+                    }
+                    return true
+                }
+                return true // digit beyond this page: swallow, no insert
+            }
+            // Any other key: dismiss suggestions, then fall through to process the key normally.
+            clearAssociations()
+```
+
+with:
+
+```swift
+            // Which digit (if any) selects an associated phrase depends on the configured
+            // trigger (issue #52). In .number mode a plain 1–9 picks (Shift+digit yields a
+            // symbol that Int() rejects, so it falls through and dismisses, as before). In
+            // .shift mode only Shift+1–9 with no ⌃⌥⌘ picks — read from the base key, since
+            // Shift+digit's `characters` is a symbol — and a bare digit is NOT a pick, so it
+            // falls through, dismisses, and the idle engine lets the app type the number.
+            let selectionDigit: Int? = {
+                switch Preferences.associationSelectionTrigger {
+                case .number:
+                    if let chars = event.characters, let d = Int(chars), (1...9).contains(d) { return d }
+                case .shift:
+                    if event.modifierFlags.contains(.shift),
+                       event.modifierFlags.intersection([.control, .option, .command]).isEmpty,
+                       let base = event.charactersIgnoringModifiers, let d = Int(base), (1...9).contains(d) { return d }
+                }
+                return nil
+            }()
+            if let d = selectionDigit {
+                let index = candidatePage * InputController.pageSize + (d - 1)
+                if index < count {
+                    // Associations are full phrases that START with the just-committed
+                    // character (already in the document), so insert only the remainder
+                    // after it (好 + association "好像" -> insert "像", giving 好像).
+                    let suffix = String(associations[index].dropFirst())
+                    clearAssociations()
+                    if !suffix.isEmpty {
+                        client.insertText(applyHanConvert(suffix), replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
+                    }
+                    return true
+                }
+                return true // digit beyond this page: swallow, no insert
+            }
+            // Any other key: dismiss suggestions, then fall through to process the key normally.
+            clearAssociations()
+```
+
+- [ ] **Step 2: Build the app to verify it compiles**
+
+Run: `tools/build-app.sh`
+Expected: builds successfully, produces `./build/YahooKeyKey2.app` with no swiftc errors.
+
+- [ ] **Step 3: Run the package test suites (regression guard)**
+
+Run: `swift test --package-path Packages/KeyKeyApp && swift test --package-path Packages/KeyKeyEngine`
+Expected: PASS (nothing regressed; Preferences tests still green).
+
+- [ ] **Step 4: Manual verification (debug build)**
+
+Run: `tools/run-debug.sh` then, in the input menu / General settings of "Yahoo KeyKey 2 Debug", verify:
+- Default ("Number key"): type a character, then `1` → picks the 1st associated phrase (unchanged behavior). Shift+`1` → dismisses and inserts full-width symbol, as before.
+- Switch to "Shift + Number": type a character, then `7` → the suggestions dismiss and `7` is typed literally. Shift+`2` → picks the 2nd associated phrase.
+- Type `這周有7天。` end-to-end in "Shift + Number" mode → the `7` appears as a digit, not a phrase pick.
+- Regular Cangjie/Simplex composition: plain `1`–`9` still selects candidates normally in both modes.
+
+Expected: all four checks pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add App/InputController.swift
+git commit -m "feat: honor associated-phrase selection-key setting in InputController (#52)"
+```
+
+---
+
+## Notes
+
+- The 臨時英數 block at the top of `handle()` (`App/InputController.swift:241`) intercepts only Shift+**letter** (`raw.isLetter`), so Shift+digit reaches the association branch untouched — no conflict.
+- No table reload is needed on change; `InputController` reads `Preferences.associationSelectionTrigger` live each keystroke.
+- `CHANGELOG.md` / version bump are release-time concerns handled separately, per the repo's release flow — not part of this feature plan.

--- a/docs/superpowers/specs/2026-07-22-associated-phrase-selection-key-design.md
+++ b/docs/superpowers/specs/2026-07-22-associated-phrase-selection-key-design.md
@@ -1,0 +1,126 @@
+# Configurable associated-phrase selection key
+
+**Date:** 2026-07-22
+**Issue:** [#52](https://github.com/teddychan/yahoo-keykey-2/issues/52)
+**Status:** Approved design
+
+## Problem
+
+After committing a single character, KeyKey offers 聯想 (associated phrases) in
+the numbered candidate window. Currently a plain number key `1`–`9` selects an
+associated phrase directly. This makes it awkward to type digits immediately
+after a Chinese character — e.g. `這周有7天。` — because the `7` is captured by
+the association picker instead of being typed. It also diverges from the common
+practice of other Chinese IMEs.
+
+## Goal
+
+Let the user choose which key selects an associated phrase:
+
+- **Number key** (default) — plain `1`–`9` picks. Today's behavior, unchanged.
+- **Shift + Number** — `Shift`+`1`–`9` picks; a plain `1`–`9` dismisses the
+  suggestions and types the literal digit, so numbers flow naturally after a
+  character.
+
+The default preserves existing behavior for current users.
+
+## Non-goals
+
+- No change to regular Cangjie / Simplex / Pinyin candidate selection — those
+  keep plain-digit selection. This affects **association mode only**.
+- No additional trigger options (Control / Option). Only Number and Shift+Number.
+
+## Design
+
+### 1. Setting model — `App/Preferences.swift`
+
+Add a string-backed enum mirroring the existing `CangjieVersion`:
+
+```swift
+enum AssociationTrigger: String {
+    case number = "number"   // default — plain 1–9 picks
+    case shift  = "shift"    // Shift+1–9 picks; plain 1–9 types the digit
+}
+```
+
+Add:
+- A `Key.associationSelectionTrigger` constant (`"associationSelectionTrigger"`).
+- A registered default of `AssociationTrigger.number.rawValue`.
+- A typed accessor `associationSelectionTrigger` following the `cangjieVersion`
+  pattern: unknown/absent value falls back to `.number`.
+
+### 2. Settings UI — `App/SettingsModel.swift`, `App/GeneralPane.swift`, `*/Localizable.strings`
+
+- `SettingsModel`: a **stored**, observation-tracked property
+  `associationTrigger`, seeded from `Preferences.associationSelectionTrigger`,
+  with a `didSet` that writes through to `Preferences` (same shape as
+  `cangjieVersion`, so a menu-style `Picker` selection sticks instead of
+  silently reverting). No table reload — `InputController` reads `Preferences`
+  live on the next composition.
+- `GeneralPane`: a `Picker` placed directly under the associated-phrase toggles,
+  with two tags — "Number key" (`.number`) and "Shift + Number" (`.shift`) —
+  plus a one-line `.dragonAnnotation` hint.
+- Localization: add `keykey.general.associationTrigger`,
+  `keykey.general.associationTriggerNumber`,
+  `keykey.general.associationTriggerShift`, and
+  `keykey.general.associationTriggerHint` to both `App/en.lproj` and
+  `App/zh-Hant.lproj` `Localizable.strings`.
+
+### 3. Engine behavior — `App/InputController.swift`
+
+The change is confined to the association-mode digit branch (currently around
+line 280, inside `if !associations.isEmpty { … }`).
+
+Replace the single `Int(event.characters)` check with a trigger-aware resolution
+of which digit (if any) selects a phrase:
+
+- `.number` mode: **unchanged** — a plain digit read from `event.characters`
+  picks; `Shift`+digit yields a symbol (not an `Int`), so it falls through to
+  the existing "any other key: dismiss" path exactly as today.
+- `.shift` mode: only `Shift`+digit (with no `⌃`/`⌥`/`⌘`), reading the base
+  digit via `charactersIgnoringModifiers`, picks. A plain digit is **not** a
+  pick, so control falls through to `clearAssociations()` and then normal
+  handling; the idle engine rejects the digit and `handle()` returns `false`,
+  so the app types the literal number.
+
+The phrase-insertion body is unchanged and shared by both modes: index into the
+current page, insert only the continuation after the just-committed character
+(`dropFirst`), then clear associations.
+
+Notes that make this safe:
+- The 臨時英數 block at the top of `handle()` intercepts only `Shift`+**letter**
+  (`raw.isLetter`), so `Shift`+digit reaches the association branch untouched.
+- Space paging, arrow paging, and Escape (handled before the digit branch) are
+  unaffected in both modes.
+
+### 4. Tests — `Packages/KeyKeyApp/Tests/KeyKeyAppTests/PreferencesTests.swift`
+
+Add a round-trip + default test for `associationSelectionTrigger`, matching the
+existing `PreferencesTests` style: assert the registered default is `.number`,
+and that setting `.shift` persists and reads back. Also:
+- Add `"associationSelectionTrigger"` to the per-test key-reset list in `setUp`.
+- Add the new key to the assertions in
+  `testRegisterDefaultsSuppliesSensibleFirstLaunchValues`.
+
+`InputController` is IMKit-bound and has no unit-test harness today; no
+InputController test is added (consistent with the current suite).
+
+## Files touched
+
+- `App/Preferences.swift` — enum + key + default + accessor
+- `App/SettingsModel.swift` — stored `associationTrigger` property
+- `App/GeneralPane.swift` — `Picker`
+- `App/en.lproj/Localizable.strings` — strings
+- `App/zh-Hant.lproj/Localizable.strings` — strings
+- `App/InputController.swift` — trigger-aware association selection
+- `Packages/KeyKeyApp/Tests/KeyKeyAppTests/PreferencesTests.swift` — test
+
+## Verification
+
+- Default install: association picking still uses plain `1`–`9`.
+- Switch to "Shift + Number": typing a character, then `7`, types `7` and
+  dismisses the suggestions; `Shift`+`2` picks the 2nd suggestion.
+- `這周有7天。` types cleanly in Shift+Number mode.
+- Regular Cangjie/Simplex/Pinyin candidate selection with plain digits is
+  unchanged in both modes.
+- `PreferencesTests` pass.

--- a/docs/superpowers/specs/2026-07-22-associated-phrase-selection-key-design.md
+++ b/docs/superpowers/specs/2026-07-22-associated-phrase-selection-key-design.md
@@ -77,11 +77,13 @@ of which digit (if any) selects a phrase:
 - `.number` mode: **unchanged** — a plain digit read from `event.characters`
   picks; `Shift`+digit yields a symbol (not an `Int`), so it falls through to
   the existing "any other key: dismiss" path exactly as today.
-- `.shift` mode: only `Shift`+digit (with no `⌃`/`⌥`/`⌘`), reading the base
-  digit via `charactersIgnoringModifiers`, picks. A plain digit is **not** a
-  pick, so control falls through to `clearAssociations()` and then normal
-  handling; the idle engine rejects the digit and `handle()` returns `false`,
-  so the app types the literal number.
+- `.shift` mode: only `Shift`+digit (with no `⌃`/`⌥`/`⌘`), matched by physical
+  key code, picks. (`charactersIgnoringModifiers` still applies Shift, so
+  `Shift`+`7` reads as `"&"`, not `"7"` — the digit must come from the key code,
+  matching the Space/arrow key-code handling already in this block.) A plain
+  digit is **not** a pick, so control falls through to `clearAssociations()` and
+  then normal handling; the idle engine rejects the digit and `handle()` returns
+  `false`, so the app types the literal number.
 
 The phrase-insertion body is unchanged and shared by both modes: index into the
 current page, insert only the continuation after the just-committed character


### PR DESCRIPTION
Closes #52.

## Problem
In association mode (聯想), a plain number key `1`–`9` selects an associated phrase directly. That makes it awkward to type digits right after a Chinese character (e.g. `這周有7天。`) because the digit gets captured by the phrase picker, and it diverges from common Chinese-IME practice.

## Change
Adds a two-option setting in **General → Input**: **Associated-phrase selection key**
- **Number key** (default) — plain `1`–`9` picks. Existing behavior, unchanged.
- **Shift + Number** — `Shift`+`1`–`9` picks; a plain `1`–`9` types the digit and dismisses the suggestions, so numbers flow naturally after a character.

Default is `Number key`, so existing users see no behavior change.

## Implementation
- `AssociationTrigger` enum + `Preferences.associationSelectionTrigger` accessor + registered default, mirroring the existing `CangjieVersion` pattern (`App/Preferences.swift`).
- Stored, observation-tracked `SettingsModel.associationTrigger` + a `Picker` in `App/GeneralPane.swift`; strings added to both `en.lproj` and `zh-Hant.lproj`.
- Trigger-aware selection in the association digit branch of `App/InputController.swift`. `Shift`+digit is detected by **physical key code** (`charactersIgnoringModifiers` still applies Shift, so `Shift`+`7` reads as `&`, not `7`). Change is confined to association mode — regular Cangjie/Simplex/Pinyin candidate selection is untouched.

## Testing
- `swift test` — KeyKeyApp 27/27, KeyKeyEngine 187/187 pass (incl. new `AssociationTrigger` preference tests).
- `tools/build-app.sh` builds clean.
- ⚠️ **Manual live-IME verification still pending** (requires a human at the keyboard): in Shift+Number mode, confirm `Shift`+`n` picks the nth phrase and a plain digit types literally; verify `這周有7天。` types cleanly; confirm default mode is unchanged.

## Notes
- Design spec: `docs/superpowers/specs/2026-07-22-associated-phrase-selection-key-design.md`
- Plan: `docs/superpowers/plans/2026-07-22-associated-phrase-selection-key.md`
- Known scope limit (Minor, accepted): `Shift`+digit selection covers the ANSI number row, not the numeric keypad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)