### PR TITLE
perf(build): compile release builds with -O

### DIFF
--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -41,6 +41,14 @@ SDK="$(xcrun --show-sdk-path)"
 # architecture. Yahoo KeyKey 2 does not ship an Intel (x86_64) slice. macOS 26 minimum.
 TARGET="arm64-apple-macosx26.0"
 
+# Optimization. swiftc defaults to -Onone, so until now every build — including the notarized
+# release, which comes through this same script — shipped the engine and the app UNOPTIMIZED,
+# inside a process attached to every app that takes keyboard input. Measured on the bundled 五代
+# table (arm64, Xcode 26.6), -Onone vs -O: Cangjie table parse 73 -> 34 ms, 速成 table derive
+# 78 -> 8 ms, 2000 速成 compositions 21 -> 2 ms. A local debug build stays at -Onone so the
+# debugger is usable (and so assert/precondition survive into the build being tested).
+if [[ "${KEYKEY_DEBUG_ID:-}" == "1" ]]; then OPT="-Onone"; else OPT="-O"; fi
+
 # Optional: regenerate the bundled LM (Resources/data.txt) first. A clean checkout omits
 # data.txt by design; pass --build-lm to generate it via tools/build-lm.sh before building.
 if [[ "${1:-}" == "--build-lm" ]]; then
@@ -63,7 +71,7 @@ swiftc \
   -emit-module-path "$MODULE_DIR/KeyKeyEngine.swiftmodule" \
   -o "$MODULE_DIR/libKeyKeyEngine.a" \
   -sdk "$SDK" -target "$TARGET" \
-  -swift-version 5 \
+  -swift-version 5 "$OPT" \
   "$ENGINE_SRC"/*.swift
 
 echo "==> Building DragonKit (SwiftPM, release) in pinned checkout"
@@ -96,7 +104,7 @@ mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
 swiftc \
   -o "$APP/Contents/MacOS/$EXECUTABLE_NAME" \
   -sdk "$SDK" -target "$TARGET" \
-  -swift-version 5 \
+  -swift-version 5 "$OPT" \
   -I "$MODULE_DIR" -L "$MODULE_DIR" -lKeyKeyEngine \
   -I "$KIT_MODULES" \
   -lDragonKit -lDragonKitUpdates \


### PR DESCRIPTION
From the `macos-swift-engineering` audit — P2 finding, the last one with a measurable user impact.

## Problem

`swiftc` defaults to `-Onone`, and neither compile in `tools/build-app.sh` passed an optimization flag. Since `release.yml` uses `build_kind: script` and `package-release.sh` calls this same script, **every notarized release so far shipped the engine and the app unoptimized** — inside a process attached to every app on the machine that takes keyboard input.

(DragonKit was unaffected: it is built with `swift build -c release`. This was only KeyKey's own code.)

## Measured, not assumed

Engine compiled both ways against the bundled 五代 table, arm64, Xcode 26.6, best of three runs:

| | `-Onone` (shipped until now) | `-O` |
|---|---|---|
| Cangjie table parse | 73 ms | **34 ms** |
| 速成 table derive | 78 ms | **8 ms** |
| 2000 速成 compositions | 21 ms | **2 ms** |
| **total** | **174 ms** | **44 ms** |

The table parse and 速成 derive are launch/first-use cost; the composition loop is the per-keystroke path.

## Change

One variable, applied to both `swiftc` invocations. A local debug build (`KEYKEY_DEBUG_ID=1`, i.e. `tools/run-debug.sh`) stays at `-Onone` so the debugger remains usable and `assert`/`precondition` survive into the build actually being tested.

## Verification

- `bash -n tools/build-app.sh` → clean.
- Flag resolution checked both ways: unset → `-O`, `KEYKEY_DEBUG_ID=1` → `-Onone`.
- **Full `./tools/build-app.sh` run**: both "Compiling KeyKeyEngine module" and "Compiling App against KeyKeyEngine + DragonKit" completed with zero errors and zero warnings under `-O`, and linked a 1,303,552-byte arm64 executable. It stops only at the expected `Resources/data.txt missing` check, which a clean checkout omits by design.
- Not verified: the running IME itself (that needs `build-lm.sh` plus a login cycle). Nothing here changes code — only the optimization level.

## One follow-up this creates

`InputController.menu()` carries a comment arguing "this app is linked without -O, so an `assert()` would be live in the shipped build". With `-O`, asserts are compiled out, so that reasoning inverts — though its conclusion (log and degrade rather than assert) still stands, and nothing breaks. It sits in the DragonKit-facing menu block, which was explicitly out of scope for this batch, so it is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)