### PR TITLE
chore(packages): enable complete concurrency checking as warnings

### DIFF
--- a/Packages/KeyKeyApp/Package.swift
+++ b/Packages/KeyKeyApp/Package.swift
@@ -20,7 +20,11 @@ let package = Package(
             dependencies: [
                 "KeyKeyEngine",
                 .product(name: "DragonKit", package: "dragon-kit"),
-            ]
+            ],
+            // Complete data-race checking, WARNINGS only under the Swift 5 language mode below
+            // (see KeyKeyEngine/Package.swift). It covers the symlinked App/ sources too, which
+            // is the only compile-time concurrency checking any App/ file gets. Keep it clean.
+            swiftSettings: [.enableUpcomingFeature("StrictConcurrency")]
         ),
         .testTarget(name: "KeyKeyAppTests", dependencies: ["KeyKeyApp"]),
     ],

--- a/Packages/KeyKeyEngine/Package.swift
+++ b/Packages/KeyKeyEngine/Package.swift
@@ -8,7 +8,11 @@ let package = Package(
     platforms: [.macOS(.v26)],
     products: [.library(name: "KeyKeyEngine", targets: ["KeyKeyEngine"])],
     targets: [
-        .target(name: "KeyKeyEngine"),
+        // StrictConcurrency turns on complete data-race checking. Under the Swift 5 language
+        // mode above it reports WARNINGS, not errors, so release semantics are unchanged — it
+        // exists to surface isolation and Sendable problems the app's own -swift-version 5
+        // compile cannot see. Keep this target at zero warnings.
+        .target(name: "KeyKeyEngine", swiftSettings: [.enableUpcomingFeature("StrictConcurrency")]),
         .testTarget(name: "KeyKeyEngineTests", dependencies: ["KeyKeyEngine"]),
     ],
     swiftLanguageModes: [.v5]

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/UserFrequency.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/UserFrequency.swift
@@ -15,7 +15,13 @@ import Foundation
 //   - `record` updates the in-memory count immediately (so `bonus` is always current) and
 //     schedules a coalesced background save rather than writing on every keystroke.
 //   - Distinct entries and single counts are capped to bound the on-disk file.
-public final class UserFrequency {
+//
+// The `@unchecked Sendable` conformance states that sharing invariant to the compiler, which
+// cannot see it on its own. It holds because EVERY stored property is either immutable or
+// lock-guarded: `fileURL`, `lock` and `saveQueue` are `let`, and `counts`, `dirty` and
+// `saveScheduled` are read and written only while `lock` is held (or in `init`, before the
+// instance is shared). Any new stored property must follow that rule or the conformance lapses.
+public final class UserFrequency: @unchecked Sendable {
     // Default on-disk location: ~/Library/Application Support/YahooKeyKey2/user-frequency.json
     public static func defaultFileURL() -> URL {
         let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first


### PR DESCRIPTION
From the `macos-swift-engineering` audit — P3 finding.

## Problem

Both packages pin `swiftLanguageModes: [.v5]` (deliberately — it keeps their semantics identical to the app's `-swift-version 5` compile in `tools/build-app.sh`), and no `-strict-concurrency` flag was passed anywhere. So **no compile-time data-race checking ran on any code in this project**. The main-thread invariants — four `MainActor.assumeIsolated` sites, which trap at runtime if violated — had nothing checking them statically, in a process loaded into every app on the machine.

## Change

`.enableUpcomingFeature("StrictConcurrency")` on both library targets. Under the Swift 5 language mode this reports **warnings, not errors**, so release semantics are unchanged. It also covers the five symlinked `App/` sources compiled by `KeyKeyApp`, which is the only compile-time concurrency checking any `App/` file gets.

It surfaced **exactly one** warning across both packages:

```
UserFrequency.swift:69:17: warning: capture of 'self' with non-Sendable type
'UserFrequency?' in a '@Sendable' closure
```

That is the debounced background save. The type genuinely is safe to share, so this states the invariant rather than suppressing the warning: `@unchecked Sendable` with a comment recording *why* it holds — every stored property is either a `let` or is read/written only under the existing `lock` — plus the rule any future property has to follow.

Both targets are now at zero warnings.

## Tests

- `swift test --package-path Packages/KeyKeyEngine` → **190 tests, 0 failures**, no warnings
- `swift test --package-path Packages/KeyKeyApp` → **40 tests, 0 failures**, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)