### PR TITLE
release: v2.9.1 — dismiss the candidate window when the input session ends (#70)

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.0</string>
+	<string>2.9.1</string>
 	<key>CFBundleVersion</key>
 	<string>23</string>
 	<key>ComponentInputModeDict</key>

--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -549,6 +549,11 @@ final class InputController: IMKInputController {
                 clearAssociations()
             }
         }
+        // Every branch above already hides the window for the state it handles, and refresh(_:)
+        // only shows it when there are candidates to pick — so .idle really does mean nothing is
+        // up. Hide anyway: this is the one place where being wrong strands a panel over another
+        // app with no way to dismiss it, which is the whole of issue #70. Costs one orderOut.
+        candidateWindow.hide()
     }
 
     @discardableResult

--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -488,6 +488,32 @@ final class InputController: IMKInputController {
         _ = commitCurrent(to: client)
     }
 
+    // IMK ends the input session when the client loses focus: the user switched app, clicked
+    // another text field, or changed input source. Nothing handled that before, and IMK does not
+    // call commitComposition for 聯想 (there is no marked text to commit), so a candidate or
+    // association page left open stayed stranded on screen over the new app — visible even after
+    // switching back to English, and unreachable because the keys that dismiss it now go to the
+    // other app (issue #70). End the session with nothing on screen.
+    override func deactivateServer(_ sender: Any!) {
+        switch SessionEndPolicy.action(hasComposition: !engine.composingText.isEmpty,
+                                       hasAssociations: !associations.isEmpty) {
+        case .idle:
+            break
+        case .dismiss:
+            clearAssociations()
+        case .commit:
+            // commitCurrent clears the marked text and hides the window; offerAssociations stays
+            // false so a system-driven commit does not open a fresh 聯想 page as we leave.
+            if let client = sender as? IMKTextInput ?? client() {
+                _ = commitCurrent(to: client)
+            } else {
+                _ = engine.commit()
+                resetCompositionState()
+                clearAssociations()
+            }
+        }
+    }
+
     @discardableResult
     private func commitCurrent(to client: IMKTextInput, offerAssociations: Bool = false) -> Bool {
         resetCompositionState()

--- a/App/KeyEventPolicy.swift
+++ b/App/KeyEventPolicy.swift
@@ -36,9 +36,11 @@ enum KeyEventPolicy {
 // Pure input-session-lifecycle decisions for InputController.
 // See InputController.deactivateServer(_:).
 enum SessionEndPolicy {
-    /// What must happen to on-screen state when the input session ends (issue #70).
+    /// What must happen to the session's own state when it ends (issue #70). The caller hides
+    /// the candidate window in every case; this decides only what to do with composition and
+    /// suggestions.
     enum Action: Equatable {
-        /// Nothing composing and nothing suggested: no window is up, so there is nothing to do.
+        /// Nothing composing and nothing suggested: no state to clear.
         case idle
         /// 聯想 suggestions are showing with no composition. They are offers the user never typed,
         /// so they are dropped without inserting anything.

--- a/App/KeyEventPolicy.swift
+++ b/App/KeyEventPolicy.swift
@@ -1,7 +1,10 @@
 import AppKit
 
-// Pure key-event routing decisions for InputController, kept free of IMK/engine state so they
-// can be unit-tested. See InputController.handle(_:client:).
+// Pure decisions for InputController — key-event routing and input-session lifecycle — kept free
+// of IMK/engine state so they can be unit-tested. Both policies live in this one file because
+// tools/build-app.sh compiles an explicit list of App/ sources; a separate file would need to be
+// added there too.
+// See InputController.handle(_:client:).
 enum KeyEventPolicy {
     /// Whether a keyDown carrying these modifiers is an app/system shortcut the IME must not
     /// touch. ⌘ and ⌃ combinations (⌘C copy, ⌘X cut, ⌘V paste, ⌃A line-start, …) belong to the
@@ -27,5 +30,30 @@ enum KeyEventPolicy {
     static func spaceConfirmsStroke(enabled: Bool, autoCompletedCode: Bool,
                                     alreadyConfirmed: Bool) -> Bool {
         enabled && autoCompletedCode && !alreadyConfirmed
+    }
+}
+
+// Pure input-session-lifecycle decisions for InputController.
+// See InputController.deactivateServer(_:).
+enum SessionEndPolicy {
+    /// What must happen to on-screen state when the input session ends (issue #70).
+    enum Action: Equatable {
+        /// Nothing composing and nothing suggested: no window is up, so there is nothing to do.
+        case idle
+        /// 聯想 suggestions are showing with no composition. They are offers the user never typed,
+        /// so they are dropped without inserting anything.
+        case dismiss
+        /// A composition is in progress: commit it, which also clears the marked text.
+        case commit
+    }
+
+    /// The action for a session that is ending because the client lost focus — the user switched
+    /// app, clicked another text field, or changed input source.
+    ///
+    /// A composition takes precedence over suggestions: it is the state holding text the user
+    /// actually typed, so it must be committed rather than silently discarded.
+    static func action(hasComposition: Bool, hasAssociations: Bool) -> Action {
+        if hasComposition { return .commit }
+        return hasAssociations ? .dismiss : .idle
     }
 }

--- a/App/WhatsNewConfig.swift
+++ b/App/WhatsNewConfig.swift
@@ -1,21 +1,19 @@
 import Foundation
 import DragonKit
 
-// "What's New" content for the current release (2.9.0). The input menu's app items now come
-// from DragonKit's shared DragonAppMenu (canonical macOS naming, each with a leading SF Symbol),
-// and Uninstall has moved out of the input menu into Settings. Keep in sync with CHANGELOG.md
+// "What's New" content for the current release (2.9.1). A single fix: the candidate / 聯想
+// window no longer stays on screen after the input session ends. Keep in sync with CHANGELOG.md
 // on release.
 enum WhatsNewConfig {
     @MainActor
     static var content: WhatsNewContent {
         WhatsNewContent(
-            version: "2.9.0",
+            version: "2.9.1",
             date: "2026-08-05",
             summary: L("keykey.whatsNew.summary"),
             sections: [
-                ChangeSection(kind: .changed, entries: [
-                    L("keykey.whatsNew.sharedMenu"),
-                    L("keykey.whatsNew.uninstallInSettings"),
+                ChangeSection(kind: .fixed, entries: [
+                    L("keykey.whatsNew.strandedWindow"),
                 ]),
             ]
         )

--- a/App/en.lproj/Localizable.strings
+++ b/App/en.lproj/Localizable.strings
@@ -36,10 +36,9 @@
 "keykey.about.cangjieTable" = "Cangjie table";
 "keykey.about.hanConversion" = "Han conversion";
 
-/* What's New pane (2.9.0) */
-"keykey.whatsNew.summary" = "This update tidies the input menu: the app items now use standard macOS names with a leading icon, and Uninstall has moved into Settings.";
-"keykey.whatsNew.sharedMenu" = "A tidier input menu. The app items at the bottom of the 倉頡／速成 input menu — About Yahoo! KeyKey 2, Check for Updates… and Settings… — now each lead with an icon and follow standard macOS naming, matching the other Dragon apps. Nothing you type changes, and the 輸出簡體字 / 全形標點 / 聯想字詞 / 反查提示 toggles above them are untouched.";
-"keykey.whatsNew.uninstallInSettings" = "Uninstall now lives in Settings. Removing Yahoo! KeyKey 2 used to sit at the bottom of the input menu, one slip away from everyday options. It is now at 設定… ▸ Uninstall instead — the same checklist, just not in the menu you open while typing.";
+/* What's New pane (2.9.1) */
+"keykey.whatsNew.summary" = "This update fixes a selection box that could be left stranded on screen after you switched to another app.";
+"keykey.whatsNew.strandedWindow" = "The selection box no longer gets stuck on screen. If you switched to another app — or to another input source — while the candidate window or the 聯想 (associated-phrase) window was open, it stayed floating above whatever you switched to, with no way to close it: the keys that dismiss it now belonged to the other app, and it was still there after switching back to English. The window now closes as soon as Yahoo! KeyKey 2 loses focus. A half-typed code is committed on the way out; 聯想 suggestions are simply dropped, since they are offers you never picked.";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "Disable Cangjie and Simplex from Input Sources";

--- a/App/zh-Hant.lproj/Localizable.strings
+++ b/App/zh-Hant.lproj/Localizable.strings
@@ -37,9 +37,8 @@
 "keykey.about.hanConversion" = "漢字轉換";
 
 /* What's New pane (2.9.0) */
-"keykey.whatsNew.summary" = "本次更新整理了輸入法選單：下方的應用項目改用標準的 macOS 名稱並加上圖示，「解除安裝」則移入設定。";
-"keykey.whatsNew.sharedMenu" = "輸入法選單更整齊。倉頡／速成 輸入法選單下方的應用項目——關於 Yahoo! KeyKey 2、檢查更新…、設定…——現在各自加上圖示，並採用標準的 macOS 命名，與其他 Dragon App 一致。輸入行為完全不變，上方的 輸出簡體字／全形標點／聯想字詞／反查提示 開關也保持原樣。";
-"keykey.whatsNew.uninstallInSettings" = "「解除安裝」移到設定裡。以前要移除 Yahoo! KeyKey 2，入口就在輸入法選單最下方，打字時一不小心就可能按到。現在改放在 設定… ▸ 解除安裝——檢查清單完全相同，只是不再出現在打字時會打開的那個選單裡。";
+"keykey.whatsNew.summary" = "本次更新修正了切換到別的應用程式後，選字框會卡在畫面上關不掉的問題。";
+"keykey.whatsNew.strandedWindow" = "選字框不會再卡在畫面上。以前候選字視窗或聯想字詞視窗還開著時，只要切換到別的應用程式（或切換輸入來源），那個視窗就會浮在新畫面上關不掉——因為能關掉它的按鍵，這時已經屬於另一個應用程式了；就算切回英文輸入，它還是在。現在只要 Yahoo! KeyKey 2 失去焦點，視窗就會立刻關閉。打到一半的字根會在離開時送出；聯想字詞則直接捨棄，因為那些只是建議，並不是你選的字。";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "從輸入來源中停用倉頡與速成";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 A plain-language list of changes in each version, newest first.
 
+## 2.9.1
+
+- **Fixed: the selection box could be left stuck on screen.** If you switched to another app —
+  or to another input source — while the candidate window or the **聯想** (associated-phrase)
+  window was open, it stayed floating above whatever you switched to, with no way to close it:
+  the keys that dismiss it now belonged to the other app, so it was still sitting there even
+  after switching back to English. The window now closes as soon as Yahoo! KeyKey 2 loses
+  focus. A half-typed code is committed on the way out; **聯想** suggestions are simply dropped,
+  since they are offers you never picked.
+
 ## 2.9.0
 
 - **A tidier input menu.** The app items at the bottom of the 倉頡／速成 input menu — **關於 Yahoo!

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
@@ -41,16 +41,16 @@ final class ConfigContentTests: XCTestCase {
     @MainActor
     func testWhatsNewVersionMatchesCurrentRelease() {
         let content = WhatsNewConfig.content
-        XCTAssertEqual(content.version, "2.9.0")
+        XCTAssertEqual(content.version, "2.9.1")
         XCTAssertEqual(content.date, "2026-08-05")
     }
 
     @MainActor
-    func testWhatsNewHasChangedSection() {
+    func testWhatsNewHasFixedSection() {
         let content = WhatsNewConfig.content
         XCTAssertEqual(content.sections.count, 1)
-        XCTAssertEqual(content.sections[0].kind, .changed)
-        XCTAssertEqual(content.sections[0].entries.count, 2)
+        XCTAssertEqual(content.sections[0].kind, .fixed)
+        XCTAssertEqual(content.sections[0].entries.count, 1)
     }
 
     // MARK: DragonAppMenu contract

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/SessionEndPolicyTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/SessionEndPolicyTests.swift
@@ -30,7 +30,8 @@ final class SessionEndPolicyTests: XCTestCase {
     }
 
     func testIdleSessionDoesNothing() {
-        // Nothing composing and nothing suggested: no window is up, so switching away is a no-op.
+        // Nothing composing and nothing suggested: no state to clear. (deactivateServer still
+        // hides the window unconditionally — that safety net is not this decision's job.)
         XCTAssertEqual(SessionEndPolicy.action(hasComposition: false, hasAssociations: false),
                        .idle)
     }

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/SessionEndPolicyTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/SessionEndPolicyTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import KeyKeyApp
+
+// Locks issue #70: a candidate or 聯想 page left open must not survive the end of the input
+// session. Switching app (or input source) while the association window was showing used to
+// leave it stranded on screen over the new app, unreachable — nothing dismissed it, because
+// InputController never handled the session ending. SessionEndPolicy is the pure decision
+// InputController.deactivateServer(_:) consults.
+final class SessionEndPolicyTests: XCTestCase {
+    func testAssociationsAreDismissedWithoutCommitting() {
+        // The reported case: 聯想 suggestions on screen, no composition. They are offers the user
+        // never typed, so the session must end by dismissing them — never by inserting text.
+        XCTAssertEqual(SessionEndPolicy.action(hasComposition: false, hasAssociations: true),
+                       .dismiss)
+    }
+
+    func testCompositionIsCommitted() {
+        // Half-typed radicals with the candidate window open: commit, exactly as an explicit
+        // commitComposition would, so the marked text does not linger either.
+        XCTAssertEqual(SessionEndPolicy.action(hasComposition: true, hasAssociations: false),
+                       .commit)
+    }
+
+    func testCompositionWinsOverAssociations() {
+        // Both flags set is not reachable today (committing clears the composition before
+        // associations are offered), but a composition is the state carrying user text, so it
+        // must take precedence over a dismiss that would silently drop it.
+        XCTAssertEqual(SessionEndPolicy.action(hasComposition: true, hasAssociations: true),
+                       .commit)
+    }
+
+    func testIdleSessionDoesNothing() {
+        // Nothing composing and nothing suggested: no window is up, so switching away is a no-op.
+        XCTAssertEqual(SessionEndPolicy.action(hasComposition: false, hasAssociations: false),
+                       .idle)
+    }
+}


### PR DESCRIPTION
## What changed and why

IMK ends the input session when the client loses focus — switching app, clicking another text field, or changing input source — but `InputController` never handled it. IMK also does not call `commitComposition` for 聯想, because association mode holds no marked text to commit. So an open candidate or associated-phrase page was left stranded on screen over the newly-focused app: still visible after switching back to English, and unreachable, because the keys that would dismiss it now belong to the other app.

This overrides `deactivateServer(_:)` so the session ends with nothing on screen:

- **Composition in progress** → commit it (exactly as `commitComposition` does), which also clears the marked text and hides the window. `offerAssociations` stays `false`, so a system-driven commit does not open a fresh 聯想 page on the way out.
- **聯想 suggestions only** → dismiss without inserting anything. They are offers the user never typed, so committing them would put text in the document that was never chosen.
- **Idle** → nothing to clear.

The window is then hidden **unconditionally**, after the switch. Every branch above already hides it, and `refresh(_:)` is the only caller of `candidateWindow.show` (gated on a non-empty candidate list, and for all three engines non-empty `candidates` implies non-empty `composingText`) — so the idle case really is empty today. It hides anyway: this is the one code path where trusting that invariant costs a panel stranded over another app with no way to dismiss it, which is issue #70 itself.

The decision itself is a pure `SessionEndPolicy` so it can be unit-tested, following the existing `KeyEventPolicy` precedent. It lives **inside `App/KeyEventPolicy.swift`** rather than its own file, because `tools/build-app.sh` compiles an explicit list of `App/` sources — a new file would silently fail to build until added there.

## Release: v2.9.1

Patch release — one user-visible fix, no behaviour changes elsewhere. Carries the version bump, `CHANGELOG.md`, and the What's New pane in both shipped locales, matching the shape of the v2.9.0 release PR (#75).

`CFBundleVersion` stays at `23`, as every release since v2.4.0 has: the shared release pipeline overwrites it in the built bundle (the published v2.9.0 appcast advertises `sparkle:version` 167, not 23), so the repo value is a placeholder CI owns. `docs/RELEASE.md` step 1 still says to bump it by hand — that line is stale, and fixing it is not this release's job.

## Test results

- `swift test --package-path Packages/KeyKeyEngine` — **190 tests, 0 failures**
- `swift test --package-path Packages/KeyKeyApp` — **40 tests, 0 failures** (36 existing + 4 new `SessionEndPolicyTests`)
- `tools/build-app.sh` — App compiled and linked against merged `main` (DragonKit v2.1.0). The run then stops at `ERROR: Resources/data.txt missing`, the by-design absence of the bundled LM in a clean checkout.

## Verification status

Automated tests cannot exercise a live input method — `deactivateServer(_:)` is unreachable from the test package, so the 4 new tests pin the pure decision, not the IMK wiring. A debug IME built from this branch was installed for hands-on testing; the reviewer elected to proceed without it.

One thing a hands-on pass would settle: on the commit path, `engine.commit()` returns `selected ?? candidates.first`, so switching away mid-code inserts the **first** candidate even though the user never picked it. That matches this file's existing `commitComposition`, but Escape in the same controller discards instead.

Closes #70
