### PR TITLE
feat(deps): adopt DragonKit v2.4.0

### DIFF
--- a/App/AppMenuController.swift
+++ b/App/AppMenuController.swift
@@ -25,6 +25,13 @@ final class AppMenuController {
         if selection.paneID == nil { selection.paneID = "general" }
         return DragonSettingsWindowController(
             title: AboutConfig.appName,
+            // Same reason, and the same spelling, as the includeQuit: false the IMK dropdown
+            // passes to DragonAppMenu (InputController): a system-managed IME is quit by the
+            // system, not by the user. The kit installs a menu bar while Settings is open, so
+            // without this the settings menu bar would reintroduce the Quit ⌘Q the dropdown
+            // deliberately omits. Not installsMainMenu: false — that would also drop ⌘W and
+            // Cut/Copy/Paste, which settings text fields get only from these menu items.
+            includeQuit: false,
             rootView: SettingsRoot(
                 appName: AboutConfig.appName,
                 panesBuilder: { [weak self] in self?.settingsPanes ?? [] },

--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -81,7 +81,7 @@ echo "==> Building DragonKit (SwiftPM, release) in pinned checkout"
 # package's own tools version (6.1) — a separate compilation from the app's -swift-version 5.
 # Clone the pinned tag on first use (e.g. a fresh CI checkout); vendor/ is gitignored, never
 # committed. Idempotent: an existing checkout (local dev) is reused as-is.
-DRAGONKIT_TAG="v2.1.0"
+DRAGONKIT_TAG="v2.4.0"
 if [ ! -d "$KIT_DIR" ]; then
   echo "==> Cloning DragonKit $DRAGONKIT_TAG into vendor/ (not committed)"
   git clone --depth 1 --branch "$DRAGONKIT_TAG" https://github.com/teddychan/dragon-kit "$KIT_DIR"


### PR DESCRIPTION
Jumps the DragonKit pin from **v2.1.0 straight to v2.4.0** — this app was the last of the four Dragon apps still on 2.1.0, so it picks up three releases of shared fixes at once.

## Why this matters

The fix that matters is the **settings-decode data loss**. Swift's synthesized `Decodable` does *not* fall back to a property's default when a key is missing from the encoded blob. So the first time this app adds a field to its settings struct:

1. Decoding the stored blob throws.
2. `DragonSettingsStore` silently returns defaults.
3. The next settings change writes those defaults back over the user's real settings.

Every preference reset on upgrade — no error, no recovery. Also fixed in the same span: restoring a malformed backup **erased** the settings suite instead of refusing, and a failed uninstall reported success.

## `includeQuit: false`

v2.3.0 made `DragonSettingsWindowController` install a menu bar while Settings is open; v2.4.0 added the option an input method needs.

`App/InputController.swift` already passes `includeQuit: false` to `DragonAppMenu`, because a system-managed IME is quit by the system and not by the user. Without this the settings menu bar would reintroduce the very Quit ⌘Q that dropdown deliberately omits.

Deliberately **not** `installsMainMenu: false` — that would also drop ⌘W and Cut/Copy/Paste, and settings text fields get the pasteboard verbs *only* from those menu items.

## Verification

The vendored checkout was deleted before building, so this is a genuinely fresh clone at the new tag rather than a stale local one silently reused (`build-app.sh` reuses an existing `vendor/dragon-kit` as-is):

```
$ git -C vendor/dragon-kit tag --points-at HEAD
v2.4.0                       # commit dbc3a4a
```

- **Build:** clean, exit 0, **zero warnings**. (`includeQuit:` compiling at all is itself proof of the new kit — the parameter does not exist in v2.1.0.)
- **Tests:** 193 engine + 64 app tests pass under `-warnings-as-errors`, matching CI.
- **Conformance:** `dragon-conformance.py` flips `FAIL — R10 tools/build-app.sh: pinned to DragonKit 2.1.0 but 2.4.0 is released` → **`PASS — no violations.`**
- **Deprecations:** none. The 5 `DragonForm`/`DragonSection` call sites pass no `spacing:`, so they bind to the current overloads, not the ones v2.3.0 deprecated.

Settings menu bar, confirmed live:

```
 | Yahoo KeyKey 2 | Edit | Window
    Yahoo KeyKey 2:  Hide, Hide Others, Show All      <- no Quit
    Edit:            Undo/Redo, Cut/Copy/Paste/Select All
    Window:          Close ⌘W, Minimize ⌘M
```

No tag pushed and no release cut — that decision is deliberately left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
