### PR TITLE
Adopt DragonKit v3.0.1 and its fixed-slot About pane

### DIFF
--- a/.dragon-conformance.json
+++ b/.dragon-conformance.json
@@ -4,6 +4,7 @@
   "strings": ["App/**/*.lproj/Localizable.strings"],
   "pin": { "file": "tools/build-app.sh", "pattern": "DRAGONKIT_TAG=\"v([0-9.]+)\"" },
   "paneOrder": { "file": "App/AppMenuController.swift" },
+  "buildFiles": ["tools/*.sh", ".github/workflows/*.yml"],
   "traits": ["sparkle", "no-permissions"],
   "exceptions": []
 }

--- a/App/AboutConfig.swift
+++ b/App/AboutConfig.swift
@@ -1,9 +1,10 @@
 import Foundation
 import DragonKit
 
-// About-pane content, ported from the old AboutWindow.swift. Reuses the same name, links,
-// and origin/data attributions. Debug builds re-id the bundle to <release-id>.debug; detect
-// that so a test build shows a distinct "Yahoo! KeyKey 2 Debug" name/version like before.
+// About-pane content. DragonKit v3 owns every row title, SF Symbol and ordering — this file
+// supplies only URLs and proper nouns, so the pane cannot drift from the other Dragon apps.
+// Debug builds re-id the bundle to <release-id>.debug; detect that so a test build shows a
+// distinct "Yahoo! KeyKey 2 Debug" name/version like before.
 enum AboutConfig {
     private static let isDebugBuild = Bundle.main.bundleIdentifier?.hasSuffix(".debug") ?? false
     static let appName = "Yahoo! KeyKey 2" + (isDebugBuild ? " Debug" : "")
@@ -17,32 +18,31 @@ enum AboutConfig {
         AboutContent(
             appName: appName,
             versionString: versionString,
-            copyright: "倉頡／簡易 輸入法",
-            links: [
-                AboutLink(
-                    title: L("keykey.about.website"),
-                    detail: "www.dragonapp.com/keykey",
-                    systemImage: "globe",
-                    url: URL(string: "https://www.dragonapp.com/keykey")!
-                ),
-                AboutLink(
-                    title: L("keykey.about.support"),
-                    detail: "teddychan/yahoo-keykey-2",
-                    systemImage: "ladybug",
-                    url: URL(string: "https://github.com/teddychan/yahoo-keykey-2/issues")!
-                ),
-                AboutLink(
-                    title: L("keykey.about.origin"),
-                    detail: "ninjapanda/YahooKeyKey",
-                    systemImage: "heart",
-                    url: URL(string: "https://github.com/ninjapanda/YahooKeyKey")!
-                ),
-            ],
-            credits: [
-                (label: L("keykey.about.origin"), value: "Yahoo! KeyKey (ninjapanda · zonble)"),
-                (label: L("keykey.about.languageModel"), value: "openvanilla/McBopomofo"),
-                (label: L("keykey.about.cangjieTable"), value: "ibus-table-chinese"),
-                (label: L("keykey.about.hanConversion"), value: "OpenCC (Apache-2.0)"),
+            // Single holder, deliberately. The dual-holder form would also name the upstream
+            // project's copyright, but this app is an independent reimplementation that uses no
+            // Yahoo! KeyKey source code (docs/THIRD-PARTY-NOTICES.md) and disclaims affiliation
+            // (README.md) — so claiming a Yahoo copyright over this binary would contradict both.
+            // The lineage is carried by originalProjectURL and originalWork instead, and the New
+            // BSD notice for the Yahoo-derived Cangjie tables lives on the licences page.
+            copyright: DragonAbout.copyright(years: "2026", holder: "Teddy Chan"),
+            // The canonical marketing page is repo-named; /keykey/ is a <meta refresh> stub whose
+            // rel=canonical points here. The kit checks this path against supportURL's repo name.
+            websiteURL: URL(string: "https://www.dragonapp.com/yahoo-keykey-2/")!,
+            supportURL: URL(string: "https://github.com/teddychan/yahoo-keykey-2/issues")!,
+            license: "MIT",
+            originalProjectURL: URL(string: "https://github.com/ninjapanda/YahooKeyKey")!,
+            // Third-party notices, chiefly OpenCC's Apache-2.0 licence and NOTICE, which that
+            // licence requires ship with the app. Trailing slash: it is the path Pages serves, so
+            // the row does not point at a redirect.
+            licensesURL: URL(string: "https://www.dragonapp.com/yahoo-keykey-2/licenses/")!,
+            originalWork: OriginalWork(name: "Yahoo! KeyKey", author: "ninjapanda · zonble"),
+            // The only app-specific rows in the pane. Unlike the canon labels above the kit does
+            // not own these — an IME's data sources have no counterpart in the other apps — so
+            // they keep their own localized keys.
+            attributions: [
+                Attribution(component: L("keykey.about.languageModel"), source: "openvanilla/McBopomofo"),
+                Attribution(component: L("keykey.about.cangjieTable"), source: "ibus-table-chinese"),
+                Attribution(component: L("keykey.about.hanConversion"), source: "OpenCC (Apache-2.0)"),
             ]
         )
     }

--- a/App/WhatsNewConfig.swift
+++ b/App/WhatsNewConfig.swift
@@ -1,14 +1,15 @@
 import Foundation
 import DragonKit
 
-// "What's New" content for the current release (2.10.0): VoiceOver support for the candidate
-// window, optimized builds, a real menu bar in Settings, and four fixes. Keep in sync with
-// CHANGELOG.md on release.
+// "What's New" content for the current release: VoiceOver support for the candidate window,
+// optimized builds, a real menu bar in Settings, and four fixes. The version is not passed — it
+// defaults to CFBundleShortVersionString and the kit adds the "v", so the pane cannot claim a
+// release the binary isn't. That makes the entries and the date the only things to keep in sync
+// with CHANGELOG.md on release.
 enum WhatsNewConfig {
     @MainActor
     static var content: WhatsNewContent {
         WhatsNewContent(
-            version: "2.10.0",
             date: "2026-08-07",
             summary: L("keykey.whatsNew.summary"),
             sections: [

--- a/App/en.lproj/Localizable.strings
+++ b/App/en.lproj/Localizable.strings
@@ -28,10 +28,7 @@
 "keykey.general.strokeConfirmationHint" = "In 速成, and in 倉頡 with the * wildcard, candidates appear before the code is finished, so Space flips to the next page instead of confirming what you typed. With this on, the first Space only confirms the code and keeps page 1 — press Space again to page, or 1–9 to pick. Plain 倉頡 is unaffected.";
 "keykey.general.language" = "Language";
 
-/* About pane */
-"keykey.about.website" = "Website";
-"keykey.about.support" = "Report an issue on GitHub";
-"keykey.about.origin" = "Homage to the original";
+/* About pane — attribution rows only; DragonKit owns every other label in the pane */
 "keykey.about.languageModel" = "Language model";
 "keykey.about.cangjieTable" = "Cangjie table";
 "keykey.about.hanConversion" = "Han conversion";

--- a/App/zh-Hant.lproj/Localizable.strings
+++ b/App/zh-Hant.lproj/Localizable.strings
@@ -28,10 +28,7 @@
 "keykey.general.strokeConfirmationHint" = "在速成、以及使用萬用字元（*）的倉頡中，字根還沒打完就會出現候選字，此時空白鍵會直接翻到下一頁，而不是確認你打的字根。開啟後，第一次按空白鍵只會確認字根並停留在第 1 頁；再按一次空白鍵才翻頁，或直接按 1–9 選字。一般倉頡不受影響。";
 "keykey.general.language" = "語言";
 
-/* About pane */
-"keykey.about.website" = "網站";
-"keykey.about.support" = "在 GitHub 回報問題";
-"keykey.about.origin" = "向原版致敬";
+/* About pane — attribution rows only; DragonKit owns every other label in the pane */
 "keykey.about.languageModel" = "語言模型";
 "keykey.about.cangjieTable" = "倉頡碼表";
 "keykey.about.hanConversion" = "漢字轉換";

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
@@ -24,24 +24,56 @@ final class ConfigContentTests: XCTestCase {
     func testAboutContentStructure() {
         let content = AboutConfig.content
         XCTAssertEqual(content.appName, "Yahoo! KeyKey 2")
-        XCTAssertEqual(content.copyright, "倉頡／簡易 輸入法")
-        XCTAssertEqual(content.links.count, 3)
-        XCTAssertEqual(content.credits.count, 4)
-        // Every link carries a resolvable https URL and an SF Symbol name.
-        for link in content.links {
-            XCTAssertEqual(link.url.scheme, "https")
-            XCTAssertFalse(link.systemImage.isEmpty)
+        // A real copyright, not the IME description that used to sit in this slot.
+        XCTAssertEqual(content.copyright, "© 2026 Teddy Chan")
+        XCTAssertEqual(content.license, "MIT")
+        // Both optional link slots are filled, so all four canon rows render, in kit order. The
+        // titles and symbols are the kit's; what this pins is that the app fills the right slots.
+        XCTAssertEqual(content.linkRows.map(\.systemImage),
+                       ["globe", "lifepreserver", "heart", "doc.text"])
+        // Details are derived from the URLs, so asserting them pins where each row actually goes.
+        XCTAssertEqual(content.linkRows.map(\.detail), [
+            "dragonapp.com/yahoo-keykey-2",
+            "teddychan/yahoo-keykey-2",
+            "ninjapanda/YahooKeyKey",
+            "dragonapp.com/yahoo-keykey-2/licenses",
+        ])
+        for row in content.linkRows {
+            XCTAssertEqual(row.url.scheme, "https")
         }
-        XCTAssertEqual(content.links.map(\.detail),
-                       ["www.dragonapp.com/keykey", "teddychan/yahoo-keykey-2", "ninjapanda/YahooKeyKey"])
+    }
+
+    // The Website row must address this repo's canonical page. It pointed at
+    // www.dragonapp.com/keykey, a <meta refresh> stub whose canonical is /yahoo-keykey-2/.
+    @MainActor
+    func testAboutWebsiteMatchesSupportRepo() {
+        XCTAssertTrue(AboutConfig.content.websiteMatchesSupportRepo)
+    }
+
+    // Created by → Based on → Built with → License, then the app's own data attributions last.
+    // "Homage to the original" used to appear twice, as both a link and a credit; it is now the
+    // Original project link plus this one Based-on credit.
+    @MainActor
+    func testAboutCreditRowsEndWithTheDataAttributions() {
+        let content = AboutConfig.content
+        XCTAssertEqual(content.originalWork,
+                       OriginalWork(name: "Yahoo! KeyKey", author: "ninjapanda · zonble"))
+        XCTAssertEqual(content.creditRows.count, 7)
+        XCTAssertEqual(Array(content.creditRows.map(\.value).suffix(3)),
+                       ["openvanilla/McBopomofo", "ibus-table-chinese", "OpenCC (Apache-2.0)"])
     }
 
     // MARK: WhatsNewConfig
 
+    // The pane hardcoded "2.10.0" while About read the bundle, so the two would disagree the day
+    // 2.11.0 shipped. It now takes no version argument and reads CFBundleShortVersionString —
+    // re-adding a literal fails here, because the expectation is computed from the same bundle.
     @MainActor
-    func testWhatsNewVersionMatchesCurrentRelease() {
+    func testWhatsNewVersionTracksTheBundleAndIsPrefixed() {
         let content = WhatsNewConfig.content
-        XCTAssertEqual(content.version, "2.10.0")
+        let short = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        XCTAssertEqual(content.displayVersion, DragonVersion.display(short ?? "1.0.0"))
+        XCTAssertTrue(content.displayVersion.hasPrefix("v"))
         XCTAssertEqual(content.date, "2026-08-07")
     }
 

--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -81,10 +81,16 @@ echo "==> Building DragonKit (SwiftPM, release) in pinned checkout"
 # package's own tools version (6.1) — a separate compilation from the app's -swift-version 5.
 # Clone the pinned tag on first use (e.g. a fresh CI checkout); vendor/ is gitignored, never
 # committed. Idempotent: an existing checkout (local dev) is reused as-is.
-DRAGONKIT_TAG="v2.4.0"
+DRAGONKIT_TAG="v3.0.1"
 if [ ! -d "$KIT_DIR" ]; then
   echo "==> Cloning DragonKit $DRAGONKIT_TAG into vendor/ (not committed)"
   git clone --depth 1 --branch "$DRAGONKIT_TAG" https://github.com/teddychan/dragon-kit "$KIT_DIR"
+elif [ "$(git -C "$KIT_DIR" describe --tags --exact-match 2>/dev/null || true)" != "$DRAGONKIT_TAG" ]; then
+  # Still reused as-is — pointing vendor/ at a kit branch is how the kit is co-developed — but say
+  # so, because a stale checkout links a different kit than the pin claims and About's
+  # "Built with · DragonKit vX.Y.Z" row would then misreport what the binary compiled against.
+  echo "WARNING: vendor/dragon-kit is not at $DRAGONKIT_TAG; building against it as-is." >&2
+  echo "         Remove vendor/dragon-kit to build against the pinned tag." >&2
 fi
 ( cd "$KIT_DIR" && swift build -c release )
 KIT_REL="$(cd "$KIT_DIR" && swift build -c release --show-bin-path)"
@@ -120,6 +126,16 @@ sed "s/\${EXECUTABLE_NAME}/$EXECUTABLE_NAME/g" "$APP_SRC/Info.plist" > "$APP/Con
 # About shows "<short> (<build>)" and each build differs. Falls back to 1 outside a git checkout.
 BUILD_NUM="$(git -C "$ROOT" rev-list --count HEAD 2>/dev/null || echo 1)"
 /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUM" "$APP/Contents/Info.plist"
+# Stamp the commit's own datetime beside the count, so both halves of About's
+# "v2.11.0 (812) · 2026-Aug-08 09:14:07 UTC" describe the same commit. DragonAbout reads this key;
+# without it the line silently drops the timestamp. Committer date (%cI), not author date, so a
+# rebase cannot leave it pointing at an earlier moment. Set-then-Add because the key is absent
+# from the committed template but present on a rebuild into an existing bundle.
+COMMIT_DATE="$(git -C "$ROOT" log -1 --format=%cI 2>/dev/null || true)"
+if [ -n "$COMMIT_DATE" ]; then
+  /usr/libexec/PlistBuddy -c "Set :DragonCommitDate $COMMIT_DATE" "$APP/Contents/Info.plist" 2>/dev/null \
+    || /usr/libexec/PlistBuddy -c "Add :DragonCommitDate string $COMMIT_DATE" "$APP/Contents/Info.plist"
+fi
 plutil -lint "$APP/Contents/Info.plist"
 
 echo "==> Copying bundled LM (data.txt)"


### PR DESCRIPTION
DragonKit v3 deletes `AboutLink` and the free-form `links` / `credits` arrays that let every app hand-write its own About pane — five apps produced five visibly different panes. The kit now owns every row title, SF Symbol and ordering; an app supplies URLs and proper nouns, so drift becomes a compile error instead of something spotted in a screenshot months later.

Design: [dragon-kit `2026-08-08-about-pane-canon-design.md`](https://github.com/teddychan/dragon-kit/blob/v3.0.1/docs/superpowers/specs/2026-08-08-about-pane-canon-design.md)

## Four defects this fixes

| Before | After |
|---|---|
| Copyright slot held `倉頡／簡易 輸入法` — a description, not a copyright | `© 2026 Teddy Chan` |
| Website → `www.dragonapp.com/keykey`, a `<meta refresh>` stub | `/yahoo-keykey-2/`, the canonical page |
| "Homage to the original" rendered **twice**, as a link *and* a credit | Original project link + Based-on credit, once each |
| **No License row at all** | `License · MIT` |

What's New stops hardcoding `"2.10.0"` — it defaults to `CFBundleShortVersionString` and the kit adds the `v`, so it can no longer claim a release the binary isn't.

## Calls worth reviewing

- **Single-holder copyright.** The dual-holder form would also name the upstream project's copyright, but this app uses **no Yahoo! KeyKey source code** (`docs/THIRD-PARTY-NOTICES.md`) and disclaims affiliation (`README.md`), so claiming a Yahoo copyright over this binary would contradict both. The recorded upstream notice is `Copyright (c) 2007-2010 Yahoo! Taiwan / Lithoglyph` — the Yahoo-derived Cangjie tables are New BSD and their notice ships on the licences page instead. Lineage still shows twice: the Original project link and the Based-on credit.
- **Three of six `keykey.about.*` keys are kept.** Website / Support / Original project are now kit-owned, but attribution row *labels* are app-supplied — deleting those would silently drop 語言模型 / 倉頡碼表 / 漢字轉換 to English.
- **`DragonCommitDate` stamp added** (conformance R12). About's version line took its timestamp from the executable's mtime, so the build count and the date described different things; both halves now fingerprint one commit.
- **Build warns on a stale `vendor/dragon-kit`.** It is still reused as-is — pointing it at a branch is how the kit gets co-developed — but a stale checkout would make the "Built with · DragonKit vX.Y.Z" row misreport what the binary compiled against. The local checkout was sitting at **v1.3.0**.

## Verification

- `swift test` — **66/66 pass**
- `tools/build-app.sh` — clean build, `DragonCommitDate` present in the packaged `Info.plist`
- `dragon-conformance.py --app . --kit ~/git/dragon-kit` — **`PASS — no violations`**
- About pane rendered from the real `AboutPane`: 4 link rows (globe / lifepreserver / heart / doc.text), then Created by → Based on → **Built with DragonKit v3.0.1** → License → 3 attributions

## Depends on

[www.dragonapp.com#56](https://github.com/teddychan/www.dragonapp.com/pull/56) — publishes `dragonapp.com/yahoo-keykey-2/licenses`, which the new `licensesURL` row links. That row 404s until it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)