### PR TITLE
refactor!: adopt DragonKit v2.0.0's shared DragonAppMenu — no Uninstall in the IMK menu

### DIFF
--- a/App/AppMenuController.swift
+++ b/App/AppMenuController.swift
@@ -4,8 +4,9 @@ import DragonKit
 import DragonKitUpdates
 
 // Host-owned owner of the shared DragonKit settings window for the IME. The IMK input menu
-// (InputController.menu) routes 關於 / 設定… / 檢查更新… / 解除安裝… here; each sets the target
-// pane before showing the window, so About opens About, Updates opens Updates, etc.
+// (InputController.menu) routes 關於 / 檢查更新… / 設定… here; each sets the target pane before
+// showing the window, so About opens About, Updates opens Updates, etc. Uninstall has no menu
+// entry point by design (see DragonAppMenu) — its pane is reached from the sidebar.
 //
 // Sidebar order (host-owned): General → Sync & Backup → What's New → Updates → About →
 // Uninstall. No Permissions pane (KeyKey uses no Accessibility/Input-Monitoring). No Quit /
@@ -98,12 +99,6 @@ final class AppMenuController {
         model.syncFromPreferences()
         settingsController.show()
         updater.checkForUpdates()
-    }
-
-    func openUninstall() {
-        selection.paneID = "uninstall"
-        model.syncFromPreferences()
-        settingsController.show()
     }
 
     private func relaunch() {

--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -153,28 +153,27 @@ final class InputController: IMKInputController {
         }
 
         // 3. App menu grouping (§5A): About · Check for updates · Settings · — · Uninstall.
-        // Quit omitted by design (system-managed IME). All top-level so IMK routes them.
+        // Built by the shared DragonAppMenu — the one source of truth for the app-item order,
+        // naming, and icons, so the Dragon apps can't drift the way hand-rolled NSMenus did.
+        // includeQuit: false omits Quit by design (system-managed IME). items(_:) carries no
+        // leading separator, so the one added below is still ours. All items are top-level so
+        // IMK routes them.
         // Titles resolve via DragonKit's L() so they follow the picked language; IMK pulls
         // menu() fresh each time the input menu opens, so no cached menu to rebuild on change.
-        // IMK calls menu() on the main thread, so entering the main actor to call L() is safe.
-        let (aboutTitle, updateTitle, settingsTitle, uninstallTitle) = MainActor.assumeIsolated {
-            (L("keykey.menu.about"), L("keykey.menu.checkForUpdates"),
-             L("keykey.menu.settings"), L("keykey.menu.uninstall"))
+        // IMK calls menu() on the main thread, so entering the main actor to reach the
+        // (main-actor) DragonAppMenu is safe.
+        menu.addItem(.separator())
+        MainActor.assumeIsolated {
+            let config = DragonAppMenu.Config(
+                appName: AboutConfig.appName,
+                onAbout: { [weak self] in self?.openAbout() },
+                onSettings: { [weak self] in self?.openSettings() },
+                onCheckForUpdates: { [weak self] in self?.checkForUpdates() },
+                onUninstall: { [weak self] in self?.uninstall() },
+                includeQuit: false
+            )
+            DragonAppMenu.items(config).forEach(menu.addItem)
         }
-        menu.addItem(.separator())
-        let about = NSMenuItem(title: aboutTitle, action: #selector(openAbout), keyEquivalent: "")
-        about.target = self
-        menu.addItem(about)
-        let update = NSMenuItem(title: updateTitle, action: #selector(checkForUpdates), keyEquivalent: "")
-        update.target = self
-        menu.addItem(update)
-        let settings = NSMenuItem(title: settingsTitle, action: #selector(openSettings), keyEquivalent: ",")
-        settings.target = self
-        menu.addItem(settings)
-        menu.addItem(.separator())
-        let uninstall = NSMenuItem(title: uninstallTitle, action: #selector(uninstall), keyEquivalent: "")
-        uninstall.target = self
-        menu.addItem(uninstall)
         return menu
     }
 

--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -112,9 +112,12 @@ final class InputController: IMKInputController {
     // shared Dragon-App app-menu standard (liquid-glass-macos SKILL §5A) for an IME:
     //   1. quick-toggles zone (輸出簡體字 / 全形標點 / 聯想字詞), checkmarks reflect live prefs;
     //   2. any settings specific to the active input method (none for Cangjie/Simplex today);
-    //   3. App menu grouping (§5A) — About Yahoo! KeyKey 2 · 檢查更新… · 設定… · — · 解除安裝….
+    //   3. App menu grouping (§5A) — About Yahoo! KeyKey 2 · 檢查更新… · 設定….
     //      Candidate-window font size (候選字大小) is no longer offered here — the coarse
     //      小/中/大 choices were superseded by the fine-grained slider in 設定….
+    //      解除安裝… is no longer offered here either — a rarely-used destructive action does
+    //      not belong one click away in the everyday menu; it lives in 設定… as the
+    //      Uninstall pane (AppMenuController.settingsPanes).
     //      Per §5A the IME app menu omits Quit (an IME is system-managed; quitting only makes
     //      typing unresponsive until macOS relaunches it). All items are TOP-LEVEL: the macOS
     //      input menu only routes top-level selections back to the controller, so a "⋯ Yahoo!
@@ -152,12 +155,13 @@ final class InputController: IMKInputController {
             methodItems.forEach(menu.addItem)
         }
 
-        // 3. App menu grouping (§5A): About · Check for updates · Settings · — · Uninstall.
+        // 3. App menu grouping (§5A): About · Check for updates · Settings.
         // Built by the shared DragonAppMenu — the one source of truth for the app-item order,
         // naming, and icons, so the Dragon apps can't drift the way hand-rolled NSMenus did.
-        // includeQuit: false omits Quit by design (system-managed IME). items(_:) carries no
-        // leading separator, so the one added below is still ours. All items are top-level so
-        // IMK routes them.
+        // includeQuit: false omits Quit by design (system-managed IME), and the kit drops the
+        // divider with it, so these three items end the menu with nothing dangling. items(_:)
+        // carries no leading separator either, so the one added below is still ours. All items
+        // are top-level so IMK routes them.
         // Titles resolve via DragonKit's L() so they follow the picked language; IMK pulls
         // menu() fresh each time the input menu opens, so no cached menu to rebuild on change.
         // IMK calls menu() on the main thread, so entering the main actor to reach the
@@ -169,7 +173,6 @@ final class InputController: IMKInputController {
                 onAbout: { [weak self] in self?.openAbout() },
                 onSettings: { [weak self] in self?.openSettings() },
                 onCheckForUpdates: { [weak self] in self?.checkForUpdates() },
-                onUninstall: { [weak self] in self?.uninstall() },
                 includeQuit: false
             )
             DragonAppMenu.items(config).forEach(menu.addItem)
@@ -205,10 +208,6 @@ final class InputController: IMKInputController {
 
     @objc private func openSettings() {
         MainActor.assumeIsolated { AppMenuController.shared.openSettings() }
-    }
-
-    @objc private func uninstall() {
-        MainActor.assumeIsolated { AppMenuController.shared.openUninstall() }
     }
 
     // IMK calls this when the user selects one of our input modes (Info.plist

--- a/App/en.lproj/Localizable.strings
+++ b/App/en.lproj/Localizable.strings
@@ -45,9 +45,3 @@
 "keykey.uninstall.item.inputSources" = "Disable Cangjie and Simplex from Input Sources";
 "keykey.uninstall.item.learningAndSettings" = "Delete user-learning data and preferences";
 "keykey.uninstall.item.trash" = "Move Yahoo! KeyKey 2 to the Trash";
-
-/* IMK input-menu app items */
-"keykey.menu.about" = "About Yahoo! KeyKey 2…";
-"keykey.menu.checkForUpdates" = "Check for Updates…";
-"keykey.menu.settings" = "Settings…";
-"keykey.menu.uninstall" = "Uninstall Yahoo! KeyKey 2…";

--- a/App/zh-Hant.lproj/Localizable.strings
+++ b/App/zh-Hant.lproj/Localizable.strings
@@ -45,9 +45,3 @@
 "keykey.uninstall.item.inputSources" = "從輸入來源中停用倉頡與速成";
 "keykey.uninstall.item.learningAndSettings" = "刪除使用者學習資料與偏好設定";
 "keykey.uninstall.item.trash" = "將 Yahoo! KeyKey 2 移到垃圾桶";
-
-/* IMK input-menu app items */
-"keykey.menu.about" = "關於 Yahoo! KeyKey 2…";
-"keykey.menu.checkForUpdates" = "檢查更新…";
-"keykey.menu.settings" = "設定…";
-"keykey.menu.uninstall" = "解除安裝 Yahoo! KeyKey 2…";

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Log out and back in after any update so macOS reloads the input method.
 1. Deactivate the input method: **System Settings ▸ Keyboard ▸ Input Sources**, select
    Yahoo KeyKey 2, and remove it.
 2. Remove the app — **Homebrew:** `brew uninstall --cask teddychan/tap/yahoo-keykey-2`;
-   **manual:** choose **解除安裝…** from the input menu, or delete
+   **manual:** open **設定…** from the input menu and use the **解除安裝** pane, or delete
    `~/Library/Input Methods/YahooKeyKey2.app`.
 3. Remove the leftover preferences and caches (what `brew uninstall --zap` deletes):
 

--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -73,7 +73,7 @@ echo "==> Building DragonKit (SwiftPM, release) in pinned checkout"
 # package's own tools version (6.1) — a separate compilation from the app's -swift-version 5.
 # Clone the pinned tag on first use (e.g. a fresh CI checkout); vendor/ is gitignored, never
 # committed. Idempotent: an existing checkout (local dev) is reused as-is.
-DRAGONKIT_TAG="v1.3.0"
+DRAGONKIT_TAG="v1.5.0"
 if [ ! -d "$KIT_DIR" ]; then
   echo "==> Cloning DragonKit $DRAGONKIT_TAG into vendor/ (not committed)"
   git clone --depth 1 --branch "$DRAGONKIT_TAG" https://github.com/teddychan/dragon-kit "$KIT_DIR"

--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -73,7 +73,7 @@ echo "==> Building DragonKit (SwiftPM, release) in pinned checkout"
 # package's own tools version (6.1) — a separate compilation from the app's -swift-version 5.
 # Clone the pinned tag on first use (e.g. a fresh CI checkout); vendor/ is gitignored, never
 # committed. Idempotent: an existing checkout (local dev) is reused as-is.
-DRAGONKIT_TAG="v1.5.0"
+DRAGONKIT_TAG="v2.0.0"
 if [ ! -d "$KIT_DIR" ]; then
   echo "==> Cloning DragonKit $DRAGONKIT_TAG into vendor/ (not committed)"
   git clone --depth 1 --branch "$DRAGONKIT_TAG" https://github.com/teddychan/dragon-kit "$KIT_DIR"


### PR DESCRIPTION
## Why

The IMK input menu hand-built its app-lifecycle group (關於 · 檢查更新… · 設定… · — · 解除安裝…), so every Dragon app owned a private copy of the same menu — and they had drifted. DragonKit ships `DragonAppMenu`, the single source of truth for that group's order, naming, and leading SF Symbols, with an `includeQuit: false` path for exactly this case (an IME is quit by the system, not the user). Adopting it deletes KeyKey's copy so the menu can't drift again.

This PR now pins **v2.0.0**, which additionally **drops Uninstall from the canonical dropdown**: a rarely-used destructive action does not belong one click away in the everyday menu. It lives in Settings as `UninstallSettingsPane` — which KeyKey already ships in its sidebar — so the flow is still one click from `設定…`; the menu just stops advertising it. `DragonAppMenu.Config.onUninstall` is gone, so this is a breaking API bump.

**For KeyKey the app-menu group is now exactly three items** — 關於 · 檢查更新… · 設定… — because it already passes `includeQuit: false` and v2.0.0 omits the divider *together with* Quit. The leading separator dividing KeyKey's own toggles from the app items stays; nothing dangles at the end.

## What changed

| File | Change |
|---|---|
| `tools/build-app.sh` | `DRAGONKIT_TAG` `v1.3.0` → **`v2.0.0`** (one line; the script git-clones that tag into the gitignored `vendor/dragon-kit`) |
| `App/InputController.swift` | `menu()` appends `DragonAppMenu.items(...)` after its own separator instead of hand-building five `NSMenuItem`s; no `onUninstall:`, and the orphaned `@objc uninstall()` handler is gone |
| `App/AppMenuController.swift` | drop `openUninstall()` (its only caller was that handler) + correct the header's list of routed items |
| `App/en.lproj/Localizable.strings`, `App/zh-Hant.lproj/Localizable.strings` | drop the four now-dead `keykey.menu.*` keys |
| `README.md` | the manual-uninstall step said "choose **解除安裝…** from the input menu" — now points through `設定…` |

Details:

- The `DragonAppMenu.items(...)` call sits inside `MainActor.assumeIsolated { }` — `DragonAppMenu` is `@MainActor` and IMK calls `menu()` from a context that is not main-actor-isolated. That's the same reason the old code wrapped its `L()` calls; the comment's reasoning is preserved.
- `items(_:)` has **no leading separator**, so the existing `menu.addItem(.separator())` before the group stays.
- The closures call the existing `openAbout` / `checkForUpdates` / `openSettings` handlers on `InputController` (weakly captured), which still hop to `AppMenuController`.
- `appName:` comes from `AboutConfig.appName`, the app's existing single source for the canonical name — so a `.debug` build keeps showing "Yahoo! KeyKey 2 Debug" here, like the settings window title already does.
- The removed keys were localized in **en + zh-Hant only**; the kit supplies these titles in all **7** languages (en, es, fr, ja, ko, zh-Hans, zh-Hant), so the menu now follows the picked language everywhere.
- **`UninstallSettingsPane` and `uninstallConfig` are untouched** — the pane stays in the Settings sidebar, which is now the only way in.

## Intended visible change (de-drift)

- **解除安裝… disappears from the input menu.** Uninstall is now reached via `設定…` ▸ 解除安裝 pane.
- **No trailing separator.** Quit and its divider are omitted together, so the menu ends on `設定…`.
- **About loses its trailing ellipsis** — `關於 Yahoo! KeyKey 2` / `About Yahoo! KeyKey 2`, was `關於 Yahoo! KeyKey 2…`. Per the shared spec only items that open a window/dialog take an ellipsis, and About is exempt.
- **Every item now leads with an SF Symbol** (`info.circle`, `arrow.down.circle`, `gearshape`) as §5A requires.
- Order, `⌘,` on Settings, and the deliberate absence of Quit are unchanged.

## Verification

```bash
rm -rf vendor/dragon-kit            # the script REUSES an existing checkout
./tools/build-app.sh                # clones v2.0.0, builds the kit, compiles + signs the app
git -C vendor/dragon-kit tag --points-at HEAD      # -> sample-v1.2.0, v2.0.0
swift test --package-path Packages/KeyKeyEngine    # 190 tests, 0 failures
swift test --package-path Packages/KeyKeyApp       # 35 tests, 0 failures
swift test --package-path vendor/dragon-kit --filter DragonAppMenuTests  # 8 tests, 0 failures
```

- App compiles with **zero warnings**; `Resources/data.txt` was already present, so `tools/build-lm.sh` was not re-run (it does not affect this change).
- The vendored checkout is v2.0.0 = commit `808d5a7`. Note `git describe --tags` prints `sample-v1.2.0` there: dragon-kit has both tags on that same commit, so `describe` picks the other name. `tag --points-at HEAD` lists both and is the reliable check.
- The kit's own v2.0.0 suite covers this PR's invariants directly: `noUninstallItemInAnyConfiguration`, `anImeMenuHasNoQuitAndNoDanglingSeparator`, `menuNeverEndsWithASeparator`.
- The built binary contains the `DragonKit.menu.*` keys and none of the old `keykey.menu.*` ones, and `DragonKit_DragonKit.bundle` ships all 7 `.lproj`s inside the app — so the titles resolve at runtime.
- **Not verified here:** actually clicking the items. That needs an installed IME (`./tools/run-debug.sh`, then open the input menu). Worth a hands-on pass, because the kit's items are closure-backed (`target` = the menu item itself) rather than `target = InputController` + `#selector`, and IMK's cross-process input-menu routing is picky — the file already documents that submenu items never fire.

## ⚠️ Blocking risk — needs a hands-on click test before merge

**Unresolved, and not settleable from code.** DragonKit's items are backed by a private `ClosureMenuItem` whose `target` is *the menu item itself* and whose action is `#selector(invoke)`. Every other item in KeyKey's input menu uses `target = InputController` + a real selector. IMK appears to route only top-level selections **back to the controller**, which would send `invoke` to `InputController` — which does not implement it — so **the three items may silently no-op**.

This PR does not attempt to fix or design around that; the v2.0.0 bump does not make it better or worse (it just removes a fourth item that had the same wiring). Someone needs to install the IME and click 關於 / 檢查更新… / 設定… before this merges.

## Out of scope (untouched, flagged only)

- `App/Info.plist` `CFBundleShortVersionString` not bumped; no tag created.
- `tools/build-app.sh` line 34 and `.gitignore` still say "Pinned DragonKit checkout (tag v1.2.1)" — already stale before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
