### PR TITLE
feat: option to require Space to confirm the code in 速成 / 倉頡-with-* (#61)

### DIFF
--- a/App/GeneralPane.swift
+++ b/App/GeneralPane.swift
@@ -2,9 +2,9 @@ import SwiftUI
 import DragonKit
 
 // KeyKey's General settings pane: the real input toggles (輸出簡體字 / 全形標點 / 聯想字詞 and the
-// 聯想只顯示接續字 option), the candidate font size, the 倉頡版本 picker, and the shared language
-// picker. Everything binds to `SettingsModel`, which forwards to the live `Preferences` the
-// engine reads — so changes apply on the next composition, no restart.
+// 聯想只顯示接續字 option), the candidate font size, the 倉頡版本 picker and 以空白鍵確認字根
+// toggle, and the shared language picker. Everything binds to `SettingsModel`, which forwards
+// to the live `Preferences` the engine reads — so changes apply on the next composition, no restart.
 struct GeneralPane: SettingsPane {
     let id = "general"
     let title = "keykey.pane.general"
@@ -55,6 +55,8 @@ private struct GeneralPaneView: View {
                     Text(L("keykey.general.cangjieV3")).tag(CangjieVersion.v3)
                 }
                 .dragonAnnotation(LocalizedStringKey(L("keykey.general.cangjieVersionHint")))
+                Toggle(L("keykey.general.strokeConfirmation"), isOn: $model.strokeConfirmation)
+                    .dragonAnnotation(LocalizedStringKey(L("keykey.general.strokeConfirmationHint")))
             }
 
             DragonSection(LocalizedStringKey(L("keykey.general.language"))) {

--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -20,6 +20,11 @@ final class InputController: IMKInputController {
     private let candidateWindow = CandidateWindow()
     // Current candidate page (9 per page) for the active composition; reused for association paging.
     private var candidatePage = 0
+    // Stroke confirmation for the active composition (issue #61). Only consulted when
+    // Preferences.strokeConfirmationEnabled and the composition is auto-completed (速成, or 倉頡
+    // with a `*` wildcard): until the user has pressed Space once, Space confirms the strokes
+    // rather than paging. Reset alongside candidatePage whenever the composition itself changes.
+    private var strokeConfirmed = false
     // Associated phrases (聯想) offered after committing a single character; empty when not in
     // association mode. Paged with `candidatePage`, shown in the same numbered candidate window.
     private var associations: [String] = []
@@ -93,7 +98,7 @@ final class InputController: IMKInputController {
         } else {
             _ = engine.commit()
         }
-        candidatePage = 0
+        resetCompositionState()
         associations = []
         candidateWindow.hide()
         engine = currentModule.makeEngine()
@@ -224,7 +229,7 @@ final class InputController: IMKInputController {
         } else {
             _ = engine.commit()
         }
-        candidatePage = 0
+        resetCompositionState()
         associations = []
         candidateWindow.hide()
         currentModule = module
@@ -330,7 +335,7 @@ final class InputController: IMKInputController {
         // composition before full-width punctuation would turn it into ＊. Simplex rejects
         // `*`, so handleKey returns false and it falls through to punctuation below.
         if event.characters?.first == "*", engine.composingText.isEmpty, engine.handleKey("*") {
-            candidatePage = 0
+            resetCompositionState()
             refresh(client)
             return true
         }
@@ -405,6 +410,19 @@ final class InputController: IMKInputController {
                 return true
             default: break
             }
+            // 以空白鍵確認字根 (issue #61): 速成 and 倉頡-with-`*` show candidates before the
+            // code is finished, so the Space a 倉頡 typist presses out of muscle memory pages the
+            // window (or commits) instead of confirming the strokes. When the option is on,
+            // swallow the FIRST Space of such a composition as that confirmation — the page and
+            // the marked text stay exactly as they are, and the next Space / 1–9 / arrow behaves
+            // as it always has.
+            if event.keyCode == 49,
+               KeyEventPolicy.spaceConfirmsStroke(enabled: Preferences.strokeConfirmationEnabled,
+                                                  autoCompletedCode: isAutoCompletedComposition,
+                                                  alreadyConfirmed: strokeConfirmed) {
+                strokeConfirmed = true
+                return true
+            }
             // SPACE pages to the next candidate page (wrapping last → first). On a
             // single page there is nothing to page, so fall through to the
             // commit-first-candidate-on-space behaviour below.
@@ -447,18 +465,19 @@ final class InputController: IMKInputController {
             return commitCurrent(to: client, offerAssociations: true)
         case 51: // Delete/Backspace
             guard !engine.composingText.isEmpty else { return false }
-            engine.backspace(); candidatePage = 0; refresh(client); return true
+            engine.backspace(); resetCompositionState(); refresh(client); return true
         case 53: // Escape cancels composition (commit-then-discard)
             guard !engine.composingText.isEmpty else { return false }
-            _ = engine.commit(); candidatePage = 0; refresh(client); return true
+            _ = engine.commit(); resetCompositionState(); refresh(client); return true
         default: break
         }
 
         guard let ch = event.characters?.first else { return false }
         let consumed = engine.handleKey(ch)
         if consumed {
-            // A new radical/key changes the candidate set; restart paging from page 0.
-            candidatePage = 0
+            // A new radical/key changes the candidate set; restart paging from page 0 and
+            // require the stroke confirmation again (issue #61).
+            resetCompositionState()
             refresh(client)
         }
         return consumed
@@ -471,7 +490,7 @@ final class InputController: IMKInputController {
 
     @discardableResult
     private func commitCurrent(to client: IMKTextInput, offerAssociations: Bool = false) -> Bool {
-        candidatePage = 0
+        resetCompositionState()
         let text = engine.commit()
         if !text.isEmpty {
             client.insertText(applyHanConvert(text), replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
@@ -500,6 +519,23 @@ final class InputController: IMKInputController {
     // Used for both committed text and candidate/association display so they stay WYSIWYG.
     private func applyHanConvert(_ text: String) -> String {
         Preferences.outputSimplifiedEnabled ? hanConvertFilter.convert(text) : text
+    }
+
+    // Per-composition transient state: candidate paging and the issue-#61 stroke confirmation.
+    // Called wherever the composition itself changes (new radical, backspace, cancel, commit,
+    // engine swap) — NOT while merely paging, which must keep the confirmation.
+    private func resetCompositionState() {
+        candidatePage = 0
+        strokeConfirmed = false
+    }
+
+    // Whether the active composition resolves to candidates before its code is complete: 速成
+    // (a first+last-radical shorthand) or a 倉頡 code carrying the `*` wildcard. `*` has no
+    // radical glyph, so composingText shows it literally and it is visible here. These are
+    // exactly the compositions where Space is not a stroke confirmation today (issue #61);
+    // plain 倉頡 types a determinate code, and 拼音 has its own key handling.
+    private var isAutoCompletedComposition: Bool {
+        engine is SimplexEngine || engine.composingText.contains("*")
     }
 
     // Leave association mode: drop the suggestions, reset paging, hide the candidate window.

--- a/App/KeyEventPolicy.swift
+++ b/App/KeyEventPolicy.swift
@@ -12,4 +12,20 @@ enum KeyEventPolicy {
     static func isSystemShortcut(_ flags: NSEvent.ModifierFlags) -> Bool {
         !flags.intersection([.command, .control]).isEmpty
     }
+
+    /// Whether this Space press should only CONFIRM the typed strokes instead of paging the
+    /// candidate window or committing (issue #61).
+    ///
+    /// 速成 and 倉頡-with-`*` resolve to candidates before the code is finished, so the Space a
+    /// 倉頡 typist presses out of muscle memory ("type strokes → Space") lands in the candidate
+    /// window and flips to page 2. With the stroke-confirmation option on, the FIRST Space of
+    /// such a composition is swallowed as that confirmation; every later Space — and every plain
+    /// 倉頡 or 拼音 composition — behaves exactly as before.
+    ///
+    /// Callers apply this only while candidates are on screen; with none there is no page to
+    /// flip and no character to pick, so Space keeps its existing commit/pass-through meaning.
+    static func spaceConfirmsStroke(enabled: Bool, autoCompletedCode: Bool,
+                                    alreadyConfirmed: Bool) -> Bool {
+        enabled && autoCompletedCode && !alreadyConfirmed
+    }
 }

--- a/App/Preferences.swift
+++ b/App/Preferences.swift
@@ -28,6 +28,7 @@ enum Preferences {
         static let associationContinuationOnly = "associationContinuationOnly"
         static let codeHintEnabled = "codeHintEnabled"
         static let associationSelectionTrigger = "associationSelectionTrigger"
+        static let strokeConfirmationEnabled = "strokeConfirmationEnabled"
     }
 
     static let minFontSize: CGFloat = 14
@@ -45,6 +46,7 @@ enum Preferences {
             Key.associationContinuationOnly: false,
             Key.codeHintEnabled: false,
             Key.associationSelectionTrigger: AssociationTrigger.number.rawValue,
+            Key.strokeConfirmationEnabled: false,
         ])
     }
 
@@ -99,5 +101,13 @@ enum Preferences {
     static var associationSelectionTrigger: AssociationTrigger {
         get { AssociationTrigger(rawValue: UserDefaults.standard.string(forKey: Key.associationSelectionTrigger) ?? "") ?? .number }
         set { UserDefaults.standard.set(newValue.rawValue, forKey: Key.associationSelectionTrigger) }
+    }
+
+    // When true, an auto-completed composition — 速成, or 倉頡 with a `*` wildcard — needs one
+    // Space press to CONFIRM the typed strokes before Space resumes its usual paging/commit
+    // role (issue #61). Off by default, so existing users see no change.
+    static var strokeConfirmationEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: Key.strokeConfirmationEnabled) }
+        set { UserDefaults.standard.set(newValue, forKey: Key.strokeConfirmationEnabled) }
     }
 }

--- a/App/SettingsModel.swift
+++ b/App/SettingsModel.swift
@@ -47,6 +47,14 @@ final class SettingsModel {
         set { Preferences.codeHintEnabled = newValue }
     }
 
+    // 以空白鍵確認字根 (issue #61): in 速成 / 倉頡-with-`*`, require one Space press to confirm the
+    // typed strokes before Space resumes paging or committing. A plain toggle, so a computed
+    // forwarder is fine here — only Picker/Slider need the stored-property treatment below.
+    var strokeConfirmation: Bool {
+        get { Preferences.strokeConfirmationEnabled }
+        set { Preferences.strokeConfirmationEnabled = newValue }
+    }
+
     // Candidate text size. Like `cangjieVersion` below, this is a STORED, observation-tracked
     // property (seeded from Preferences at init) — NOT a computed forwarder. An @Observable
     // *computed* property bound to a Slider never registers an observation dependency in its

--- a/App/en.lproj/Localizable.strings
+++ b/App/en.lproj/Localizable.strings
@@ -24,6 +24,8 @@
 "keykey.general.cangjieV5" = "5th-generation Cangjie";
 "keykey.general.cangjieV3" = "3rd-generation Cangjie (Yahoo KeyKey compatible)";
 "keykey.general.cangjieVersionHint" = "3rd-generation Cangjie uses the original Yahoo! KeyKey code table and candidate order (applied to both Cangjie and Simplex), effective immediately.";
+"keykey.general.strokeConfirmation" = "Press Space to confirm the code";
+"keykey.general.strokeConfirmationHint" = "In 速成, and in 倉頡 with the * wildcard, candidates appear before the code is finished, so Space flips to the next page instead of confirming what you typed. With this on, the first Space only confirms the code and keeps page 1 — press Space again to page, or 1–9 to pick. Plain 倉頡 is unaffected.";
 "keykey.general.language" = "Language";
 
 /* About pane */

--- a/App/zh-Hant.lproj/Localizable.strings
+++ b/App/zh-Hant.lproj/Localizable.strings
@@ -24,6 +24,8 @@
 "keykey.general.cangjieV5" = "五代倉頡";
 "keykey.general.cangjieV3" = "三代倉頡（Yahoo KeyKey 相容）";
 "keykey.general.cangjieVersionHint" = "「三代倉頡」使用 Yahoo! KeyKey 原版的拆碼與候選字順序（同時套用到倉頡與速成），立即生效。";
+"keykey.general.strokeConfirmation" = "以空白鍵確認字根";
+"keykey.general.strokeConfirmationHint" = "在速成、以及使用萬用字元（*）的倉頡中，字根還沒打完就會出現候選字，此時空白鍵會直接翻到下一頁，而不是確認你打的字根。開啟後，第一次按空白鍵只會確認字根並停留在第 1 頁；再按一次空白鍵才翻頁，或直接按 1–9 選字。一般倉頡不受影響。";
 "keykey.general.language" = "語言";
 
 /* About pane */

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/KeyEventPolicyTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/KeyEventPolicyTests.swift
@@ -18,6 +18,34 @@ final class KeyEventPolicyTests: XCTestCase {
         XCTAssertTrue(KeyEventPolicy.isSystemShortcut([.control, .command]))
     }
 
+    // MARK: spaceConfirmsStroke (issue #61)
+
+    func testFirstSpaceConfirmsAnAutoCompletedCodeWhenEnabled() {
+        // 速成 / 倉頡-with-`*`, option on, not yet confirmed: Space is the stroke confirmation.
+        XCTAssertTrue(KeyEventPolicy.spaceConfirmsStroke(enabled: true, autoCompletedCode: true,
+                                                        alreadyConfirmed: false))
+    }
+
+    func testSecondSpaceDoesNotConfirmAgain() {
+        // Once confirmed, Space goes back to paging / committing for the rest of the composition.
+        XCTAssertFalse(KeyEventPolicy.spaceConfirmsStroke(enabled: true, autoCompletedCode: true,
+                                                         alreadyConfirmed: true))
+    }
+
+    func testPlainCangjieNeverNeedsConfirmation() {
+        // A determinate 倉頡 code already treats Space as "confirm + commit"; nothing to change.
+        XCTAssertFalse(KeyEventPolicy.spaceConfirmsStroke(enabled: true, autoCompletedCode: false,
+                                                         alreadyConfirmed: false))
+    }
+
+    func testDisabledOptionLeavesSpaceUntouched() {
+        // Default (off): existing users keep today's paging behaviour in every case.
+        XCTAssertFalse(KeyEventPolicy.spaceConfirmsStroke(enabled: false, autoCompletedCode: true,
+                                                         alreadyConfirmed: false))
+        XCTAssertFalse(KeyEventPolicy.spaceConfirmsStroke(enabled: false, autoCompletedCode: false,
+                                                         alreadyConfirmed: false))
+    }
+
     func testImeRelevantModifiersAreNotSystemShortcuts() {
         // ⇧+letter (臨時英數) and plain/⌥ typing stay with the IME.
         XCTAssertFalse(KeyEventPolicy.isSystemShortcut([]))

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/PreferencesTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/PreferencesTests.swift
@@ -10,7 +10,7 @@ final class PreferencesTests: XCTestCase {
     override func tearDown() {
         for key in ["candidateFontSize", "associatedPhrasesEnabled", "fullWidthPunctuationEnabled",
                     "outputSimplifiedEnabled", "cangjieVersion", "associationContinuationOnly",
-                    "codeHintEnabled", "associationSelectionTrigger"] {
+                    "codeHintEnabled", "associationSelectionTrigger", "strokeConfirmationEnabled"] {
             defaults.removeObject(forKey: key)
         }
         super.tearDown()
@@ -73,6 +73,18 @@ final class PreferencesTests: XCTestCase {
         XCTAssertTrue(Preferences.codeHintEnabled)
         Preferences.codeHintEnabled = false
         XCTAssertFalse(Preferences.codeHintEnabled)
+
+        Preferences.strokeConfirmationEnabled = true
+        XCTAssertTrue(Preferences.strokeConfirmationEnabled)
+        Preferences.strokeConfirmationEnabled = false
+        XCTAssertFalse(Preferences.strokeConfirmationEnabled)
+    }
+
+    // Issue #61: absent (never set) must read false, so an existing install keeps today's
+    // Space behaviour until the user opts in.
+    func testStrokeConfirmationDefaultsOffWhenAbsent() {
+        defaults.removeObject(forKey: "strokeConfirmationEnabled")
+        XCTAssertFalse(Preferences.strokeConfirmationEnabled)
     }
 
     // MARK: cangjieVersion
@@ -129,7 +141,7 @@ final class PreferencesTests: XCTestCase {
     func testRegisterDefaultsSuppliesSensibleFirstLaunchValues() {
         for key in ["candidateFontSize", "associatedPhrasesEnabled", "fullWidthPunctuationEnabled",
                     "outputSimplifiedEnabled", "cangjieVersion", "associationContinuationOnly",
-                    "codeHintEnabled", "associationSelectionTrigger"] {
+                    "codeHintEnabled", "associationSelectionTrigger", "strokeConfirmationEnabled"] {
             defaults.removeObject(forKey: key)
         }
         Preferences.registerDefaults()
@@ -138,6 +150,7 @@ final class PreferencesTests: XCTestCase {
         XCTAssertFalse(Preferences.outputSimplifiedEnabled)
         XCTAssertFalse(Preferences.associationContinuationOnly)
         XCTAssertFalse(Preferences.codeHintEnabled)
+        XCTAssertFalse(Preferences.strokeConfirmationEnabled)
         XCTAssertEqual(Preferences.cangjieVersion, .v5)
         XCTAssertEqual(Preferences.associationSelectionTrigger, .number)
         XCTAssertEqual(Preferences.candidateFontSize, 18)    // defaultFontSize

--- a/docs/superpowers/specs/2026-07-25-stroke-confirmation-design.md
+++ b/docs/superpowers/specs/2026-07-25-stroke-confirmation-design.md
@@ -1,0 +1,128 @@
+# Space-to-confirm the code in 速成 / 倉頡-with-wildcard
+
+**Date:** 2026-07-25
+**Issue:** [#61](https://github.com/teddychan/yahoo-keykey-2/issues/61)
+**Status:** Implemented
+
+## Problem
+
+In 倉頡 the classic typing flow is *type the radicals → press Space → the character
+is committed*. KeyKey matches that today: `H` `Q` `I` `Space` commits the first
+candidate, because a plain 倉頡 code is looked up **exactly**, so it usually
+resolves to a single page of candidates and Space falls through to
+"commit the first candidate".
+
+Two input styles break that flow:
+
+- **速成 (Simplex)** — the code is a first+last-radical shorthand, so it matches
+  many characters.
+- **倉頡 with the `*` wildcard** — `characters(matching:)` expands the wildcard
+  across the whole table.
+
+Both resolve to **multiple pages** of candidates *before* the user has finished
+describing the character. `InputController.handle(_:client:)` pages on Space
+whenever `lastPage > 0`, so the Space pressed out of muscle memory flips to
+**page 2** instead of confirming the code. The user must instead type
+`H` `*` `I` `1` — dropping the Space from the sequence entirely, which is what
+breaks the muscle memory the issue describes.
+
+## Goal
+
+An opt-in setting: when on, an auto-completed composition needs **one Space to
+confirm the code** before Space resumes its normal meaning. The reported flow
+`H` `*` `I` `Space` `1` then works.
+
+Off by default, so existing users see no change.
+
+## Non-goals
+
+- **No change to plain 倉頡.** Its code is determinate; Space already means
+  "confirm + commit" there.
+- **No change to 拼音.** It owns its own key handling (`PhraseComposingEngine`)
+  and Space already commits the whole buffer.
+- **No change to digit selection.** `1`–`9` keep picking a candidate whether or
+  not the code has been confirmed — the option adds a Space step, it does not
+  take the direct pick away.
+- **No new candidate-window chrome.** Confirming is silent: the marked text and
+  the current page are untouched.
+
+## Design
+
+### Behaviour
+
+With the option ON and an auto-completed composition showing candidates:
+
+| Key | Result |
+| --- | --- |
+| 1st Space | Confirms the code. Page and marked text unchanged; the key is swallowed. |
+| 2nd Space | Exactly today's behaviour — pages (wrapping last → first), or commits the first candidate when there is only one page. |
+| `1`–`9` | Picks that candidate, confirmed or not. |
+| Arrows / Page Up / Page Down | Page, confirmed or not. |
+
+The confirmation is **per composition**: any change to the composition (a new
+radical, Backspace, Esc, commit, an engine/table swap) requires it again.
+
+### 1. Setting — `App/Preferences.swift`
+
+A plain Bool alongside the existing toggles:
+
+```swift
+static var strokeConfirmationEnabled: Bool   // key "strokeConfirmationEnabled", default false
+```
+
+Registered `false` in `registerDefaults()` so a fresh install and an existing
+install both start with today's behaviour.
+
+### 2. Decision — `App/KeyEventPolicy.swift`
+
+The rule lives in the existing pure-policy enum so it is unit-testable without
+IMK:
+
+```swift
+static func spaceConfirmsStroke(enabled: Bool, autoCompletedCode: Bool,
+                                alreadyConfirmed: Bool) -> Bool
+```
+
+Callers apply it only while candidates are on screen — with none there is no
+page to flip and no character to pick, so Space keeps its existing
+commit / pass-through meaning.
+
+### 3. Wiring — `App/InputController.swift`
+
+- `strokeConfirmed: Bool` — per-composition state, sitting next to `candidatePage`.
+- `resetCompositionState()` — resets `candidatePage` **and** `strokeConfirmed`.
+  It replaces the bare `candidatePage = 0` at every site where the composition
+  itself changes (new radical, Backspace, Esc, commit, 倉頡版本 change, input-mode
+  switch, wildcard start). Paging sites keep assigning `candidatePage`
+  directly, so flipping pages does not drop the confirmation.
+- `isAutoCompletedComposition` — `engine is SimplexEngine ||
+  engine.composingText.contains("*")`. `*` has no radical glyph, so
+  `composingText` renders it literally and the wildcard is visible there.
+- The new Space branch sits inside the existing `!engine.candidates.isEmpty`
+  block, **after** the arrow-key paging switch and **before** the Space-paging
+  check, so it intercepts only the case that regressed.
+
+### 4. UI — `App/GeneralPane.swift`, `App/SettingsModel.swift`, `Localizable.strings`
+
+A toggle in the existing **輸入方式 / Input Method** section (with the 倉頡版本
+picker, since this is 倉頡/速成 typing behaviour rather than a global input
+option), bound to a computed `SettingsModel.strokeConfirmation` forwarder — a
+plain Toggle does not need the stored-property treatment the Picker/Slider do.
+
+- `keykey.general.strokeConfirmation` — 以空白鍵確認字根 / "Press Space to confirm the code"
+- `keykey.general.strokeConfirmationHint` — explains the 速成/`*` scope and that
+  plain 倉頡 is unaffected.
+
+Not added to the IMK input menu; like the 聯想選字鍵 picker (#52) it stays in 設定….
+
+## Tests
+
+- `KeyEventPolicyTests` — truth table for `spaceConfirmsStroke`: first Space
+  confirms, second does not, plain 倉頡 never does, and the disabled default
+  never does.
+- `PreferencesTests` — round-trip, absent-key default (`false`), and inclusion in
+  `registerDefaults()`.
+
+`InputController` itself is IMK-bound and outside the SwiftPM test package, so
+the key-routing change is covered through the policy function it consults —
+the same approach used for issue #56.


### PR DESCRIPTION
Closes #61

## Problem

In 倉頡 the flow is *type the radicals → press Space → character committed*, and KeyKey matches that today: a plain 倉頡 code is looked up **exactly**, so `H` `Q` `I` `Space` usually has a single page of candidates and Space commits the first one.

Two styles break it:

- **速成** — a first+last-radical shorthand, so it matches many characters.
- **倉頡 with `*`** — the wildcard expands across the whole table.

Both produce **multiple pages** of candidates *before* the code is finished, and `handle(_:client:)` pages on Space whenever `lastPage > 0`. So `H` `*` `I` `Space` lands on **page 2** instead of confirming, and the user has to type `H` `*` `I` `1` — dropping Space from the sequence and breaking 倉頡 muscle memory.

## What this adds

An opt-in **設定… ▸ 一般 ▸ 輸入方式 ▸ 以空白鍵確認字根** toggle (“Press Space to confirm the code”). With it on, for 速成 / 倉頡-with-`*` compositions:

| Key | Result |
| --- | --- |
| 1st Space | Confirms the code. Page and marked text unchanged; the key is swallowed. |
| 2nd Space | Exactly today's behaviour — pages (wrapping), or commits the first candidate on a single page. |
| `1`–`9` | Picks that candidate, confirmed or not. |
| Arrows / Page Up / Page Down | Page, confirmed or not. |

So the reported `H` `*` `I` `Space` `1` now works. The confirmation is **per composition** and resets on any change to it (new radical, Backspace, Esc, commit, 倉頡版本 change, input-mode switch).

**Off by default** — existing users see no difference. Plain 倉頡 (determinate code, Space already means confirm+commit) and 拼音 (own key handling) are untouched.

### Interpretation note

The issue asks for Space to *confirm* rather than page, and spells the target flow as `H` `*` `I` `Space` `1`. I read that literally: the first Space confirms only — it does **not** commit the first candidate — and everything after the confirmation keeps the behaviour it has today (including Space-paging added in #53). Digit selection still works before confirming, since the option is about adding the Space step back, not removing the direct pick. Happy to change either of those if you meant something tighter.

## Changes

- `App/Preferences.swift` — `strokeConfirmationEnabled` (default `false`, registered).
- `App/KeyEventPolicy.swift` — `spaceConfirmsStroke(enabled:autoCompletedCode:alreadyConfirmed:)`, the pure decision, kept unit-testable outside IMK like the #56 fix.
- `App/InputController.swift` — `strokeConfirmed` state; `resetCompositionState()` replaces the bare `candidatePage = 0` at every composition-changing site so paging alone never drops the confirmation; `isAutoCompletedComposition` (`engine is SimplexEngine || composingText.contains("*")` — `*` has no radical glyph so it renders literally). The new branch sits inside the existing `!engine.candidates.isEmpty` block, after arrow paging and before Space paging, so it intercepts only the regressed case.
- `App/GeneralPane.swift` / `App/SettingsModel.swift` / en + zh-Hant `Localizable.strings` — the toggle. Not added to the IMK input menu; like the 聯想選字鍵 picker (#52) it stays in 設定….
- `docs/superpowers/specs/2026-07-25-stroke-confirmation-design.md` — design record.

## Verification

- `swift test` in `Packages/KeyKeyApp` — **35 passed** (4 new `spaceConfirmsStroke` truth-table cases, 2 new `Preferences` cases).
- `swift test` in `Packages/KeyKeyEngine` — **187 passed**, unchanged.
- `tools/build-app.sh` compiles `App/` clean (no warnings); it stops only at the expected `Resources/data.txt missing` gate for a clean checkout.

Not hand-tested in a live IME session — that needs a built LM plus installing and switching to the input source, which I couldn't do here. The `InputController` routing itself is covered indirectly through the policy function; worth a quick manual pass on `H` `*` `I` `Space` `1` in 速成 and 倉頡 before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)