### PR TITLE
feat(a11y): expose the candidate window to assistive technologies

### DIFF
--- a/App/CandidateWindow.swift
+++ b/App/CandidateWindow.swift
@@ -29,6 +29,15 @@ final class CandidateWindow {
     private let footerRow = NSView()
     private let footerArrow = NSTextField(labelWithString: "▼")
     private let pageLabel = NSTextField(labelWithString: "")
+    // The rows are runs inside ONE attributed string, so they cannot be exposed by annotating the
+    // label; the box publishes a synthetic accessibility element per row instead (plus one for the
+    // page indicator). Created once rather than per show so assistive technologies keep seeing the
+    // same elements while the user types.
+    private let rowElements = (0..<9).map { _ in NSAccessibilityElement() }
+    private let pageElement = NSAccessibilityElement()
+    // Page last shown, so a page turn — which changes nothing else an assistive technology can
+    // observe — can be announced. Cleared on hide so a later list never announces against it.
+    private var lastShownPage: Int?
 
     init() {
         panel = NSPanel(contentRect: NSRect(x: 0, y: 0, width: 10, height: 10),
@@ -78,6 +87,28 @@ final class CandidateWindow {
             footerRow.widthAnchor.constraint(equalTo: candLabel.widthAnchor),
         ])
         panel.contentView = content
+        configureAccessibility()
+    }
+
+    // Static half of the accessibility exposure (roles, labels, what to ignore); the per-show half
+    // is in updateAccessibility.
+    private func configureAccessibility() {
+        // The box is a list of numbered choices. The drawn views are hidden from assistive
+        // technologies because neither reads usefully: the candidate label is one attributed blob,
+        // and the footer would be spoken as the bare glyph "▼" plus "1/3". The synthetic elements
+        // below stand in for both.
+        content.setAccessibilityElement(true)
+        content.setAccessibilityRole(.list)
+        content.setAccessibilityLabel("候選字")
+        for v in [candLabel, footerArrow, pageLabel] { v.setAccessibilityElement(false) }
+        for (i, element) in rowElements.enumerated() {
+            element.setAccessibilityRole(.staticText)
+            element.setAccessibilityLabel("\(i + 1)")   // the digit that selects this candidate
+            element.setAccessibilityParent(content)
+        }
+        pageElement.setAccessibilityRole(.staticText)
+        pageElement.setAccessibilityLabel("頁數")
+        pageElement.setAccessibilityParent(content)
     }
 
     private func configureChrome(_ field: NSTextField) {
@@ -144,6 +175,46 @@ final class CandidateWindow {
         panel.setContentSize(stack.fittingSize)
         positionPanel(near: caret)
         panel.orderFront(nil)
+        updateAccessibility(pageCandidates, page: page, pageCount: pageCount, hints: hints)
+    }
+
+    // Mirror what was just drawn into the synthetic elements. Purely additive: nothing here touches
+    // the views, so drawing and layout are unaffected.
+    private func updateAccessibility(_ pageCandidates: [String], page: Int, pageCount: Int,
+                                     hints: [String?]) {
+        // Row frames are derived from the label's frame, which is only final once the panel has
+        // been resized and the stack has actually laid out.
+        content.layoutSubtreeIfNeeded()
+        let listFrame = content.convert(candLabel.bounds, from: candLabel)
+        let visible = pageCandidates.prefix(9)
+        let rowHeight = listFrame.height / CGFloat(max(1, visible.count))
+        for (i, cand) in visible.enumerated() {
+            let element = rowElements[i]
+            if i < hints.count, let hint = hints[i], !hint.isEmpty {
+                element.setAccessibilityValue("\(cand)，\(hint)")
+            } else {
+                element.setAccessibilityValue(cand)
+            }
+            // Rows run top-down inside the label and view coordinates are y-up, so row 0 is the
+            // topmost slice. Equal slices ignore the inter-row paragraph gap — close enough to put
+            // the VoiceOver cursor on the right row.
+            element.setAccessibilityFrameInParentSpace(
+                NSRect(x: listFrame.minX, y: listFrame.maxY - CGFloat(i + 1) * rowHeight,
+                       width: listFrame.width, height: rowHeight))
+        }
+        pageElement.setAccessibilityValue("第 \(page + 1) 頁，共 \(pageCount) 頁")
+        pageElement.setAccessibilityFrameInParentSpace(content.convert(footerRow.bounds, from: footerRow))
+        content.setAccessibilityChildren(Array(rowElements.prefix(visible.count)) + [pageElement])
+
+        // A page turn leaves the window, its position and its element set unchanged, so nothing
+        // would be spoken on its own — announce the new position. Only on an actual change: every
+        // keystroke re-shows page 1, and announcing that would talk over the typing.
+        if let last = lastShownPage, last != page {
+            NSAccessibility.post(element: panel, notification: .announcementRequested,
+                                 userInfo: [.announcement: "第 \(page + 1) 頁，共 \(pageCount) 頁",
+                                            .priority: NSAccessibilityPriorityLevel.high.rawValue])
+        }
+        lastShownPage = page
     }
 
     // Layer colours are CGColors and don't auto-adapt to appearance, so resolve them against the
@@ -180,5 +251,8 @@ final class CandidateWindow {
         panel.setFrameTopLeftPoint(NSPoint(x: x, y: top))
     }
 
-    func hide() { panel.orderOut(nil) }
+    func hide() {
+        panel.orderOut(nil)
+        lastShownPage = nil   // the next show starts a fresh list, not a page turn
+    }
 }


### PR DESCRIPTION
From the `macos-swift-engineering` audit — P2 finding.

## Problem

`CandidateWindow` draws all nine candidates into **one** attributed `NSTextField` inside a borderless `.nonactivatingPanel`, and no accessibility role, label or value was set anywhere in the project. Picking a candidate is the app's core workflow, so a VoiceOver user got nothing usable: one undifferentiated text blob, and a footer that reads as the bare glyph `▼` plus `1/3`. Keyboard-only operation was already fine — this is purely about assistive-technology exposure.

## Change — synthetic accessibility elements, zero view changes

Nine `NSAccessibilityElement` rows plus one page element are published as children of the content view, over the existing drawing:

- content view → role `.list`, label `候選字`
- each row → label = the digit `1`–`9` that selects it, value = the candidate (plus the 反查 code hint when one is shown)
- page indicator → `第 2 頁，共 3 頁` instead of `▼` + `1/3`
- the drawn `candLabel` / `footerArrow` / `pageLabel` are marked non-elements so the raw blob is not read twice
- a page turn posts an `.announcementRequested` notification, since a page change alters nothing else an assistive technology can observe

The alternative — rebuilding the list as per-row `NSTextField`s — would have removed the tab-stop column alignment, the `paragraphSpacing` row gap and the equal-width constraints that size the whole box. **This approach touches no view, constraint, colour, font or geometry**, so "visually and behaviourally identical" holds by construction rather than by inspection.

## Verification — read this before merging

- `swiftc -typecheck … -swift-version 5 App/CandidateWindow.swift` → **clean, zero warnings** (run independently after review, not just by the author).
- **Runtime and VoiceOver behaviour is UNVERIFIED.** The bundle cannot be built here (it needs generated data files plus network dependencies) and VoiceOver could not be run. Specifically unverified: whether `.list` + `.staticText` children read as expected; whether the announcement is delivered from a `.nonactivatingPanel` that never becomes key; and whether a VoiceOver user can practically navigate *into* a panel owned by the IME process that never takes focus — the announcement may be the only channel that fires in practice.

## Known rough edges (deliberate)

- **No AX hit-testing** — pointer-driven VoiceOver navigation will not find the synthetic rows; that needs an `NSView` subclass overriding `accessibilityHitTest(_:)`. The window is number-key driven and never focused, so children-based traversal was judged enough.
- **Row frames are approximate** — equal slices of the label, ignoring the inter-row gap. Enough to place the VO cursor on the right row; exact placement would need laying the attributed string out a second time.
- **Announces on a reset to page 1** — if the user was on page 2+ and a new composition starts, the position is announced again. Informative, but slightly chatty.
- **Four inline zh-Hant strings**, no new localization keys (`候選字`, `頁數`, `第 N 頁，共 M 頁`, and the `，` hint separator) — they are the only user-visible strings added, if you later want them in `Localizable.strings`.

Nothing DragonKit-related, no build-script change, no new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)