### PR TITLE
feat: adopt DragonKit 3.1.0 and settle attributions on name → licence

### DIFF
--- a/App/AboutConfig.swift
+++ b/App/AboutConfig.swift
@@ -36,13 +36,24 @@ enum AboutConfig {
             // the row does not point at a redirect.
             licensesURL: URL(string: "https://www.dragonapp.com/yahoo-keykey-2/licenses/")!,
             originalWork: OriginalWork(name: "Yahoo! KeyKey", author: "ninjapanda · zonble"),
-            // The only app-specific rows in the pane. Unlike the canon labels above the kit does
-            // not own these — an IME's data sources have no counterpart in the other apps — so
-            // they keep their own localized keys.
+            // Attributions are name → licence, the kit's canon since 3.1.0: the thing's own name
+            // as its authors spell it, then its licence. These were role labels paired with an
+            // origin — L("keykey.about.cangjieTable") → "ibus-table-chinese" — on the reasoning
+            // that an IME's data sources have no counterpart in the other apps, so they keep their
+            // own localized keys. That reasoning was wrong on the canon's terms: a project name and
+            // a licence identifier are proper nouns, not translatable prose. The three
+            // keykey.about.* keys were deleted with the labels they fed.
+            //
+            // Every licence below is quoted from docs/THIRD-PARTY-NOTICES.md, never inferred — a
+            // wrong licence here is an attribution error, not a cosmetic one. The Cangjie-5 table
+            // has no SPDX identifier: its upstream header declares "LICENSE = Freely
+            // redistributable without restriction", so it gets that phrase rather than an invented
+            // id. It is specifically NOT GPL-3.0, which covers the surrounding ibus-table-chinese
+            // repository packaging and not the one table this app bundles.
             attributions: [
-                Attribution(component: L("keykey.about.languageModel"), source: "openvanilla/McBopomofo"),
-                Attribution(component: L("keykey.about.cangjieTable"), source: "ibus-table-chinese"),
-                Attribution(component: L("keykey.about.hanConversion"), source: "OpenCC (Apache-2.0)"),
+                Attribution(name: "McBopomofo", license: "MIT"),
+                Attribution(name: "ibus-table-chinese", license: "Freely redistributable"),
+                Attribution(name: "OpenCC", license: "Apache-2.0"),
             ]
         )
     }

--- a/App/en.lproj/Localizable.strings
+++ b/App/en.lproj/Localizable.strings
@@ -28,11 +28,6 @@
 "keykey.general.strokeConfirmationHint" = "In 速成, and in 倉頡 with the * wildcard, candidates appear before the code is finished, so Space flips to the next page instead of confirming what you typed. With this on, the first Space only confirms the code and keeps page 1 — press Space again to page, or 1–9 to pick. Plain 倉頡 is unaffected.";
 "keykey.general.language" = "Language";
 
-/* About pane — attribution rows only; DragonKit owns every other label in the pane */
-"keykey.about.languageModel" = "Language model";
-"keykey.about.cangjieTable" = "Cangjie table";
-"keykey.about.hanConversion" = "Han conversion";
-
 /* What's New pane (2.10.0) */
 "keykey.whatsNew.summary" = "The selection box can now be read by VoiceOver, everything is faster, and Settings finally has a proper menu bar.";
 "keykey.whatsNew.voiceOver" = "The selection box can be read by VoiceOver. The nine candidates are drawn as one piece of text, so VoiceOver read the picker as a run of digits and glyphs — or skipped it altogether — even though picking a candidate is the whole job. The window now publishes a proper list: each row is announced with its selecting digit, the candidate, and its 反查 code hint when shown, and the page indicator reads 第 2 頁，共 3 頁 instead of a bare “▼ 1/3”. Turning the page is announced too. Nothing about how the window looks or behaves changed.";

