### PR TITLE
chore: bump DragonKit to v2.1.0

### DIFF
--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -73,7 +73,7 @@ echo "==> Building DragonKit (SwiftPM, release) in pinned checkout"
 # package's own tools version (6.1) — a separate compilation from the app's -swift-version 5.
 # Clone the pinned tag on first use (e.g. a fresh CI checkout); vendor/ is gitignored, never
 # committed. Idempotent: an existing checkout (local dev) is reused as-is.
-DRAGONKIT_TAG="v2.0.1"
+DRAGONKIT_TAG="v2.1.0"
 if [ ! -d "$KIT_DIR" ]; then
   echo "==> Cloning DragonKit $DRAGONKIT_TAG into vendor/ (not committed)"
   git clone --depth 1 --branch "$DRAGONKIT_TAG" https://github.com/teddychan/dragon-kit "$KIT_DIR"


### PR DESCRIPTION
Bumps the DragonKit pin from **v2.0.1** to **v2.1.0** — dependency bump only, no app version change and no release tag.

## Why now

Conformance rule **R10** requires this app's pin to be `>=` dragon-kit's newest `vX.Y.Z` tag. The kit is at v2.1.0, so every PR — including unrelated work — fails conformance until this lands.

## Behaviour

DragonKit 2.1.0 adds `DragonUpdaterConfig` + `DragonUpdater.start()`, letting an app opt into Sparkle's gentle scheduled reminders and hook background-found updates. **Its defaults preserve existing behaviour exactly**, so this bump is behaviour-neutral for KeyKey — it adopts none of the new hooks here, it just moves the pin.

## Diff

One line: `tools/build-app.sh`, `DRAGONKIT_TAG="v2.0.1"` -> `"v2.1.0"`. `vendor/dragon-kit` is gitignored and cloned on demand, so there is no lockfile to commit. `.github/workflows/tests.yml` reads the tag straight out of this script, so CI follows automatically.

## Verified locally

`tools/build-app.sh` reuses an existing `vendor/dragon-kit` checkout, so a stale local copy would silently compile against the old tag. Verified against a wiped `vendor/`:

- `rm -rf vendor/dragon-kit && ./tools/build-app.sh` -> clean, logged `Cloning DragonKit v2.1.0`
- vendored checkout confirmed with `git -C vendor/dragon-kit tag --points-at HEAD` -> `v2.1.0` (sha `d68e669`, matching the kit's v2.1.0 tag)
- conformance: `PASS — no violations` (was `FAIL — R10 stale pin`)
- `swift test --package-path Packages/KeyKeyEngine`: **190 tests passed** — unchanged
- `swift test --package-path Packages/KeyKeyApp` (against the fresh v2.1.0 vendor): **35 tests passed** — unchanged