### PR TITLE
fix(engine): report and set aside an unreadable user-frequency store

### DIFF
--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/UserFrequency.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/UserFrequency.swift
@@ -101,8 +101,16 @@ public final class UserFrequency {
 
     // Persisted as a [String: Int] map (JSON has no Character key type), one char per key.
     private static func load(from url: URL) -> [Character: Int] {
+        // No file yet is the normal first-launch case, not a failure: start empty, say nothing.
+        guard FileManager.default.fileExists(atPath: url.path) else { return [:] }
         guard let data = try? Data(contentsOf: url),
               let raw = try? JSONDecoder().decode([String: Int].self, from: data) else {
+            // The file is there but unreadable. Silently returning [:] here reset the user's
+            // learning with no signal, and the next debounced save then overwrote the evidence.
+            // Log it (file name only — the full path carries the user's home directory) and move
+            // the bad file aside so it survives for diagnosis.
+            NSLog("YahooKeyKey: \(url.lastPathComponent) unreadable; starting with empty user frequency")
+            quarantine(url)
             return [:]
         }
         var result: [Character: Int] = [:]
@@ -110,6 +118,20 @@ public final class UserFrequency {
             if let ch = key.first { result[ch] = value }
         }
         return result
+    }
+
+    // Move an unreadable store aside as "<name>.corrupt" so the next save writes a fresh file
+    // instead of overwriting the broken one, keeping it around to diagnose. Best-effort: if the
+    // move fails there is nothing more to do — the store is already lost either way.
+    private static func quarantine(_ url: URL) {
+        let corrupt = url.deletingLastPathComponent()
+            .appendingPathComponent(url.lastPathComponent + ".corrupt")
+        try? FileManager.default.removeItem(at: corrupt)   // replace any earlier quarantine
+        do {
+            try FileManager.default.moveItem(at: url, to: corrupt)
+        } catch {
+            NSLog("YahooKeyKey: could not set aside the unreadable user frequency store: \(error)")
+        }
     }
 
     private static func save(_ counts: [Character: Int], to url: URL) {

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/UserFrequencyTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/UserFrequencyTests.swift
@@ -80,6 +80,36 @@ final class UserFrequencyTests: XCTestCase {
         XCTAssertEqual(uf.bonus(for: "好"), 0)
     }
 
+    func testCorruptFileIsSetAsideForDiagnosis() throws {
+        // An unreadable store must not be silently overwritten by the next save: it is moved
+        // to "<name>.corrupt", contents intact, so it can still be inspected.
+        try "not json".data(using: .utf8)!.write(to: fileURL)
+        _ = UserFrequency(fileURL: fileURL)
+
+        let corrupt = fileURL.appendingPathExtension("corrupt")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+        XCTAssertEqual(try String(contentsOf: corrupt, encoding: .utf8), "not json")
+    }
+
+    func testMissingFileIsNotSetAside() {
+        // First launch has no file at all; that is normal, so nothing is quarantined.
+        let missing = tempDir.appendingPathComponent("does-not-exist.json")
+        _ = UserFrequency(fileURL: missing)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: missing.appendingPathExtension("corrupt").path))
+    }
+
+    func testStoreRecoversAfterCorruption() throws {
+        // Learning starts over from empty, but it must keep working: the next flush writes a
+        // fresh, valid file that a later instance can read back.
+        try "not json".data(using: .utf8)!.write(to: fileURL)
+        let uf = UserFrequency(fileURL: fileURL)
+        uf.record("好")
+        uf.flush()
+
+        let reloaded = UserFrequency(fileURL: fileURL)
+        XCTAssertGreaterThan(reloaded.bonus(for: "好"), 0)
+    }
+
     // MARK: - Hardening
 
     func testConcurrentRecordIsThreadSafe() {


### PR DESCRIPTION
From the `macos-swift-engineering` audit — P3 finding.

## Problem

`UserFrequency.load` returned `[:]` on any read or decode failure with no log, and the next debounced save overwrote the bad file. A user whose learning store got damaged silently lost their adaptive ranking, with no signal and no evidence left to diagnose. It was also the only fail-safe path in the project that did not log — `save()` on the same type already does.

## Change

- A **missing** file stays silent — that is the normal first-launch case.
- A file that is **present but unreadable** now logs (file name only; the full path carries the user's home directory) and is moved aside to `<name>.corrupt`, so the next save writes a fresh file rather than destroying the evidence.

No behavior change for the working case, and learning still starts over from empty after corruption.

## Tests

3 new cases in `UserFrequencyTests`: the corrupt file is set aside with contents intact, a missing file is *not* quarantined, and the store still round-trips after a corruption.

`swift test --package-path Packages/KeyKeyEngine` → **193 tests, 0 failures** (baseline on main: 190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)