--- a/App/zh-Hant.lproj/Localizable.strings
+++ b/App/zh-Hant.lproj/Localizable.strings
@@ -28,11 +28,6 @@
 "keykey.general.strokeConfirmationHint" = "在速成、以及使用萬用字元（*）的倉頡中，字根還沒打完就會出現候選字，此時空白鍵會直接翻到下一頁，而不是確認你打的字根。開啟後，第一次按空白鍵只會確認字根並停留在第 1 頁；再按一次空白鍵才翻頁，或直接按 1–9 選字。一般倉頡不受影響。";
 "keykey.general.language" = "語言";
 
-/* About pane — attribution rows only; DragonKit owns every other label in the pane */
-"keykey.about.languageModel" = "語言模型";
-"keykey.about.cangjieTable" = "倉頡碼表";
-"keykey.about.hanConversion" = "漢字轉換";
-
 /* What's New pane (2.10.0) */
 "keykey.whatsNew.summary" = "本次更新讓 VoiceOver 能夠讀出選字框，整體速度更快，設定視窗也終於有了正常的選單列。";
 "keykey.whatsNew.voiceOver" = "VoiceOver 可以讀出選字框了。九個候選字是畫在同一段文字裡的，所以 VoiceOver 只會把整個選字框讀成一串數字和字形——甚至整個跳過——但選字正是這個輸入法最主要的操作。現在選字框會提供一份真正的清單：每一列都會唸出對應的選字數字、候選字，以及有顯示時的反查提示；頁碼也會讀成「第 2 頁，共 3 頁」，而不是只有「▼ 1/3」。翻頁時同樣會播報。視窗的外觀和操作方式完全沒有改變。";

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
@@ -59,8 +59,14 @@ final class ConfigContentTests: XCTestCase {
         XCTAssertEqual(content.originalWork,
                        OriginalWork(name: "Yahoo! KeyKey", author: "ninjapanda · zonble"))
         XCTAssertEqual(content.creditRows.count, 7)
-        XCTAssertEqual(Array(content.creditRows.map(\.value).suffix(3)),
-                       ["openvanilla/McBopomofo", "ibus-table-chinese", "OpenCC (Apache-2.0)"])
+        // Pinned as name → licence pairs, not values alone. The kit renders an Attribution as
+        // label: name, value: licence, so checking one half would let a role label ("Cangjie
+        // table") or a wrong licence back in — and these rows were role labels until 3.1.0.
+        // Licences track docs/THIRD-PARTY-NOTICES.md; the Cangjie table has no SPDX id.
+        XCTAssertEqual(content.creditRows.suffix(3).map { [$0.label, $0.value] },
+                       [["McBopomofo", "MIT"],
+                        ["ibus-table-chinese", "Freely redistributable"],
+                        ["OpenCC", "Apache-2.0"]])
     }
 
     // MARK: WhatsNewConfig

--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -81,7 +81,7 @@ echo "==> Building DragonKit (SwiftPM, release) in pinned checkout"
 # package's own tools version (6.1) — a separate compilation from the app's -swift-version 5.
 # Clone the pinned tag on first use (e.g. a fresh CI checkout); vendor/ is gitignored, never
 # committed. Idempotent: an existing checkout (local dev) is reused as-is.
-DRAGONKIT_TAG="v3.0.1"
+DRAGONKIT_TAG="v3.1.0"
 if [ ! -d "$KIT_DIR" ]; then
   echo "==> Cloning DragonKit $DRAGONKIT_TAG into vendor/ (not committed)"
   git clone --depth 1 --branch "$DRAGONKIT_TAG" https://github.com/teddychan/dragon-kit "$KIT_DIR"


### PR DESCRIPTION
Two commits: the version pin, then the attribution migration that version requires.

## 1 — pin to DragonKit 3.1.0

`tools/build-app.sh`: `DRAGONKIT_TAG="v3.0.1"` → `"v3.1.0"`. Conformance R10 requires the declared
pin to be >= the newest kit tag; this repo was failing.

