### PR TITLE
release: v2.7.0 — candidate paging, configurable 聯想 key, ⌘/⌃ passthrough

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.4</string>
+	<string>2.7.0</string>
 	<key>CFBundleVersion</key>
 	<string>23</string>
 	<key>ComponentInputModeDict</key>

--- a/App/WhatsNewConfig.swift
+++ b/App/WhatsNewConfig.swift
@@ -1,20 +1,23 @@
 import Foundation
 import DragonKit
 
-// "What's New" content for the current release (2.6.4). Performance + robustness: single-pass
-// dictionary load, lazily-built 速成 table / 反查 index, and a 拼音 composer that stays responsive
-// on unusual input. Keep in sync with CHANGELOG.md on release.
+// "What's New" content for the current release (2.7.0). Page Up / Page Down candidate paging,
+// a configurable associated-phrase selection key (1–9 vs Shift+1–9), and a fix so ⌘/⌃ shortcuts
+// pass through to the app. Keep in sync with CHANGELOG.md on release.
 enum WhatsNewConfig {
     @MainActor
     static var content: WhatsNewContent {
         WhatsNewContent(
-            version: "2.6.4",
-            date: "2026-07-10",
+            version: "2.7.0",
+            date: "2026-07-23",
             summary: L("keykey.whatsNew.summary"),
             sections: [
-                ChangeSection(kind: .changed, entries: [
-                    L("keykey.whatsNew.perfMemory"),
-                    L("keykey.whatsNew.perfPinyin"),
+                ChangeSection(kind: .added, entries: [
+                    L("keykey.whatsNew.paging"),
+                    L("keykey.whatsNew.assocKey"),
+                ]),
+                ChangeSection(kind: .fixed, entries: [
+                    L("keykey.whatsNew.shortcutPassthrough"),
                 ]),
             ]
         )

--- a/App/en.lproj/Localizable.strings
+++ b/App/en.lproj/Localizable.strings
@@ -34,10 +34,11 @@
 "keykey.about.cangjieTable" = "Cangjie table";
 "keykey.about.hanConversion" = "Han conversion";
 
-/* What's New pane (2.6.4) */
-"keykey.whatsNew.summary" = "This update trims startup and memory a little further, and keeps 拼音 responsive even on unusual input.";
-"keykey.whatsNew.perfMemory" = "Starts up even faster and lighter. At launch the app now reads its dictionary in a single pass instead of two, and it builds the 速成 (Simplex) table and the 反查／拆碼提示 reverse-lookup index only when you actually use them. If you type only 倉頡 or 拼音, that's less work and less memory at startup. What you type is unchanged.";
-"keykey.whatsNew.perfPinyin" = "拼音 stays responsive on unusual input. Typing a long run of letters that don't form valid syllables no longer makes the composer do more and more work on each keystroke.";
+/* What's New pane (2.7.0) */
+"keykey.whatsNew.summary" = "This update adds Page Up / Page Down paging and an option to pick associated phrases with Shift + number, and fixes ⌘/⌃ shortcuts that were being intercepted.";
+"keykey.whatsNew.paging" = "Page Up / Page Down flip candidate pages. In both the 倉頡／速成 candidate window and the 聯想 (associated-phrase) window, Page Up and Page Down now move between pages, alongside the arrow keys and Space.";
+"keykey.whatsNew.assocKey" = "Choose how to pick associated phrases. A new option in 設定… ▸ 一般 lets you keep the default (1–9 picks an associated phrase) or switch to Shift + 1–9 — with that on, a plain 1–9 types the digit instead, so numbers flow naturally right after a character (e.g. 這周有7天。). Existing users see no change by default.";
+"keykey.whatsNew.shortcutPassthrough" = "⌘ and ⌃ shortcuts pass through to the app again. With Yahoo KeyKey 2 selected, combinations like ⌘C / ⌘X / ⌘V were captured by the input method (⌘C could turn into the 倉頡 radical 金) instead of copying, cutting, or pasting. They now reach the app as expected.";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "Disable Cangjie and Simplex from Input Sources";

--- a/App/zh-Hant.lproj/Localizable.strings
+++ b/App/zh-Hant.lproj/Localizable.strings
@@ -34,10 +34,11 @@
 "keykey.about.cangjieTable" = "倉頡碼表";
 "keykey.about.hanConversion" = "漢字轉換";
 
-/* What's New pane (2.6.4) */
-"keykey.whatsNew.summary" = "本次更新進一步縮減啟動時間與記憶體用量，並讓拼音在遇到異常輸入時仍保持流暢。";
-"keykey.whatsNew.perfMemory" = "啟動更快、更輕巧。啟動時，應用程式改以單次讀取詞庫（原本需讀取兩次），並僅在您實際使用時才建立速成碼表與反查／拆碼提示的反查索引。若您只使用倉頡或拼音，啟動時的運算與記憶體用量都更少。您輸入的內容完全不受影響。";
-"keykey.whatsNew.perfPinyin" = "拼音在異常輸入時依然流暢。連續輸入一長串無法組成有效音節的字母時，組字引擎不再於每次按鍵進行越來越多的運算。";
+/* What's New pane (2.7.0) */
+"keykey.whatsNew.summary" = "本次更新新增 Page Up／Page Down 翻頁、可選擇以 Shift＋數字挑選聯想字詞，並修正被輸入法攔截的 ⌘／⌃ 快捷鍵。";
+"keykey.whatsNew.paging" = "Page Up／Page Down 可翻頁。在倉頡／速成候選字視窗與聯想字詞視窗中，除了方向鍵與空白鍵外，現在也可用 Page Up 與 Page Down 前後翻頁。";
+"keykey.whatsNew.assocKey" = "可自行選擇挑選聯想字詞的按鍵。設定… ▸ 一般 新增一個選項：維持預設（以 1–9 直接挑選聯想字詞），或改為 Shift＋1–9；改用後，單獨按 1–9 會直接輸入該數字，方便在字元後緊接著輸入數字（例如「這周有7天。」）。預設維持不變，現有使用者不受影響。";
+"keykey.whatsNew.shortcutPassthrough" = "⌘ 與 ⌃ 快捷鍵恢復正常傳遞。選用 Yahoo KeyKey 2 時，⌘C／⌘X／⌘V 等組合鍵原本會被輸入法攔截（⌘C 可能被當成倉頡字根「金」）而無法複製、剪下或貼上，現在會正確傳給應用程式。";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "從輸入來源中停用倉頡與速成";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,20 @@
 
 A plain-language list of changes in each version, newest first.
 
-## Unreleased
+## 2.7.0
 
 - **Page Up / Page Down now flip candidate pages.** In both the 倉頡／速成 candidate window and
   the 聯想 (associated-phrase) window, you can now page through choices with **Page Up**
   (previous page) and **Page Down** (next page), the way many traditional Chinese IMEs do — in
   addition to the existing arrow keys and Space.
+- **Choose how to pick associated phrases.** A new **設定… ▸ 一般** option lets you keep the
+  default (**1–9** picks an associated phrase) or switch to **Shift + 1–9** — with that on, a
+  plain **1–9** types the digit and dismisses the suggestions, so numbers flow naturally right
+  after a character (e.g. `這周有7天。`). Default is unchanged, so existing users see no difference.
+- **Fixed: ⌘ and ⌃ shortcuts now pass through to the app.** With Yahoo KeyKey 2 selected,
+  combinations like **⌘C / ⌘X / ⌘V** were intercepted by the input method (⌘C could turn into the
+  倉頡 radical 金) instead of copying, cutting, or pasting. ⌘/⌃ key combinations now reach the app
+  as expected.
 - **Corrected the install instructions.** Releases ship a `.zip` (not a `.pkg`), so the
   README and the `Install.txt` inside the download now tell you to unzip and move
   `YahooKeyKey2.app` into `~/Library/Input Methods/` yourself — or just use Homebrew.

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
@@ -41,16 +41,17 @@ final class ConfigContentTests: XCTestCase {
     @MainActor
     func testWhatsNewVersionMatchesCurrentRelease() {
         let content = WhatsNewConfig.content
-        XCTAssertEqual(content.version, "2.6.4")
-        XCTAssertEqual(content.date, "2026-07-10")
+        XCTAssertEqual(content.version, "2.7.0")
+        XCTAssertEqual(content.date, "2026-07-23")
     }
 
     @MainActor
-    func testWhatsNewHasSingleChangedSectionWithTwoEntries() {
+    func testWhatsNewHasAddedAndFixedSections() {
         let content = WhatsNewConfig.content
-        XCTAssertEqual(content.sections.count, 1)
-        let section = content.sections[0]
-        XCTAssertEqual(section.kind, .changed)
-        XCTAssertEqual(section.entries.count, 2)
+        XCTAssertEqual(content.sections.count, 2)
+        XCTAssertEqual(content.sections[0].kind, .added)
+        XCTAssertEqual(content.sections[0].entries.count, 2)
+        XCTAssertEqual(content.sections[1].kind, .fixed)
+        XCTAssertEqual(content.sections[1].entries.count, 1)
     }
 }


### PR DESCRIPTION
## Summary

Release prep for **v2.7.0** — cuts the changes accumulated on `main` since v2.6.4 into a versioned release. This is the prep PR; once merged, pushing the `v2.7.0` tag triggers the signed/notarized GitHub Release + Homebrew cask bump + Sparkle appcast.

### What ships in 2.7.0
- **Page Up / Page Down candidate paging** (#55)
- **Configurable associated-phrase selection key** — 1–9 (default) vs Shift+1–9 (#59)
- **⌘/⌃ shortcuts now pass through to the app** (#58)
- **Corrected install docs** — releases ship `.zip`, not `.pkg` (#57, closed #54)

## Changes in this PR
- `App/Info.plist` — `CFBundleShortVersionString` 2.6.4 → **2.7.0** (`CFBundleVersion` is stamped from git commit count at build time, so untouched).
- `CHANGELOG.md` — rename `Unreleased` → `2.7.0`; add the missing #59 and #58 entries.
- `App/WhatsNewConfig.swift` — bump to 2.7.0 / 2026-07-23; **Added** (paging, 聯想 key) + **Fixed** (⌘/⌃ passthrough) sections.
- `App/{en,zh-Hant}.lproj/Localizable.strings` — new `keykey.whatsNew.*` keys (replacing the old perf keys).
- `ConfigContentTests.swift` — update the What's New version/date/section-shape assertions to match.

## Verification
- `swift test --package-path Packages/KeyKeyEngine` → 187 passed
- `swift test --package-path Packages/KeyKeyApp` → 30 passed (incl. updated What's New tests)

## Release steps after merge
1. Merge this PR.
2. Push tag `v2.7.0` on `main` → `release.yml` builds, signs, notarizes, publishes the GitHub Release, pushes the Sparkle appcast, and bumps the Homebrew cask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)