### PR TITLE
ci: fail the build on compiler warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,12 @@ jobs:
         run: swift --version
 
       # KeyKeyEngine has no external dependencies — it tests standalone.
+      # -warnings-as-errors is the gate: a compiler warning fails the build rather than
+      # scrolling past in the log. It is what gives the packages' StrictConcurrency setting
+      # (see Packages/*/Package.swift) teeth — those data-race findings are warnings under the
+      # Swift 5 language mode, so without this nothing would stop one from landing.
       - name: Engine tests (KeyKeyEngine)
-        run: swift test --package-path Packages/KeyKeyEngine
+        run: swift test --package-path Packages/KeyKeyEngine -Xswiftc -warnings-as-errors
 
       # The App-logic package depends on the pinned DragonKit checkout (vendor/ is gitignored,
       # cloned on demand). Read the SAME tag build-app.sh pins so CI never drifts from release.
@@ -35,4 +39,4 @@ jobs:
           git clone --depth 1 --branch "$TAG" https://github.com/teddychan/dragon-kit vendor/dragon-kit
 
       - name: App-logic tests (KeyKeyApp)
-        run: swift test --package-path Packages/KeyKeyApp
+        run: swift test --package-path Packages/KeyKeyApp -Xswiftc -warnings-as-errors


### PR DESCRIPTION
From the `macos-swift-engineering` audit — the last item, a Note-level finding. Completes the batch.

## Problem

`tests.yml` ran both suites but passed no warning gate, and there is no lint or format step anywhere. A compiler warning would scroll past in the log and land on `main`. The standard treats warnings as defects; nothing enforced that.

This got sharper with #77: `StrictConcurrency` reports complete data-race checking as **warnings** under the Swift 5 language mode, so without a gate those findings had nothing backing them up.

## Change

`-Xswiftc -warnings-as-errors` on both `swift test` steps.

## Verification

Run locally from a **wiped `.build`** with the exact commands CI will run, on current `main`:

| Step | Result |
|---|---|
| `swift test --package-path Packages/KeyKeyEngine -Xswiftc -warnings-as-errors` | **193 tests, 0 failures**, no warnings |
| `swift test --package-path Packages/KeyKeyApp -Xswiftc -warnings-as-errors` | **64 tests, 0 failures**, no warnings |

The app package compiles DragonKit from source, so the flag applies to it too — it is clean at the pinned `v2.1.0`. Worth knowing: a future DragonKit bump that introduces a warning will now fail this repo's CI. That is the intended trade, but it is the one way this can bite from outside.

Note this covers the two SwiftPM packages, which include the five symlinked `App/` sources. The other eight `App/` files are compiled only by `tools/build-app.sh`, which CI does not run — so they remain ungated. (They do build warning-free today; that was checked by hand while verifying #81.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)