`Packages/KeyKeyApp/Package.swift` depends on `../../vendor/dragon-kit` **by path**, so it inherits
the same pin — there is no second version to bump.

**The vendored-checkout trap.** `tools/build-app.sh` clones the kit only `if [ ! -d "$KIT_DIR" ]`,
so an existing `vendor/dragon-kit` is reused as-is. Editing the tag without deleting it produces a
build that silently links the OLD kit while everything still reports success — the build passes,
and conformance passes because R10 reads the tag string out of the shell script, not the checkout
on disk. CI wouldn't catch it either, since a fresh runner has no `vendor/`. It was deleted and
re-cloned, and proven:

```
$ git -C vendor/dragon-kit tag --points-at HEAD
v3.1.0
```

(`tag --points-at`, not `git describe` — dragon-kit carries two tag series on the same commits and
`describe` reports the sample-app one.)

## 2 — settle attributions on `name → licence`

3.1.0 deprecates `Attribution(component:source:)`. This repo used it three times with role labels:

```swift
Attribution(component: L("keykey.about.languageModel"), source: "openvanilla/McBopomofo")
Attribution(component: L("keykey.about.cangjieTable"),  source: "ibus-table-chinese")
Attribution(component: L("keykey.about.hanConversion"), source: "OpenCC (Apache-2.0)")
```

Now:

```swift
Attribution(name: "McBopomofo",          license: "MIT"),
Attribution(name: "ibus-table-chinese",  license: "Freely redistributable"),
Attribution(name: "OpenCC",              license: "Apache-2.0"),
```

**Not optional.** `.github/workflows/tests.yml` builds with `-Xswiftc -warnings-as-errors`, so the
three deprecations were hard errors — the pin alone left CI red.

**Every licence is quoted from this repo's own `docs/THIRD-PARTY-NOTICES.md`, never inferred.** A
wrong licence in an About pane is an attribution error, not a cosmetic one. The Cangjie-5 table has
no SPDX identifier — its upstream header declares *"LICENSE = Freely redistributable without
restriction"* — so it gets that phrase rather than an invented id. It is specifically **not**
GPL-3.0, which covers the surrounding `ibus-table-chinese` repository packaging and not the single
table bundled here. (dragon-kit's own test fixture asserted GPL-3.0 for this and is being corrected
in dragon-kit#48 — found while doing this migration.)

The three `keykey.about.*` keys were deleted with the labels they fed, from both locales.

`ConfigContentTests.swift` needed updating: it pinned `creditRows.map(\.value).suffix(3)` to the old
`source` strings. The kit renders an Attribution as `AboutCreditRow(label: name, value: license)`,
so those values are now licences. Both halves are pinned as pairs — checking values alone would
pass even if the names were dropped.

**User-visible:** the last three About → Credits rows change from role labels to project names.

## Verification

| | |
|---|---|
| `KeyKeyApp` tests (`-warnings-as-errors`) | 66 passed, 0 failures — was failing |
| `KeyKeyEngine` tests | 193 passed, 0 failures |
| `./tools/build-app.sh` | completes, ad-hoc signed, **no warnings or errors** |
| Conformance | `PASS — no violations` |
| Locale key sets | identical, 34 keys each, `plutil -lint` OK |

## Not verified

The IME was never installed or launched — `includeQuit: false` at `App/AppMenuController.swift:34`
and `App/InputController.swift:180` was confirmed by reading the code, not by observing the menu
bar. Release packaging (signing, notarization) is untested; no tag was pushed, by design.

## Left out deliberately

libtabe/TaBE is upstream of *McBopomofo's* phrase data, so it sits one level further out than the
three things this app actually bundles. Its BSD-style licence requires the attribution be
*preserved*, which the shipped licences page (`licensesURL`) and `THIRD-PARTY-NOTICES.md` already
do. Adding it would also put a second non-SPDX phrase in the list. If you'd rather the pane name
every upstream with an attribution duty, that's a consistent position — but it means auditing the
whole transitive set, not adding this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)