### PR TITLE
release: v2.8.0 — Space-to-confirm option, 三代 wrong-code fix

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.7.0</string>
+	<string>2.8.0</string>
 	<key>CFBundleVersion</key>
 	<string>23</string>
 	<key>ComponentInputModeDict</key>

--- a/App/WhatsNewConfig.swift
+++ b/App/WhatsNewConfig.swift
@@ -1,23 +1,22 @@
 import Foundation
 import DragonKit
 
-// "What's New" content for the current release (2.7.0). Page Up / Page Down candidate paging,
-// a configurable associated-phrase selection key (1–9 vs Shift+1–9), and a fix so ⌘/⌃ shortcuts
-// pass through to the app. Keep in sync with CHANGELOG.md on release.
+// "What's New" content for the current release (2.8.0). An option that makes Space confirm the
+// typed code in 速成 / 倉頡-with-`*`, and a fix for the 三代 table offering characters under codes
+// they do not decompose to. Keep in sync with CHANGELOG.md on release.
 enum WhatsNewConfig {
     @MainActor
     static var content: WhatsNewContent {
         WhatsNewContent(
-            version: "2.7.0",
-            date: "2026-07-23",
+            version: "2.8.0",
+            date: "2026-07-25",
             summary: L("keykey.whatsNew.summary"),
             sections: [
                 ChangeSection(kind: .added, entries: [
-                    L("keykey.whatsNew.paging"),
-                    L("keykey.whatsNew.assocKey"),
+                    L("keykey.whatsNew.strokeConfirm"),
                 ]),
                 ChangeSection(kind: .fixed, entries: [
-                    L("keykey.whatsNew.shortcutPassthrough"),
+                    L("keykey.whatsNew.cangjieCodes"),
                 ]),
             ]
         )

--- a/App/en.lproj/Localizable.strings
+++ b/App/en.lproj/Localizable.strings
@@ -36,11 +36,10 @@
 "keykey.about.cangjieTable" = "Cangjie table";
 "keykey.about.hanConversion" = "Han conversion";
 
-/* What's New pane (2.7.0) */
-"keykey.whatsNew.summary" = "This update adds Page Up / Page Down paging and an option to pick associated phrases with Shift + number, and fixes ⌘/⌃ shortcuts that were being intercepted.";
-"keykey.whatsNew.paging" = "Page Up / Page Down flip candidate pages. In both the 倉頡／速成 candidate window and the 聯想 (associated-phrase) window, Page Up and Page Down now move between pages, alongside the arrow keys and Space.";
-"keykey.whatsNew.assocKey" = "Choose how to pick associated phrases. A new option in 設定… ▸ 一般 lets you keep the default (1–9 picks an associated phrase) or switch to Shift + 1–9 — with that on, a plain 1–9 types the digit instead, so numbers flow naturally right after a character (e.g. 這周有7天。). Existing users see no change by default.";
-"keykey.whatsNew.shortcutPassthrough" = "⌘ and ⌃ shortcuts pass through to the app again. With Yahoo KeyKey 2 selected, combinations like ⌘C / ⌘X / ⌘V were captured by the input method (⌘C could turn into the 倉頡 radical 金) instead of copying, cutting, or pasting. They now reach the app as expected.";
+/* What's New pane (2.8.0) */
+"keykey.whatsNew.summary" = "This update lets Space confirm your code in 速成 and in 倉頡 with the * wildcard, and fixes 三代倉頡 offering characters under codes they don't decompose to.";
+"keykey.whatsNew.strokeConfirm" = "Press Space to confirm the code. In 速成, and in 倉頡 with the * wildcard, candidates appear before the code is finished — so Space flipped to the next page instead of confirming what you typed, breaking the 倉頡 habit of “type the radicals, press Space”. A new option in 設定… ▸ 一般 ▸ 輸入方式 makes the first Space confirm the code and stay on page 1; press Space again to page, or 1–9 to pick. Off by default, and plain 倉頡 is unaffected.";
+"keykey.whatsNew.cangjieCodes" = "Fixed: 三代倉頡 offered characters under the wrong code. Typing 人一弓口 (何's code) also offered 含, which decomposes as 人戈弓口 — as the 反查 hint beside it already said. The bundled 三代 table came from an upstream merge that never removed duplicates, handing 800 characters a second, non-standard code. Those extra codes are gone; every character keeps its real one, and 五代倉頡 was never affected.";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "Disable Cangjie and Simplex from Input Sources";

--- a/App/zh-Hant.lproj/Localizable.strings
+++ b/App/zh-Hant.lproj/Localizable.strings
@@ -36,11 +36,10 @@
 "keykey.about.cangjieTable" = "倉頡碼表";
 "keykey.about.hanConversion" = "漢字轉換";
 
-/* What's New pane (2.7.0) */
-"keykey.whatsNew.summary" = "本次更新新增 Page Up／Page Down 翻頁、可選擇以 Shift＋數字挑選聯想字詞，並修正被輸入法攔截的 ⌘／⌃ 快捷鍵。";
-"keykey.whatsNew.paging" = "Page Up／Page Down 可翻頁。在倉頡／速成候選字視窗與聯想字詞視窗中，除了方向鍵與空白鍵外，現在也可用 Page Up 與 Page Down 前後翻頁。";
-"keykey.whatsNew.assocKey" = "可自行選擇挑選聯想字詞的按鍵。設定… ▸ 一般 新增一個選項：維持預設（以 1–9 直接挑選聯想字詞），或改為 Shift＋1–9；改用後，單獨按 1–9 會直接輸入該數字，方便在字元後緊接著輸入數字（例如「這周有7天。」）。預設維持不變，現有使用者不受影響。";
-"keykey.whatsNew.shortcutPassthrough" = "⌘ 與 ⌃ 快捷鍵恢復正常傳遞。選用 Yahoo KeyKey 2 時，⌘C／⌘X／⌘V 等組合鍵原本會被輸入法攔截（⌘C 可能被當成倉頡字根「金」）而無法複製、剪下或貼上，現在會正確傳給應用程式。";
+/* What's New pane (2.8.0) */
+"keykey.whatsNew.summary" = "本次更新新增「以空白鍵確認字根」選項（適用速成與含萬用字元的倉頡），並修正三代倉頡會用錯誤字根配對出字的問題。";
+"keykey.whatsNew.strokeConfirm" = "以空白鍵確認字根。在速成、以及使用萬用字元（*）的倉頡中，字根還沒打完就會出現候選字，空白鍵因此變成翻頁而不是確認字根，打斷了倉頡「打字根、按空白」的習慣。設定… ▸ 一般 ▸ 輸入方式 新增一個選項：開啟後第一次按空白鍵只確認字根並停留在第 1 頁，再按一次才翻頁，或直接按 1–9 選字。預設關閉，一般倉頡不受影響。";
+"keykey.whatsNew.cangjieCodes" = "修正：三代倉頡會用錯誤的字根配對出字。輸入「人一弓口」（「何」的字根）時也會出現「含」，但「含」的拆碼是「人戈弓口」——旁邊的反查提示本來就是這麼顯示的。內附的三代碼表源自上游一次未去重的合併，讓 800 個字多出一組不正確的字根。這些多餘的字根已移除，每個字都保留原本正確的拆碼；五代倉頡從未受影響。";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "從輸入來源中停用倉頡與速成";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 A plain-language list of changes in each version, newest first.
 
+## 2.8.0
+
+- **Press Space to confirm the code (new option).** In **速成**, and in **倉頡** with the `*`
+  wildcard, candidates appear before the code is finished — so **Space** flipped to the next
+  page instead of confirming what you typed, breaking the 倉頡 habit of "type the radicals,
+  press Space". A new **設定… ▸ 一般 ▸ 輸入方式** option, **以空白鍵確認字根**, makes the first
+  Space confirm the code and stay on page 1; press Space again to page, or **1–9** to pick.
+  Off by default, and plain 倉頡 is unaffected.
+- **Fixed: 三代倉頡 offered characters under the wrong code.** Typing `人一弓口` (何's code)
+  also offered 含, which decomposes as `人戈弓口` — as the 反查 hint beside it already said.
+  The bundled 三代 table came from an upstream merge that never removed duplicates, handing
+  800 characters a second, non-standard code. Those extra codes are gone; every character
+  keeps its real one, Yahoo's original candidate order is untouched, and **五代倉頡 was never
+  affected**.
+
 ## 2.7.0
 
 - **Page Up / Page Down now flip candidate pages.** In both the 倉頡／速成 candidate window and

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
@@ -41,8 +41,8 @@ final class ConfigContentTests: XCTestCase {
     @MainActor
     func testWhatsNewVersionMatchesCurrentRelease() {
         let content = WhatsNewConfig.content
-        XCTAssertEqual(content.version, "2.7.0")
-        XCTAssertEqual(content.date, "2026-07-23")
+        XCTAssertEqual(content.version, "2.8.0")
+        XCTAssertEqual(content.date, "2026-07-25")
     }
 
     @MainActor
@@ -50,7 +50,7 @@ final class ConfigContentTests: XCTestCase {
         let content = WhatsNewConfig.content
         XCTAssertEqual(content.sections.count, 2)
         XCTAssertEqual(content.sections[0].kind, .added)
-        XCTAssertEqual(content.sections[0].entries.count, 2)
+        XCTAssertEqual(content.sections[0].entries.count, 1)
         XCTAssertEqual(content.sections[1].kind, .fixed)
         XCTAssertEqual(content.sections[1].entries.count, 1)
     }


### PR DESCRIPTION
Cuts the accumulated `main` changes since v2.7.0 as **v2.8.0**.

## In this release

- **Press Space to confirm the code (new option)** — #63, closes #61. In 速成 and in 倉頡 with the `*` wildcard, the first Space now confirms the typed code instead of flipping to page 2. Off by default; plain 倉頡 unaffected.
- **Fixed: 三代倉頡 offered characters under the wrong code** — #64, closes #62. `人一弓口` no longer offers 含 (whose code is `人戈弓口`). 800 duplicate codes from an un-deduplicated upstream table merge removed; 五代 was never affected.

## Changes here

- `App/Info.plist` — `CFBundleShortVersionString` 2.7.0 → 2.8.0. `CFBundleVersion` is stamped from the git commit count at build time, so it is not edited.
- `CHANGELOG.md` — new 2.8.0 section.
- `App/WhatsNewConfig.swift` — 2.8.0 / 2026-07-25, Added + Fixed sections.
- `App/{en,zh-Hant}.lproj/Localizable.strings` — 2.8.0 What's New copy.
- `ConfigContentTests` — version/date/section assertions.

## Verification

- `Packages/KeyKeyEngine` — 190 tests pass; `Packages/KeyKeyApp` — 35 tests pass.
- `tools/build-app.sh` compiles `App/` clean (stops only at the expected `Resources/data.txt` gate).

## After merge

Push tag `v2.8.0` to trigger `.github/workflows/release.yml`, which builds, Developer ID-signs, notarizes and staples, then publishes all three channels: the GitHub Release `.zip`, the EdDSA-signed Sparkle appcast on `www.dragonapp.com`, and the `teddychan/homebrew-tap` cask bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)