### PR TITLE
refactor(input): extract pure key-routing decisions and cover them with tests

### DIFF
--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -29,12 +29,6 @@ final class InputController: IMKInputController {
     // association mode. Paged with `candidatePage`, shown in the same numbered candidate window.
     private var associations: [String] = []
     private static let pageSize = 9
-    // Number-row key codes → digit (1–9). Layout-stable and Shift-independent, unlike
-    // `characters`/`charactersIgnoringModifiers`, which return the shifted symbol (7 → &).
-    // Used to detect Shift+digit for associated-phrase selection (issue #52).
-    private static let numberRowDigits: [UInt16: Int] = [
-        18: 1, 19: 2, 20: 3, 21: 4, 23: 5, 22: 6, 26: 7, 28: 8, 25: 9,
-    ]
 
     override init!(server: IMKServer!, delegate: Any!, client inputClient: Any!) {
         // All heavy resources are loaded ONCE in SharedResources and shared across every
@@ -312,22 +306,23 @@ final class InputController: IMKInputController {
         if !associations.isEmpty {
             let count = associations.count
             let lastPage = (count - 1) / InputController.pageSize
-            switch event.keyCode {
-            case 53: // Escape dismisses associations
+            if event.keyCode == 53 { // Escape dismisses associations
                 clearAssociations(); return true
-            case 125, 124, 121: // Down / Right arrow / Page Down → next page
-                if candidatePage < lastPage { candidatePage += 1; refresh(client) }
-                return true
-            case 126, 123, 116: // Up / Left arrow / Page Up → previous page
-                if candidatePage > 0 { candidatePage -= 1; refresh(client) }
-                return true
-            default: break
+            }
+            // Arrows / Page Up / Page Down page through the suggestions; they are consumed even
+            // at the first/last page, which they clamp to.
+            switch KeyEventPolicy.pageStep(keyCode: event.keyCode, page: candidatePage,
+                                           lastPage: lastPage) {
+            case .move(let page): candidatePage = page; refresh(client); return true
+            case .atEdge: return true
+            case .notPaging: break
             }
             // SPACE pages to the next association page (wrapping last → first). On a
             // single page, fall through to dismiss the suggestions and insert a
             // literal space.
-            if event.keyCode == 49, lastPage > 0 {
-                candidatePage = (candidatePage + 1) % (lastPage + 1)
+            if event.keyCode == 49,
+               let page = KeyEventPolicy.spacePage(page: candidatePage, lastPage: lastPage) {
+                candidatePage = page
                 refresh(client)
                 return true
             }
@@ -338,24 +333,19 @@ final class InputController: IMKInputController {
             // since `characters`/`charactersIgnoringModifiers` both apply Shift (7 → &) — and
             // a bare digit is NOT a pick, so it falls through, dismisses, and the idle engine
             // lets the app type the number.
-            let selectionDigit: Int? = {
-                switch Preferences.associationSelectionTrigger {
-                case .number:
-                    if let chars = event.characters, let d = Int(chars), (1...9).contains(d) { return d }
-                case .shift:
-                    if event.modifierFlags.contains(.shift),
-                       event.modifierFlags.intersection([.control, .option, .command]).isEmpty,
-                       let d = InputController.numberRowDigits[event.keyCode] { return d }
-                }
-                return nil
-            }()
+            let selectionDigit = KeyEventPolicy.associationSelectionDigit(
+                trigger: Preferences.associationSelectionTrigger,
+                characters: event.characters,
+                modifierFlags: event.modifierFlags,
+                keyCode: event.keyCode)
             if let d = selectionDigit {
-                let index = candidatePage * InputController.pageSize + (d - 1)
-                if index < count {
+                if let index = KeyEventPolicy.candidateIndex(digit: d, page: candidatePage,
+                                                            pageSize: InputController.pageSize,
+                                                            count: count) {
                     // Associations are full phrases that START with the just-committed
                     // character (already in the document), so insert only the remainder
                     // after it (好 + association "好像" -> insert "像", giving 好像).
-                    let suffix = String(associations[index].dropFirst())
+                    let suffix = KeyEventPolicy.associationSuffix(associations[index])
                     clearAssociations()
                     if !suffix.isEmpty {
                         client.insertText(applyHanConvert(suffix), replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
@@ -438,14 +428,13 @@ final class InputController: IMKInputController {
         if !engine.candidates.isEmpty {
             let count = engine.candidates.count
             let lastPage = (count - 1) / InputController.pageSize
-            switch event.keyCode {
-            case 125, 124, 121: // Down / Right arrow / Page Down → next page
-                if candidatePage < lastPage { candidatePage += 1; refresh(client) }
-                return true
-            case 126, 123, 116: // Up / Left arrow / Page Up → previous page
-                if candidatePage > 0 { candidatePage -= 1; refresh(client) }
-                return true
-            default: break
+            // Arrows / Page Up / Page Down page through the candidates; they are consumed even at
+            // the first/last page, which they clamp to.
+            switch KeyEventPolicy.pageStep(keyCode: event.keyCode, page: candidatePage,
+                                           lastPage: lastPage) {
+            case .move(let page): candidatePage = page; refresh(client); return true
+            case .atEdge: return true
+            case .notPaging: break
             }
             // 以空白鍵確認字根 (issue #61): 速成 and 倉頡-with-`*` show candidates before the
             // code is finished, so the Space a 倉頡 typist presses out of muscle memory pages the
@@ -463,14 +452,16 @@ final class InputController: IMKInputController {
             // SPACE pages to the next candidate page (wrapping last → first). On a
             // single page there is nothing to page, so fall through to the
             // commit-first-candidate-on-space behaviour below.
-            if event.keyCode == 49, lastPage > 0 {
-                candidatePage = (candidatePage + 1) % (lastPage + 1)
+            if event.keyCode == 49,
+               let page = KeyEventPolicy.spacePage(page: candidatePage, lastPage: lastPage) {
+                candidatePage = page
                 refresh(client)
                 return true
             }
-            if let chars = event.characters, let d = Int(chars), (1...9).contains(d) {
-                let index = candidatePage * InputController.pageSize + (d - 1)
-                if index < count {
+            if let d = KeyEventPolicy.selectionDigit(characters: event.characters) {
+                if let index = KeyEventPolicy.candidateIndex(digit: d, page: candidatePage,
+                                                            pageSize: InputController.pageSize,
+                                                            count: count) {
                     engine.selectCandidate(index)
                     return commitCurrent(to: client, offerAssociations: true)
                 }

--- a/App/KeyEventPolicy.swift
+++ b/App/KeyEventPolicy.swift
@@ -31,6 +31,90 @@ enum KeyEventPolicy {
                                     alreadyConfirmed: Bool) -> Bool {
         enabled && autoCompletedCode && !alreadyConfirmed
     }
+
+    // MARK: - The numbered candidate window (candidates and 聯想 page identically)
+
+    /// The 1–9 selection digit a key event's `characters` denotes, or nil for anything else. Reads
+    /// `characters`, so a SHIFTED number key — which reports its symbol (7 → &) — is deliberately
+    /// not a selection.
+    static func selectionDigit(characters: String?) -> Int? {
+        guard let characters, let digit = Int(characters), (1...9).contains(digit) else { return nil }
+        return digit
+    }
+
+    // Number-row key codes → digit (1–9). Layout-stable and Shift-independent, unlike
+    // `characters`/`charactersIgnoringModifiers`, which return the shifted symbol (7 → &).
+    // Used to detect Shift+digit for associated-phrase selection (issue #52).
+    private static let numberRowDigits: [UInt16: Int] = [
+        18: 1, 19: 2, 20: 3, 21: 4, 23: 5, 22: 6, 26: 7, 28: 8, 25: 9,
+    ]
+
+    /// Which digit (if any) selects an associated phrase, given the configured trigger (issue #52).
+    /// In `.number` mode a plain 1–9 picks (Shift+digit yields a symbol that Int() rejects, so it
+    /// falls through and dismisses, as before). In `.shift` mode only Shift+1–9 with no ⌃⌥⌘ picks —
+    /// matched by physical key code, since `characters`/`charactersIgnoringModifiers` both apply
+    /// Shift (7 → &) — and a bare digit is NOT a pick, so it falls through, dismisses, and the idle
+    /// engine lets the app type the number.
+    static func associationSelectionDigit(trigger: AssociationTrigger, characters: String?,
+                                          modifierFlags: NSEvent.ModifierFlags,
+                                          keyCode: UInt16) -> Int? {
+        switch trigger {
+        case .number:
+            return selectionDigit(characters: characters)
+        case .shift:
+            guard modifierFlags.contains(.shift),
+                  modifierFlags.intersection([.control, .option, .command]).isEmpty else { return nil }
+            return numberRowDigits[keyCode]
+        }
+    }
+
+    /// The index into the FULL list that selection digit `digit` picks on `page`, or nil when that
+    /// row falls past the end of the list. A nil is not a key the caller should pass on: the last
+    /// page is rarely full, and a digit pressed on an empty row is swallowed so no stray number
+    /// leaks into the document.
+    static func candidateIndex(digit: Int, page: Int, pageSize: Int, count: Int) -> Int? {
+        let index = page * pageSize + (digit - 1)
+        return index < count ? index : nil
+    }
+
+    /// What an arrow / Page Up / Page Down key does to the shown page.
+    enum PageStep: Equatable {
+        /// Not a paging key: the caller carries on with its other branches.
+        case notPaging
+        /// A paging key on the first (or last) page. Arrows clamp rather than wrap, but the key is
+        /// still consumed, leaving the page and the marked text exactly as they are.
+        case atEdge
+        /// Show this page instead, and redraw.
+        case move(to: Int)
+    }
+
+    /// The paging step for a key pressed while the numbered window is up.
+    static func pageStep(keyCode: UInt16, page: Int, lastPage: Int) -> PageStep {
+        switch keyCode {
+        case 125, 124, 121: // Down / Right arrow / Page Down → next page
+            return page < lastPage ? .move(to: page + 1) : .atEdge
+        case 126, 123, 116: // Up / Left arrow / Page Up → previous page
+            return page > 0 ? .move(to: page - 1) : .atEdge
+        default:
+            return .notPaging
+        }
+    }
+
+    /// The page SPACE moves to, wrapping last → first — or nil on a single page, where there is
+    /// nothing to page and Space keeps its other meaning (dismiss the 聯想 suggestions and insert a
+    /// literal space; with candidates up, commit the first one).
+    static func spacePage(page: Int, lastPage: Int) -> Int? {
+        guard lastPage > 0 else { return nil }
+        return (page + 1) % (lastPage + 1)
+    }
+
+    /// The text a picked association inserts. Associations are full phrases that START with the
+    /// just-committed character (already in the document), so only the remainder after it is
+    /// inserted (好 + association "好像" -> insert "像", giving 好像). Empty for a one-character
+    /// phrase, which inserts nothing.
+    static func associationSuffix(_ phrase: String) -> String {
+        String(phrase.dropFirst())
+    }
 }
 
 // Pure input-session-lifecycle decisions for InputController.

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/KeyRoutingPolicyTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/KeyRoutingPolicyTests.swift
@@ -1,0 +1,204 @@
+import XCTest
+import AppKit
+@testable import KeyKeyApp
+
+// Characterization tests for the candidate/聯想 key-routing decisions InputController.handle()
+// consults — the numbered-window half of KeyEventPolicy. (KeyEventPolicyTests covers the two
+// older decisions, isSystemShortcut/spaceConfirmsStroke, i.e. issues #56 and #61.)
+//
+// Every expectation here was derived from the routing code as it stood BEFORE the extraction,
+// so a change in any of these values is a change in what the IME does on a keystroke — never a
+// test to "fix". The window is 9 rows (InputController.pageSize), so the tests pass pageSize: 9.
+final class KeyRoutingPolicyTests: XCTestCase {
+
+    // MARK: selectionDigit — the 1–9 pick read from `characters`
+
+    func testDigitCharactersSelect() {
+        for digit in 1...9 {
+            XCTAssertEqual(KeyEventPolicy.selectionDigit(characters: String(digit)), digit)
+        }
+    }
+
+    func testZeroIsNotASelection() {
+        // The window numbers rows 1–9, so 0 picks nothing and falls through to be typed.
+        XCTAssertNil(KeyEventPolicy.selectionDigit(characters: "0"))
+    }
+
+    func testNonDigitsAreNotSelections() {
+        XCTAssertNil(KeyEventPolicy.selectionDigit(characters: nil))
+        XCTAssertNil(KeyEventPolicy.selectionDigit(characters: ""))
+        XCTAssertNil(KeyEventPolicy.selectionDigit(characters: "a"))
+        XCTAssertNil(KeyEventPolicy.selectionDigit(characters: " "))
+        // Shift+1 reports its symbol, not the digit — this is exactly why a shifted number key
+        // is not a pick in the default (.number) 聯想 mode.
+        XCTAssertNil(KeyEventPolicy.selectionDigit(characters: "!"))
+        XCTAssertNil(KeyEventPolicy.selectionDigit(characters: "&"))
+        // Int() would parse "10", but it is outside the 1–9 the window offers.
+        XCTAssertNil(KeyEventPolicy.selectionDigit(characters: "10"))
+    }
+
+    // MARK: associationSelectionDigit — .number trigger (default, issue #52)
+
+    func testNumberTriggerPicksOnPlainDigit() {
+        XCTAssertEqual(KeyEventPolicy.associationSelectionDigit(trigger: .number, characters: "3",
+                                                                modifierFlags: [], keyCode: 20), 3)
+    }
+
+    func testNumberTriggerIgnoresTheKeyCode() {
+        // .number reads `characters` only, so any key that types a digit picks, and a key code
+        // from the number row does NOT pick by itself.
+        XCTAssertEqual(KeyEventPolicy.associationSelectionDigit(trigger: .number, characters: "7",
+                                                                modifierFlags: [], keyCode: 0), 7)
+        XCTAssertNil(KeyEventPolicy.associationSelectionDigit(trigger: .number, characters: "a",
+                                                              modifierFlags: [], keyCode: 18))
+    }
+
+    func testNumberTriggerFallsThroughOnShiftedDigit() {
+        // Shift+7 arrives as "&", which Int() rejects: no pick, so the caller dismisses the
+        // suggestions and processes the key normally. Documented as "as before" in the routing.
+        XCTAssertNil(KeyEventPolicy.associationSelectionDigit(trigger: .number, characters: "&",
+                                                              modifierFlags: [.shift], keyCode: 26))
+    }
+
+    // MARK: associationSelectionDigit — .shift trigger (issue #52)
+
+    func testShiftTriggerPicksByPhysicalNumberRowKeyCode() {
+        // The number row, left to right. Note 23/22 (5/6) and 26/28/25 (7/8/9) are not in
+        // ascending key-code order — that is the real US keyboard layout, not a typo.
+        let numberRow: [(UInt16, Int)] = [(18, 1), (19, 2), (20, 3), (21, 4), (23, 5),
+                                          (22, 6), (26, 7), (28, 8), (25, 9)]
+        for (keyCode, digit) in numberRow {
+            // `characters` is the shifted symbol here (7 → &) and is deliberately not consulted.
+            XCTAssertEqual(KeyEventPolicy.associationSelectionDigit(trigger: .shift, characters: "&",
+                                                                    modifierFlags: [.shift],
+                                                                    keyCode: keyCode),
+                           digit, "key code \(keyCode) must pick \(digit)")
+        }
+    }
+
+    func testShiftTriggerRejectsABareDigit() {
+        // The whole point of #52: with .shift selected, a plain 1–9 types the number instead of
+        // picking a phrase.
+        XCTAssertNil(KeyEventPolicy.associationSelectionDigit(trigger: .shift, characters: "1",
+                                                              modifierFlags: [], keyCode: 18))
+    }
+
+    func testShiftTriggerRejectsOtherModifiers() {
+        for extra in [NSEvent.ModifierFlags.control, .option, .command] {
+            XCTAssertNil(KeyEventPolicy.associationSelectionDigit(trigger: .shift, characters: "!",
+                                                                  modifierFlags: [.shift, extra],
+                                                                  keyCode: 18))
+        }
+    }
+
+    func testShiftTriggerToleratesCapsLock() {
+        // Caps Lock is not one of ⌃⌥⌘, so Shift+1 still picks with Caps on.
+        XCTAssertEqual(KeyEventPolicy.associationSelectionDigit(trigger: .shift, characters: "!",
+                                                                modifierFlags: [.shift, .capsLock],
+                                                                keyCode: 18), 1)
+    }
+
+    func testShiftTriggerRejectsKeysOffTheNumberRow() {
+        // 29 is the `0` key; 12 is `q`. Neither is in the 1–9 map.
+        XCTAssertNil(KeyEventPolicy.associationSelectionDigit(trigger: .shift, characters: ")",
+                                                              modifierFlags: [.shift], keyCode: 29))
+        XCTAssertNil(KeyEventPolicy.associationSelectionDigit(trigger: .shift, characters: "Q",
+                                                              modifierFlags: [.shift], keyCode: 12))
+    }
+
+    // MARK: candidateIndex — page arithmetic, shared by candidates and 聯想
+
+    func testFirstPageMapsDigitsToTheFirstNineRows() {
+        for digit in 1...9 {
+            XCTAssertEqual(KeyEventPolicy.candidateIndex(digit: digit, page: 0, pageSize: 9, count: 30),
+                           digit - 1)
+        }
+    }
+
+    func testLaterPagesOffsetByWholePages() {
+        XCTAssertEqual(KeyEventPolicy.candidateIndex(digit: 1, page: 1, pageSize: 9, count: 30), 9)
+        XCTAssertEqual(KeyEventPolicy.candidateIndex(digit: 9, page: 1, pageSize: 9, count: 30), 17)
+        XCTAssertEqual(KeyEventPolicy.candidateIndex(digit: 1, page: 2, pageSize: 9, count: 30), 18)
+    }
+
+    func testDigitPastTheEndOfTheListSelectsNothing() {
+        // A short last page: 20 candidates means page 2 shows only rows 1–2 (indices 18, 19).
+        XCTAssertEqual(KeyEventPolicy.candidateIndex(digit: 2, page: 2, pageSize: 9, count: 20), 19)
+        XCTAssertNil(KeyEventPolicy.candidateIndex(digit: 3, page: 2, pageSize: 9, count: 20))
+        XCTAssertNil(KeyEventPolicy.candidateIndex(digit: 9, page: 2, pageSize: 9, count: 20))
+        // Callers SWALLOW that nil rather than passing the key on, so no stray digit is typed.
+    }
+
+    func testShortSingleListPage() {
+        XCTAssertEqual(KeyEventPolicy.candidateIndex(digit: 3, page: 0, pageSize: 9, count: 3), 2)
+        XCTAssertNil(KeyEventPolicy.candidateIndex(digit: 4, page: 0, pageSize: 9, count: 3))
+    }
+
+    // MARK: pageStep — arrows and Page Up / Page Down
+
+    func testNextPageKeys() {
+        for keyCode: UInt16 in [125, 124, 121] { // Down / Right arrow / Page Down
+            XCTAssertEqual(KeyEventPolicy.pageStep(keyCode: keyCode, page: 0, lastPage: 2),
+                           .move(to: 1), "key code \(keyCode)")
+        }
+    }
+
+    func testPreviousPageKeys() {
+        for keyCode: UInt16 in [126, 123, 116] { // Up / Left arrow / Page Up
+            XCTAssertEqual(KeyEventPolicy.pageStep(keyCode: keyCode, page: 2, lastPage: 2),
+                           .move(to: 1), "key code \(keyCode)")
+        }
+    }
+
+    func testPagingKeysAtTheEdgesDoNotWrapButAreStillConsumed() {
+        // Arrows clamp — unlike Space, which wraps. Both ends still swallow the key so the arrow
+        // never reaches the app while the window is up.
+        XCTAssertEqual(KeyEventPolicy.pageStep(keyCode: 125, page: 2, lastPage: 2), .atEdge)
+        XCTAssertEqual(KeyEventPolicy.pageStep(keyCode: 126, page: 0, lastPage: 2), .atEdge)
+        // A single page has nowhere to go in either direction.
+        XCTAssertEqual(KeyEventPolicy.pageStep(keyCode: 125, page: 0, lastPage: 0), .atEdge)
+        XCTAssertEqual(KeyEventPolicy.pageStep(keyCode: 126, page: 0, lastPage: 0), .atEdge)
+    }
+
+    func testNonPagingKeysFallThrough() {
+        // Space (49), Return (36), Escape (53), Backspace (51) and ordinary keys (18 = "1") all
+        // have their own meanings further down handle(), so paging must not claim them.
+        for keyCode: UInt16 in [49, 36, 53, 51, 18, 0] {
+            XCTAssertEqual(KeyEventPolicy.pageStep(keyCode: keyCode, page: 0, lastPage: 2),
+                           .notPaging, "key code \(keyCode)")
+        }
+    }
+
+    // MARK: spacePage — Space wraps last → first
+
+    func testSpaceAdvancesAPage() {
+        XCTAssertEqual(KeyEventPolicy.spacePage(page: 0, lastPage: 2), 1)
+        XCTAssertEqual(KeyEventPolicy.spacePage(page: 1, lastPage: 2), 2)
+    }
+
+    func testSpaceWrapsFromTheLastPageBackToTheFirst() {
+        XCTAssertEqual(KeyEventPolicy.spacePage(page: 2, lastPage: 2), 0)
+        XCTAssertEqual(KeyEventPolicy.spacePage(page: 1, lastPage: 1), 0)
+    }
+
+    func testSpaceOnASinglePageIsNotPaging() {
+        // nil means "fall through": in 聯想 that dismisses the suggestions and types a literal
+        // space; with candidates up it commits the first candidate.
+        XCTAssertNil(KeyEventPolicy.spacePage(page: 0, lastPage: 0))
+    }
+
+    // MARK: associationSuffix — insert only the continuation
+
+    func testSuffixDropsTheAlreadyCommittedFirstCharacter() {
+        // 好 is already in the document; picking "好像" must insert only "像".
+        XCTAssertEqual(KeyEventPolicy.associationSuffix("好像"), "像")
+        XCTAssertEqual(KeyEventPolicy.associationSuffix("關係"), "係")
+        XCTAssertEqual(KeyEventPolicy.associationSuffix("中華民國"), "華民國")
+    }
+
+    func testSingleCharacterAssociationHasNothingToInsert() {
+        // The caller checks for empty and inserts nothing rather than an empty string.
+        XCTAssertEqual(KeyEventPolicy.associationSuffix("好"), "")
+        XCTAssertEqual(KeyEventPolicy.associationSuffix(""), "")
+    }
+}


### PR DESCRIPTION
From the `macos-swift-engineering` audit — P2 finding. **This is the riskiest change in the batch; please review the wiring rather than rubber-stamping it.**

## Problem

`InputController.handle(_:client:)` is a ~240-line method routing seven modes, and only two pure decisions had been extracted (`isSystemShortcut`, `spaceConfirmsStroke`). Everything else needs a live `IMKTextInput` and an IMK server to exercise, so it had **zero** coverage — despite being exactly where issues #52, #56, #61 and #70 were fixed.

## Change

Continues the pattern the repo already established with `KeyEventPolicy` / `SessionEndPolicy`. Six pure decisions moved into `App/KeyEventPolicy.swift` (no new `App/` file — `tools/build-app.sh` compiles a hard-coded source list, and that file is already symlinked into the test package):

| Extracted | Covers |
|---|---|
| `selectionDigit(characters:)` | 1–9 pick; `"0"`, `"10"`, `""`, shifted symbols → nil |
| `associationSelectionDigit(trigger:characters:modifierFlags:keyCode:)` | issue #52 — `.number` vs `.shift`, physical key codes |
| `candidateIndex(digit:page:pageSize:count:)` | page offset arithmetic and the short-last-page swallow |
| `pageStep(keyCode:page:lastPage:)` | arrows / Page Up / Page Down, including clamp-but-consume at the edges |
| `spacePage(page:lastPage:)` | Space paging with last → first wrap, nil on a single page |
| `associationSuffix(_:)` | the `dropFirst()` insertion (好 + "好像" → "像") |

`InputController` keeps its structure, its branch order and every existing comment — the touched branches become calls to these functions with the surrounding effect code unchanged. **No behavior change intended.**

Tests were written first against the not-yet-existing API (confirmed red: `type 'KeyEventPolicy' has no member 'selectionDigit'`), then the extraction made them green, then `InputController` was rewired and the same tests re-run unchanged.

## Verification (re-run independently, not just by the author)

- `swift test --package-path Packages/KeyKeyApp` → **64 tests, 0 failures** (baseline 40 + 24 new)
- `swift test --package-path Packages/KeyKeyEngine` → **190 tests, 0 failures**
- `./tools/build-app.sh` → the "Compiling App against KeyKeyEngine + DragonKit" step emits nothing (no errors, no warnings) and links a 1.5 MB arm64 executable, failing only at the expected `Resources/data.txt missing` check. That proves `InputController.swift` compiles and links.
- Every substitution was re-read line by line against the original; all are equivalent.

## What to actually review

1. **No test exercises `handle()` itself.** The pure functions are pinned, but the *wiring* is verified by review + clean compile only. A swapped `.atEdge`/`.notPaging` or a wrong argument would compile and pass all 64 tests. The four spots: `InputController.swift` ~306-330 (association Esc/paging/Space), ~333-350 (association digit/index/suffix), ~428-440 (candidate paging), ~452-467 (candidate Space/digit/index).
2. **One control-flow shape change:** in the association block, `case 53` (Escape) became a standalone `if` ahead of the paging `switch`. Equivalent because the key codes are disjoint and Escape is evaluated first either way — but that is reasoning, not a test.
3. **One member relocated:** `numberRowDigits` moved from `InputController` to `KeyEventPolicy` (it had to, for the key-code path to be testable), keeping its access level and comment. One stale mention remains in a historical plan doc under `docs/superpowers/`, left alone as out of scope.
4. **Inherited quirk, not introduced:** `selectionDigit` uses `Int(String)`, so `"+5"` would parse as 5. Equally true before; `NSEvent.characters` cannot produce it for one keystroke.

Deliberately **not** extracted, still uncovered: `lastPage` arithmetic, the 拼音 block, 臨時英數, the `*` wildcard, full-width punctuation, and the Return/Backspace/Esc tail — all need `insertText`/`setMarkedText` or the engine, so the effects were left alone.

Nothing DragonKit-related was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)