### PR TITLE
docs: a release ships the .zip only — fix RELEASE.md and package-release.sh header

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -90,7 +90,7 @@ env vars:
 `tools/package-installer.sh` additionally produces:
 
 - `build/YahooKeyKey2-<version>.pkg` — a GUI installer for local use
-  ([details below](#gui-installer-pkg--legacy-not-shipped)).
+  ([details below](#gui-installer-pkg-legacy-not-shipped)).
 
 Only the `.zip` belongs on a release; the `.pkg` is **not** published. Neither
 script produces a `.dmg`.
@@ -193,7 +193,7 @@ If running locally instead of CI:
 
 ---
 
-## GUI installer (`.pkg`) — legacy, not shipped
+## GUI installer (`.pkg`): legacy, not shipped
 
 > **Not part of the release.** CI publishes the `.zip` only, and the Homebrew cask
 > installs from that `.zip`. This script is retained as a local option; nothing in

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -247,7 +247,7 @@ For a quick **local / unsigned** installer, run it with no env vars:
 
 Either way it produces, in `build/`:
 
-- `build/YahooKeyKey2-1.0.0.pkg` — the GUI installer.
+- `build/YahooKeyKey2-<version>.pkg` — the GUI installer.
 
 The installer resources (`distribution.xml.template`, `welcome.txt`,
 `conclusion.txt`, `postinstall`) live in `installer/`; the script materializes
@@ -258,7 +258,7 @@ version, pkg signing status, and notarization status.
 
 ### End-user experience
 
-1. **Double-click `YahooKeyKey2-1.0.0.pkg`** → the macOS Installer GUI opens.
+1. **Double-click `YahooKeyKey2-<version>.pkg`** → the macOS Installer GUI opens.
    (For an unsigned pkg, right-click ▸ **Open** the first time.)
 2. Click through; it installs **without** an admin password into
    **`~/Library/Input Methods/`**.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -4,12 +4,20 @@ This describes how to produce a downloadable build of **Yahoo KeyKey 2** (an
 InputMethodKit input method) for distribution **outside the Mac App Store**.
 App Store distribution is **not** used for this version.
 
-Packaging is handled by `tools/package-release.sh` (builds + signs + notarizes
-the app, and produces a `.zip` containing the app + `Install.txt`) and
-`tools/package-installer.sh` (additionally produces a GUI `.pkg`).
+The tagged release is published by CI: [`.github/workflows/release.yml`](../.github/workflows/release.yml)
+is a thin caller that delegates to the shared pipeline
+`teddychan/dragon-release-ci/.github/workflows/release-macos.yml@v5`, which builds,
+Developer ID-signs, notarizes, staples, and zips the app.
 
-**A release ships exactly two files: the `.pkg` and the `.zip`. No `.dmg`.**
-The `.zip` is both the user download and the Sparkle update payload.
+**A release ships exactly one file: the `.zip`. No `.pkg`, no `.dmg`.** That `.zip`
+(`YahooKeyKey2-<version>.zip`) is the user download, the Sparkle update payload, and
+what the Homebrew cask `Casks/yahoo-keykey-2.rb` installs from.
+
+Two scripts still package the app **locally**, outside CI: `tools/package-release.sh`
+(builds + signs + notarizes the app and produces the same `.zip` containing the app +
+`Install.txt`) and `tools/package-installer.sh` (wraps it in a GUI `.pkg`). They are a
+**legacy / local-testing path — neither is what the tagged release publishes**, and the
+`.pkg` is not published anywhere.
 
 ---
 
@@ -48,10 +56,14 @@ and notarized by Apple, otherwise Gatekeeper blocks it. You need:
 
 ---
 
-## Build & package
+## Build & package locally (legacy path)
+
+> This section is the **local** packaging path, kept for building and testing a
+> signed/notarized app on your own machine. The published release comes from CI —
+> see [Per release (automated)](#per-release-automated).
 
 Signing and notarization are controlled by two environment variables. Set both
-for a public release:
+to reproduce a public-quality build locally:
 
 ```sh
 export DEVELOPER_ID_APP="Developer ID Application: Teddy Chan (TEAMID)"
@@ -72,12 +84,16 @@ env vars:
 
 - `build/YahooKeyKey2-<version>.zip` — contains `YahooKeyKey2.app` + `Install.txt`
   (the user download **and** the Sparkle update payload).
+- `build/appcast.xml` — Developer ID-signed builds only (see
+  [Sparkle auto-update](#sparkle-auto-update-appcast)).
 
 `tools/package-installer.sh` additionally produces:
 
-- `build/YahooKeyKey2-<version>.pkg` — the GUI installer (see below).
+- `build/YahooKeyKey2-<version>.pkg` — a GUI installer for local use
+  ([details below](#gui-installer-pkg--legacy-not-shipped)).
 
-Upload **both** to the release. No `.dmg` is produced.
+Only the `.zip` belongs on a release; the `.pkg` is **not** published. Neither
+script produces a `.dmg`.
 
 The script prints a final summary stating the version, signing status
 (Developer ID vs ad-hoc), and notarization status.
@@ -124,9 +140,9 @@ If running locally instead of CI:
 2. Run `tools/package-release.sh` with `DEVELOPER_ID_APP` (and `NOTARY_PROFILE`)
    set. In addition to the `.zip`, it writes **`build/appcast.xml`**
    (EdDSA-signed; enclosure URL → the GitHub release zip).
-3. Create the GitHub release at tag `v<version>` and upload the `.zip` (Sparkle
-   downloads this) alongside the `.pkg` (first-time users). The zip must be named
-   `YahooKeyKey2-<version>.zip` so the appcast URL matches.
+3. Create the GitHub release at tag `v<version>` and upload the `.zip` — that single
+   file is the entire release (first-time users download it; Sparkle updates from it).
+   It must be named `YahooKeyKey2-<version>.zip` so the appcast URL matches.
 4. **Publish the appcast:** copy `build/appcast.xml` into the website repo at
    `docs/yahoo-keykey-2/appcast.xml`, commit, and push. GitHub Pages serves it at
    `https://www.dragonapp.com/yahoo-keykey-2/appcast.xml` — the `SUFeedURL` the app reads.
@@ -147,10 +163,9 @@ If running locally instead of CI:
 
 (Put these in the release notes / download page.)
 
-1. **Easiest:** download and run the `.pkg` installer (click through; no admin
-   password). Skip to step 3. **Or** download the `.zip` and continue:
+1. Download `YahooKeyKey2-<version>.zip` from the release and unzip it.
 2. **Copy `YahooKeyKey2.app`** (from the zip) into `~/Library/Input Methods/`
-   (create the folder if it doesn't exist).
+   (create the folder if it doesn't exist). No admin password needed.
 3. **Log out and log back in** — macOS only scans for input methods at login.
 4. Open **System Settings ▸ Keyboard ▸ Input Sources ▸ `+`**, choose
    **Traditional Chinese**, and add **Yahoo KeyKey 2 — Cangjie** and/or
@@ -178,7 +193,11 @@ If running locally instead of CI:
 
 ---
 
-## GUI installer (`.pkg`)
+## GUI installer (`.pkg`) — legacy, not shipped
+
+> **Not part of the release.** CI publishes the `.zip` only, and the Homebrew cask
+> installs from that `.zip`. This script is retained as a local option; nothing in
+> the release path builds or uploads a `.pkg`, so end users never see one.
 
 For a native double-click experience, `tools/package-installer.sh` builds a
 **GUI `.pkg`** that drives the macOS **Installer.app** flow: it installs

--- a/tools/package-release.sh
+++ b/tools/package-release.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 # Package "Yahoo KeyKey 2" for non-App-Store distribution.
 #
-# Produces a downloadable DMG (and a .zip alternative) containing YahooKeyKey2.app,
-# which users copy into ~/Library/Input Methods/ and enable in System Settings.
+# Produces a downloadable .zip containing YahooKeyKey2.app + Install.txt, which
+# users copy into ~/Library/Input Methods/ and enable in System Settings. No DMG.
+#
+# This is the LOCAL packaging path. The tagged release is published by
+# .github/workflows/release.yml (see docs/RELEASE.md), not by this script.
 #
 # Code signing and notarization are OPTIONAL and driven entirely by environment
 # variables so this script never embeds Teddy's identity and can run on CI or any
@@ -18,7 +21,8 @@
 #                      was Developer-ID-signed, the app is notarized and stapled.
 #
 # Requires: tools/build-app.sh deps, plus codesign, xcrun (notarytool/stapler),
-# hdiutil, ditto, plutil. Produces ./build/YahooKeyKey2-<version>.dmg and .zip.
+# ditto, plutil. Produces ./build/YahooKeyKey2-<version>.zip, plus build/appcast.xml
+# when DEVELOPER_ID_APP is set.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"


### PR DESCRIPTION
## Problem

Two docs asserted artifacts the release path doesn't produce.

`docs/RELEASE.md`:

> **A release ships exactly two files: the `.pkg` and the `.zip`. No `.dmg`.**

and its end-user section led with *"**Easiest:** download and run the `.pkg` installer"* — pointing users at a file that exists in no release.

`tools/package-release.sh` header:

> Produces a downloadable DMG (and a .zip alternative)

…while its own body comment at line 106 said *"No DMG/.pkg: the release ships the .zip only."* The file contradicted itself, and `hdiutil` was listed under `Requires:` despite never being called.

## What the release path actually does

Verified against the sources rather than assumed:

| Source | Reality |
|---|---|
| [`.github/workflows/release.yml`](.github/workflows/release.yml) | Thin caller of `teddychan/dragon-release-ci/.github/workflows/release-macos.yml@v5`, passing only `zip_name_template: 'YahooKeyKey2-{VERSION}.zip'` — no pkg asset input |
| `homebrew-tap` `Casks/yahoo-keykey-2.rb` | `url .../YahooKeyKey2-#{version}.zip` |
| `tools/package-release.sh` | No `hdiutil` call, no DMG variable — emits the `.zip`, plus `build/appcast.xml` when `DEVELOPER_ID_APP` is set |

A release ships **one** file: the `.zip`, which doubles as the Sparkle update payload and the cask source.

## Changes

**`docs/RELEASE.md`**
- Shipped-artifact statement now reads "exactly one file: the `.zip`. No `.pkg`, no `.dmg`", and names CI as the publisher.
- `## Build & package` → `## Build & package locally (legacy path)` with a callout redirecting to the CI section.
- Artifacts list: "Upload **both** to the release" → only the `.zip` belongs on a release. Also documents `build/appcast.xml`, previously unlisted.
- Manual-fallback step 3 no longer says to upload the `.pkg` alongside the zip.
- End-user install starts from the `.zip` instead of a nonexistent `.pkg`.
- `## GUI installer (.pkg)` → `— legacy, not shipped`, with a "not part of the release" callout. Body kept intact: the script still works locally.

**`tools/package-release.sh`** (comment-only)
- Header DMG claim replaced with what it really emits; `hdiutil` dropped from `Requires:`. The remaining deps (`codesign`, `ditto`, `plutil`, `notarytool`, `stapler`) are each actually invoked.
- Notes that this is the local path and that `release.yml` publishes the tagged release.
- No executable line changed; `bash -n` clean; file mode preserved.

`tools/package-release.sh` and `tools/package-installer.sh` remain documented — they're just no longer presented as the release path.

## Out of scope

- The legacy `.pkg` section of `RELEASE.md` hardcodes `YahooKeyKey2-1.0.0.pkg` instead of `<version>` (current version is 2.8.0).
- `tools/package-installer.sh`'s header doesn't mention that its `.pkg` is never published. Accurate as written, just not self-evident.

Docs and comments only — no code, build, or CI behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)