### PR TITLE
fix(build): make vendor/dragon-kit resolution non-destructive, and restore the full Cangjie licence phrase

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,14 @@ jobs:
       - name: Swift version
         run: swift --version
 
+      # Regression tests for the vendor/dragon-kit resolution in tools/build-app.sh. Runs first
+      # and offline (throwaway local git repos, ~1s): the states it covers — a stale pin, a
+      # co-development branch, an unpushed detached commit, a dirty tree at the pin — are ones a
+      # CI runner's own clean checkout never reaches, so nothing else here would catch a
+      # regression in them until it stranded a workspace.
+      - name: Build-script tests (vendor/dragon-kit resolution)
+        run: ./tools/test-resolve-dragon-kit.sh
+
       # KeyKeyEngine has no external dependencies — it tests standalone.
       # -warnings-as-errors is the gate: a compiler warning fails the build rather than
       # scrolling past in the log. It is what gives the packages' StrictConcurrency setting

--- a/App/AboutConfig.swift
+++ b/App/AboutConfig.swift
@@ -52,7 +52,7 @@ enum AboutConfig {
             // repository packaging and not the one table this app bundles.
             attributions: [
                 Attribution(name: "McBopomofo", license: "MIT"),
-                Attribution(name: "ibus-table-chinese", license: "Freely redistributable"),
+                Attribution(name: "ibus-table-chinese", license: "Freely redistributable without restriction"),
                 Attribution(name: "OpenCC", license: "Apache-2.0"),
             ]
         )

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
@@ -65,7 +65,7 @@ final class ConfigContentTests: XCTestCase {
         // Licences track docs/THIRD-PARTY-NOTICES.md; the Cangjie table has no SPDX id.
         XCTAssertEqual(content.creditRows.suffix(3).map { [$0.label, $0.value] },
                        [["McBopomofo", "MIT"],
-                        ["ibus-table-chinese", "Freely redistributable"],
+                        ["ibus-table-chinese", "Freely redistributable without restriction"],
                         ["OpenCC", "Apache-2.0"]])
     }
 

--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -80,83 +80,14 @@ echo "==> Building DragonKit (SwiftPM, release) in pinned checkout"
 # .a), so archive them into static libraries the app's swiftc link can consume. Uses the
 # package's own tools version (6.1) — a separate compilation from the app's -swift-version 5.
 # Clone the pinned tag on first use (e.g. a fresh CI checkout); vendor/ is gitignored, never
-# committed. An existing checkout is reused only once it has been identified: it is either at the
-# pin, or on a branch (kit co-development, warned about), or stale-but-disposable (re-cloned at
-# the pin), or unidentifiable (build stops). Reusing an unidentified checkout is what stranded
-# established workspaces on v3.0.1 after the 3.1.0 bump — that kit has no
-# Attribution(name:license:), so App/AboutConfig.swift failed to compile until the operator
-# guessed that vendor/dragon-kit had to be deleted by hand.
+# committed. An existing checkout is reused only once it has been identified — the states and the
+# reasoning live in tools/resolve-dragon-kit.sh, which is split out so
+# tools/test-resolve-dragon-kit.sh can drive every one of them without a swiftc build.
+# DRAGONKIT_TAG stays HERE: the propagation SOP and .github/workflows/tests.yml both read the pin
+# out of this file.
 DRAGONKIT_TAG="v3.2.0"
 DRAGONKIT_URL="https://github.com/teddychan/dragon-kit"
-KIT_NEEDS_CLONE=""
-if [ ! -d "$KIT_DIR" ]; then
-  echo "==> Cloning DragonKit $DRAGONKIT_TAG into vendor/ (not committed)"
-  KIT_NEEDS_CLONE=1
-else
-  # Test for .git rather than asking git: `git -C <dir>` walks UP to the first enclosing
-  # repository, so on a vendor/dragon-kit that is a plain directory (an interrupted clone) every
-  # query below would be answered by yahoo-keykey-2 itself — the branch check reported THIS repo's
-  # branch and the build went ahead against a directory holding no kit at all, failing later and
-  # further away with "Could not find Package.swift".
-  if [ ! -e "$KIT_DIR/.git" ]; then
-    echo "ERROR: $KIT_DIR exists but is not a git checkout, so the DragonKit it would build" >&2
-    echo "       cannot be identified. Remove it and re-run: rm -rf $KIT_DIR" >&2
-    exit 1
-  fi
-  # `git tag --points-at HEAD`, not `git describe --tags --exact-match`: dragon-kit carries TWO tag
-  # series on the same commits — vX.Y.Z for the library and sample-vX.Y.Z for its sample app — and
-  # `describe` prints exactly one name, so on a dual-tagged commit it can name the series we are
-  # not pinning against. This is not hypothetical: 808d5a7 carries both v2.0.0 and sample-v1.2.0,
-  # and `describe --tags --exact-match` there answers "sample-v1.2.0". Pinned at v2.0.0 the old
-  # check would therefore have called a perfectly correct checkout stale on every single build.
-  # v3.1.0 happens to be singly tagged, which is the only reason this never fired. --points-at
-  # lists every tag on the commit; test for membership.
-  KIT_TAGS="$(git -C "$KIT_DIR" tag --points-at HEAD 2>/dev/null || true)"
-  KIT_BRANCH="$(git -C "$KIT_DIR" symbolic-ref -q --short HEAD 2>/dev/null || true)"
-  if printf '%s\n' "$KIT_TAGS" | grep -qxF "$DRAGONKIT_TAG"; then
-    : # At the pin — the common case. Use it, silently.
-  elif [ -n "$KIT_BRANCH" ]; then
-    # Deliberately a warning and never an error: pointing vendor/ at a kit branch is how the kit is
-    # co-developed, and the branch is the operator's own work, so it is neither replaced nor
-    # refused. Say so loudly, because it links a different kit than the pin claims and About's
-    # "Built with · DragonKit vX.Y.Z" row would then misreport what the binary compiled against.
-    echo "WARNING: vendor/dragon-kit is on branch '$KIT_BRANCH', not $DRAGONKIT_TAG; building" >&2
-    echo "         against it as-is (this is how the kit is co-developed). About's \"Built with ·" >&2
-    echo "         DragonKit vX.Y.Z\" row will report that branch's kit, not the pin." >&2
-    echo "         Remove vendor/dragon-kit to build against the pinned tag." >&2
-  elif [ -n "$(git -C "$KIT_DIR" status --porcelain 2>/dev/null)" ]; then
-    # Detached and edited. Re-cloning would throw the edits away and building would link a kit no
-    # version identifies, so do neither — the operator decides.
-    echo "ERROR: vendor/dragon-kit is not at $DRAGONKIT_TAG and has uncommitted changes, so the" >&2
-    echo "       DragonKit it would build cannot be identified. Put the changes on a branch to" >&2
-    echo "       co-develop the kit, or discard them: rm -rf $KIT_DIR" >&2
-    exit 1
-  else
-    # A different tag (or a bare detached commit) with a clean tree: an established workspace left
-    # on an older pin. Nothing here is the operator's — vendor/ is gitignored and this checkout is
-    # reproduced by cloning — so bring it to the pin rather than failing the build.
-    KIT_AT="$(printf '%s' "$KIT_TAGS" | tr '\n' ' ')"
-    [ -n "$KIT_AT" ] || KIT_AT="commit $(git -C "$KIT_DIR" rev-parse --short HEAD)"
-    echo "==> vendor/dragon-kit is at $KIT_AT, not the pinned $DRAGONKIT_TAG; re-cloning at the pin"
-    KIT_NEEDS_CLONE=1
-  fi
-fi
-if [ -n "$KIT_NEEDS_CLONE" ]; then
-  # Clone alongside, swap only on success: `rm -rf` first would leave a workspace with no kit at
-  # all when the clone then fails. Re-cloning rather than `git checkout "$DRAGONKIT_TAG"` because
-  # this is a --depth 1 --branch <tag> clone, which holds no object for any other tag.
-  KIT_STAGING="$KIT_DIR.incoming"
-  rm -rf "$KIT_STAGING"
-  if ! git clone --depth 1 --branch "$DRAGONKIT_TAG" "$DRAGONKIT_URL" "$KIT_STAGING"; then
-    rm -rf "$KIT_STAGING"
-    echo "ERROR: could not clone DragonKit $DRAGONKIT_TAG from $DRAGONKIT_URL. The existing" >&2
-    echo "       checkout (if any) was left untouched and was NOT built against. Fix the network" >&2
-    echo "       or credentials and re-run, or start clean: rm -rf $KIT_DIR" >&2
-    exit 1
-  fi
-  rm -rf "$KIT_DIR"
-  mv "$KIT_STAGING" "$KIT_DIR"
-fi
+"$ROOT/tools/resolve-dragon-kit.sh" "$KIT_DIR" "$DRAGONKIT_TAG" "$DRAGONKIT_URL"
 ( cd "$KIT_DIR" && swift build -c release )
 KIT_REL="$(cd "$KIT_DIR" && swift build -c release --show-bin-path)"
 KIT_MODULES="$KIT_REL/Modules"

--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -80,17 +80,82 @@ echo "==> Building DragonKit (SwiftPM, release) in pinned checkout"
 # .a), so archive them into static libraries the app's swiftc link can consume. Uses the
 # package's own tools version (6.1) — a separate compilation from the app's -swift-version 5.
 # Clone the pinned tag on first use (e.g. a fresh CI checkout); vendor/ is gitignored, never
-# committed. Idempotent: an existing checkout (local dev) is reused as-is.
+# committed. An existing checkout is reused only once it has been identified: it is either at the
+# pin, or on a branch (kit co-development, warned about), or stale-but-disposable (re-cloned at
+# the pin), or unidentifiable (build stops). Reusing an unidentified checkout is what stranded
+# established workspaces on v3.0.1 after the 3.1.0 bump — that kit has no
+# Attribution(name:license:), so App/AboutConfig.swift failed to compile until the operator
+# guessed that vendor/dragon-kit had to be deleted by hand.
 DRAGONKIT_TAG="v3.2.0"
+DRAGONKIT_URL="https://github.com/teddychan/dragon-kit"
+KIT_NEEDS_CLONE=""
 if [ ! -d "$KIT_DIR" ]; then
   echo "==> Cloning DragonKit $DRAGONKIT_TAG into vendor/ (not committed)"
-  git clone --depth 1 --branch "$DRAGONKIT_TAG" https://github.com/teddychan/dragon-kit "$KIT_DIR"
-elif [ "$(git -C "$KIT_DIR" describe --tags --exact-match 2>/dev/null || true)" != "$DRAGONKIT_TAG" ]; then
-  # Still reused as-is — pointing vendor/ at a kit branch is how the kit is co-developed — but say
-  # so, because a stale checkout links a different kit than the pin claims and About's
-  # "Built with · DragonKit vX.Y.Z" row would then misreport what the binary compiled against.
-  echo "WARNING: vendor/dragon-kit is not at $DRAGONKIT_TAG; building against it as-is." >&2
-  echo "         Remove vendor/dragon-kit to build against the pinned tag." >&2
+  KIT_NEEDS_CLONE=1
+else
+  # Test for .git rather than asking git: `git -C <dir>` walks UP to the first enclosing
+  # repository, so on a vendor/dragon-kit that is a plain directory (an interrupted clone) every
+  # query below would be answered by yahoo-keykey-2 itself — the branch check reported THIS repo's
+  # branch and the build went ahead against a directory holding no kit at all, failing later and
+  # further away with "Could not find Package.swift".
+  if [ ! -e "$KIT_DIR/.git" ]; then
+    echo "ERROR: $KIT_DIR exists but is not a git checkout, so the DragonKit it would build" >&2
+    echo "       cannot be identified. Remove it and re-run: rm -rf $KIT_DIR" >&2
+    exit 1
+  fi
+  # `git tag --points-at HEAD`, not `git describe --tags --exact-match`: dragon-kit carries TWO tag
+  # series on the same commits — vX.Y.Z for the library and sample-vX.Y.Z for its sample app — and
+  # `describe` prints exactly one name, so on a dual-tagged commit it can name the series we are
+  # not pinning against. This is not hypothetical: 808d5a7 carries both v2.0.0 and sample-v1.2.0,
+  # and `describe --tags --exact-match` there answers "sample-v1.2.0". Pinned at v2.0.0 the old
+  # check would therefore have called a perfectly correct checkout stale on every single build.
+  # v3.1.0 happens to be singly tagged, which is the only reason this never fired. --points-at
+  # lists every tag on the commit; test for membership.
+  KIT_TAGS="$(git -C "$KIT_DIR" tag --points-at HEAD 2>/dev/null || true)"
+  KIT_BRANCH="$(git -C "$KIT_DIR" symbolic-ref -q --short HEAD 2>/dev/null || true)"
+  if printf '%s\n' "$KIT_TAGS" | grep -qxF "$DRAGONKIT_TAG"; then
+    : # At the pin — the common case. Use it, silently.
+  elif [ -n "$KIT_BRANCH" ]; then
+    # Deliberately a warning and never an error: pointing vendor/ at a kit branch is how the kit is
+    # co-developed, and the branch is the operator's own work, so it is neither replaced nor
+    # refused. Say so loudly, because it links a different kit than the pin claims and About's
+    # "Built with · DragonKit vX.Y.Z" row would then misreport what the binary compiled against.
+    echo "WARNING: vendor/dragon-kit is on branch '$KIT_BRANCH', not $DRAGONKIT_TAG; building" >&2
+    echo "         against it as-is (this is how the kit is co-developed). About's \"Built with ·" >&2
+    echo "         DragonKit vX.Y.Z\" row will report that branch's kit, not the pin." >&2
+    echo "         Remove vendor/dragon-kit to build against the pinned tag." >&2
+  elif [ -n "$(git -C "$KIT_DIR" status --porcelain 2>/dev/null)" ]; then
+    # Detached and edited. Re-cloning would throw the edits away and building would link a kit no
+    # version identifies, so do neither — the operator decides.
+    echo "ERROR: vendor/dragon-kit is not at $DRAGONKIT_TAG and has uncommitted changes, so the" >&2
+    echo "       DragonKit it would build cannot be identified. Put the changes on a branch to" >&2
+    echo "       co-develop the kit, or discard them: rm -rf $KIT_DIR" >&2
+    exit 1
+  else
+    # A different tag (or a bare detached commit) with a clean tree: an established workspace left
+    # on an older pin. Nothing here is the operator's — vendor/ is gitignored and this checkout is
+    # reproduced by cloning — so bring it to the pin rather than failing the build.
+    KIT_AT="$(printf '%s' "$KIT_TAGS" | tr '\n' ' ')"
+    [ -n "$KIT_AT" ] || KIT_AT="commit $(git -C "$KIT_DIR" rev-parse --short HEAD)"
+    echo "==> vendor/dragon-kit is at $KIT_AT, not the pinned $DRAGONKIT_TAG; re-cloning at the pin"
+    KIT_NEEDS_CLONE=1
+  fi
+fi
+if [ -n "$KIT_NEEDS_CLONE" ]; then
+  # Clone alongside, swap only on success: `rm -rf` first would leave a workspace with no kit at
+  # all when the clone then fails. Re-cloning rather than `git checkout "$DRAGONKIT_TAG"` because
+  # this is a --depth 1 --branch <tag> clone, which holds no object for any other tag.
+  KIT_STAGING="$KIT_DIR.incoming"
+  rm -rf "$KIT_STAGING"
+  if ! git clone --depth 1 --branch "$DRAGONKIT_TAG" "$DRAGONKIT_URL" "$KIT_STAGING"; then
+    rm -rf "$KIT_STAGING"
+    echo "ERROR: could not clone DragonKit $DRAGONKIT_TAG from $DRAGONKIT_URL. The existing" >&2
+    echo "       checkout (if any) was left untouched and was NOT built against. Fix the network" >&2
+    echo "       or credentials and re-run, or start clean: rm -rf $KIT_DIR" >&2
+    exit 1
+  fi
+  rm -rf "$KIT_DIR"
+  mv "$KIT_STAGING" "$KIT_DIR"
 fi
 ( cd "$KIT_DIR" && swift build -c release )
 KIT_REL="$(cd "$KIT_DIR" && swift build -c release --show-bin-path)"

--- a/tools/resolve-dragon-kit.sh
+++ b/tools/resolve-dragon-kit.sh
@@ -21,17 +21,26 @@
 #   on a branch, otherwise -> WARNING, build against it (kit co-development; never replaced)
 #   detached + dirty       -> ERROR, stop
 #   detached, clean, @pin  -> silent, build (the common case)
-#   detached, clean, @tag  -> re-clone at the pin, but ONLY once the remote confirms the tag
+#   detached, clean, @tag  -> fetch the pin INTO this repository and detach at it, but ONLY once
+#                             the remote confirms the tag. The repository is never replaced.
 #   detached, clean, no tag-> ERROR, stop
 #   not a git checkout     -> ERROR, stop
 #   absent                 -> clone at the pin (the fresh-CI path)
 #
+# A STALE CHECKOUT IS UPDATED IN PLACE; only the ABSENT case ever creates a repository, and no case
+# deletes one. `rm -rf "$KIT_DIR"` was the whole bug: verifying HEAD against the remote proves that
+# HEAD is reproducible and nothing more — it says nothing about the other branches, tags, stashes,
+# reflog entries and unreachable objects in that repository, and no amount of verification can,
+# because none of them are reachable from HEAD. An operator sitting on a published stale tag with
+# an unpushed local branch beside it watched the resolver verify, re-clone and exit 0, having
+# deleted the branch and its only commit.
+#
 # OFFLINE CONSEQUENCE, deliberate: refreshing a stale tagged checkout takes one round-trip to the
-# kit remote, so with no network (or no credentials) that case now STOPS the build instead of
-# re-cloning. A local `git tag` is not evidence of publication, and the only way to tell the two
-# apart is to ask the remote; erring the other way deletes commits that exist nowhere else. The
-# remedy is in the error text and is always the same: rm -rf vendor/dragon-kit rebuilds at the pin.
-# Every other path stays offline, so ordinary builds are unaffected.
+# kit remote, so with no network (or no credentials) that case STOPS the build instead of
+# refreshing. A local `git tag` is not evidence of publication, and the only way to tell the two
+# apart is to ask the remote; erring the other way moves HEAD off commits that exist nowhere else.
+# The remedy is in the error text and is always the same: rm -rf vendor/dragon-kit rebuilds at the
+# pin. Every other path stays offline, so ordinary builds are unaffected.
 set -euo pipefail
 
 KIT_DIR="$1"
@@ -39,6 +48,7 @@ DRAGONKIT_TAG="$2"
 DRAGONKIT_URL="$3"
 
 KIT_NEEDS_CLONE=""
+KIT_NEEDS_REFRESH=""
 if [ ! -d "$KIT_DIR" ]; then
   echo "==> Cloning DragonKit $DRAGONKIT_TAG into vendor/ (not committed)"
   KIT_NEEDS_CLONE=1
@@ -106,15 +116,18 @@ else
     : # At the pin, detached and clean — the common case. Use it, silently.
   elif [ -n "$KIT_TAGS" ]; then
     # An older tag with a clean tree: an established workspace left on an older pin. This is the
-    # ONLY state replaced automatically — and replacing means `rm -rf`, so it is allowed only
-    # after the remote has confirmed the checkout is reproducible.
+    # ONLY state the script moves automatically — and moving it means detaching HEAD somewhere
+    # else, so it is allowed only after the remote has confirmed the commit that is there now is
+    # reproducible. (It no longer means deleting the repository; see the refresh block below.)
     #
     # A tag at HEAD is NOT that confirmation on its own. `git tag` writes a ref in this clone and
     # contacts nothing, so a tag is exactly as local as the commit under it: an operator who
-    # committed on a detached HEAD and tagged it had that commit deleted by the re-clone below —
-    # the same data loss the untagged case further down exists to prevent, one step further in.
-    # The NAME is no evidence either: `v9.9.9` is as easy to write locally as `local-only`, so
-    # nothing here keys off a vX.Y.Z pattern. Only the remote can answer, so ask it.
+    # committed on a detached HEAD and tagged it had that commit deleted outright by the re-clone
+    # this branch used to end in, and would now have it stranded in the reflog with nothing but
+    # HEAD ever having referenced it — the same data loss the untagged case further down exists to
+    # prevent, one step further in. The NAME is no evidence either: `v9.9.9` is as easy to write
+    # locally as `local-only`, so nothing here keys off a vX.Y.Z pattern. Only the remote can
+    # answer, so ask it.
     #
     # One round-trip, and only on this branch: every other path stays offline and fast. (Round 2
     # declined to add a network call for the UNTAGGED case, where the answer is knowable locally
@@ -144,10 +157,10 @@ else
     if ! KIT_REMOTE_REFS="$(git ls-remote --tags "$DRAGONKIT_URL" "${KIT_TAG_REFS[@]}")"; then
       echo "ERROR: vendor/dragon-kit is at $KIT_AT, not the pinned $DRAGONKIT_TAG, and $KIT_AT could" >&2
       echo "       not be looked up on $DRAGONKIT_URL (offline, DNS, or credentials — git's own" >&2
-      echo "       error is above). Refreshing this checkout means DELETING it, and a tag is not" >&2
-      echo "       proof of publication until the remote says so, so it is preserved instead." >&2
+      echo "       error is above). Refreshing this checkout means moving HEAD off $KIT_AT, and a" >&2
+      echo "       tag is not proof of publication until the remote says so, so HEAD stays put." >&2
       echo "       With no network a stale checkout stops the build rather than refreshing; that" >&2
-      echo "       is the safe direction, because guessing the other way destroys commits no" >&2
+      echo "       is the safe direction, because guessing the other way strands commits no" >&2
       echo "       remote has. Reconnect and re-run, or discard the checkout to rebuild at the" >&2
       echo "       pin: rm -rf $KIT_DIR" >&2
       exit 1
@@ -156,14 +169,15 @@ else
     # them resolving to this very commit — which is precisely the proof required, and it reads the
     # same for a lightweight tag (id on refs/tags/X) and an annotated one (id on refs/tags/X^{}).
     if printf '%s\n' "$KIT_REMOTE_REFS" | awk -v sha="$KIT_HEAD" '$1 == sha { found = 1 } END { exit !found }'; then
-      echo "==> vendor/dragon-kit is at $KIT_AT, not the pinned $DRAGONKIT_TAG; re-cloning at the pin"
-      KIT_NEEDS_CLONE=1
+      echo "==> vendor/dragon-kit is at $KIT_AT, not the pinned $DRAGONKIT_TAG; fetching the pin into it"
+      KIT_NEEDS_REFRESH=1
     else
       echo "ERROR: vendor/dragon-kit is at $KIT_AT, not the pinned $DRAGONKIT_TAG, but no tag on its" >&2
       echo "       HEAD resolves to commit $(git -C "$KIT_DIR" rev-parse --short HEAD) on $DRAGONKIT_URL." >&2
       echo "       Either the tag was never pushed, or it has been moved or recreated since — a" >&2
       echo "       local \`git tag\` contacts no remote, so a tag at HEAD proves no more about this" >&2
-      echo "       commit than a clean tree does, and re-cloning could destroy the only copy of it." >&2
+      echo "       commit than a clean tree does, and detaching elsewhere would leave the only copy" >&2
+      echo "       of it referenced by nothing but this checkout's reflog." >&2
       echo "       Push the tag if it is meant to be published, put the commit on a branch to" >&2
       echo "       co-develop the kit, or discard the checkout to rebuild at the pin:" >&2
       echo "       rm -rf $KIT_DIR" >&2
@@ -185,10 +199,67 @@ else
   fi
 fi
 
+if [ -n "$KIT_NEEDS_REFRESH" ]; then
+  # UPDATE THE EXISTING REPOSITORY. Nothing here deletes, replaces or moves the directory: the
+  # pinned tag is fetched into the repository that is already there and HEAD is detached at it, so
+  # every unrelated branch, tag, stash, reflog entry and unreachable object in it survives. The
+  # `rm -rf` this block replaced could not preserve any of them, and the remote verification above
+  # could not compensate — it only ever spoke for HEAD.
+  #
+  # Three details, each of which would itself lose local state if done casually:
+  #
+  # NO --force ON THE TAG REFSPEC. `refs/tags/X:refs/tags/X` without it fails outright ("would
+  # clobber existing tag") when this repository already holds a DIFFERENT $DRAGONKIT_TAG — a pin
+  # moved or recreated locally. That failure is the correct outcome and is why it is not forced:
+  # overwriting that ref is precisely the destruction of local work this round exists to stop.
+  #
+  # NO --depth. The absent-checkout path clones --depth 1, so this fetch may have to deepen a
+  # shallow repository, which is additive. Passing --depth against a checkout that is a FULL clone
+  # would truncate its history instead — local-state loss by another name.
+  #
+  # THE TAG REF, NOT JUST THE COMMIT, MUST LAND. This script identifies a checkout with
+  # `git tag --points-at HEAD`, so detaching at a bare FETCH_HEAD would leave the very next build
+  # looking at an untagged detached HEAD and stopping. Hence a named refspec, and a check that the
+  # name resolves locally afterwards.
+  #
+  # git's own diagnosis goes to stderr ahead of ours, as with ls-remote above: "would clobber
+  # existing tag" and "couldn't find remote ref" send the operator to different remedies.
+  if ! git -C "$KIT_DIR" fetch "$DRAGONKIT_URL" "refs/tags/$DRAGONKIT_TAG:refs/tags/$DRAGONKIT_TAG"; then
+    echo "ERROR: could not fetch DragonKit $DRAGONKIT_TAG into $KIT_DIR (git's own error is" >&2
+    echo "       above). Nothing was deleted and HEAD did not move: the checkout is still at" >&2
+    echo "       $KIT_AT and still holds every branch, tag and commit it held before." >&2
+    echo "       If the fetch was refused as \"would clobber existing tag\", this repository already" >&2
+    echo "       carries a DIFFERENT $DRAGONKIT_TAG — a pin moved or recreated locally — and it is" >&2
+    echo "       kept rather than overwritten. Settle that tag, reconnect if this was the network," >&2
+    echo "       or discard the checkout to rebuild at the pin: rm -rf $KIT_DIR" >&2
+    exit 1
+  fi
+  if ! git -C "$KIT_DIR" rev-parse --verify -q "refs/tags/$DRAGONKIT_TAG^{commit}" >/dev/null; then
+    echo "ERROR: fetched DragonKit $DRAGONKIT_TAG into $KIT_DIR, but refs/tags/$DRAGONKIT_TAG does" >&2
+    echo "       not resolve to a commit there, so HEAD was left where it is rather than detached" >&2
+    echo "       at something this script could not identify on the next run. The checkout is" >&2
+    echo "       unchanged, still at $KIT_AT. Start clean: rm -rf $KIT_DIR" >&2
+    exit 1
+  fi
+  # -q: the resolver already said what it is doing, and git's "HEAD is now at" repeats it. The
+  # tree is known clean here (dirty detached stopped further up), so this cannot discard edits.
+  if ! git -C "$KIT_DIR" checkout -q --detach "refs/tags/$DRAGONKIT_TAG"; then
+    echo "ERROR: fetched DragonKit $DRAGONKIT_TAG into $KIT_DIR but could not check it out (git's" >&2
+    echo "       own error is above). The checkout was NOT half-moved: HEAD is still at $KIT_AT," >&2
+    echo "       which is a usable kit, and the fetched objects are simply extra. Re-run once the" >&2
+    echo "       cause is fixed, or start clean: rm -rf $KIT_DIR" >&2
+    exit 1
+  fi
+fi
+
 if [ -n "$KIT_NEEDS_CLONE" ]; then
-  # Clone alongside, swap only on success: `rm -rf` first would leave a workspace with no kit at
-  # all when the clone then fails. Re-cloning rather than `git checkout "$DRAGONKIT_TAG"` because
-  # this is a --depth 1 --branch <tag> clone, which holds no object for any other tag.
+  # Reached ONLY when there was no checkout at all — the one state with no repository to lose, and
+  # so the only one this script is willing to create a directory for. A stale checkout is refreshed
+  # in place above and never arrives here.
+  #
+  # Clone alongside, swap only on success: clearing the path first would leave a workspace with no
+  # kit at all when the clone then fails, and would delete anything a concurrent run had put there
+  # in the meantime.
   #
   # A UNIQUE staging dir, not a fixed "dragon-kit.incoming": that fixed path is one this run does
   # not own. A second build running concurrently, or the leftovers of an interrupted one, share

--- a/tools/resolve-dragon-kit.sh
+++ b/tools/resolve-dragon-kit.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# Resolve vendor/dragon-kit to a DragonKit checkout the build is allowed to link.
+#
+# Usage: resolve-dragon-kit.sh <kit-dir> <tag> <clone-url>
+#
+# Split out of tools/build-app.sh so it can be exercised on its own: this is a handful of
+# checkout states that only differ in git metadata, and driving them through a full swiftc
+# build takes minutes each. tools/test-resolve-dragon-kit.sh runs every branch below against
+# throwaway local repos in about a second. The pin itself stays in build-app.sh
+# (DRAGONKIT_TAG="vX.Y.Z"), which is where the DragonKit propagation SOP and
+# .github/workflows/tests.yml both look for it — do not move it here.
+#
+# The rule the states serve: an existing checkout is reused only once it has been IDENTIFIED,
+# because App's About pane reports the pinned tag as "Built with · DragonKit vX.Y.Z" whatever
+# the binary actually linked. Reusing an unidentified checkout is what stranded established
+# workspaces on v3.0.1 after the 3.1.0 bump — that kit has no Attribution(name:license:), so
+# App/AboutConfig.swift failed to compile until the operator guessed that vendor/dragon-kit
+# had to be deleted by hand.
+#
+#   on a branch            -> WARNING, build against it (kit co-development; never touched)
+#   detached + dirty       -> ERROR, stop
+#   detached, clean, @pin  -> silent, build (the common case)
+#   detached, clean, @tag  -> re-clone at the pin, and say so
+#   detached, clean, no tag-> ERROR, stop
+#   not a git checkout     -> ERROR, stop
+#   absent                 -> clone at the pin (the fresh-CI path)
+set -euo pipefail
+
+KIT_DIR="$1"
+DRAGONKIT_TAG="$2"
+DRAGONKIT_URL="$3"
+
+KIT_NEEDS_CLONE=""
+if [ ! -d "$KIT_DIR" ]; then
+  echo "==> Cloning DragonKit $DRAGONKIT_TAG into vendor/ (not committed)"
+  KIT_NEEDS_CLONE=1
+else
+  # Test for .git rather than asking git: `git -C <dir>` walks UP to the first enclosing
+  # repository, so on a vendor/dragon-kit that is a plain directory (an interrupted clone) every
+  # query below would be answered by yahoo-keykey-2 itself — the branch check reported THIS repo's
+  # branch and the build went ahead against a directory holding no kit at all, failing later and
+  # further away with "Could not find Package.swift".
+  if [ ! -e "$KIT_DIR/.git" ]; then
+    echo "ERROR: $KIT_DIR exists but is not a git checkout, so the DragonKit it would build" >&2
+    echo "       cannot be identified. Remove it and re-run: rm -rf $KIT_DIR" >&2
+    exit 1
+  fi
+  # `git tag --points-at HEAD`, not `git describe --tags --exact-match`: dragon-kit carries TWO tag
+  # series on the same commits — vX.Y.Z for the library and sample-vX.Y.Z for its sample app — and
+  # `describe` prints exactly one name, so on a dual-tagged commit it can name the series we are
+  # not pinning against. This is not hypothetical: 808d5a7 carries both v2.0.0 and sample-v1.2.0,
+  # and `describe --tags --exact-match` there answers "sample-v1.2.0". Pinned at v2.0.0 the old
+  # check would therefore have called a perfectly correct checkout stale on every single build.
+  # v3.1.0 happens to be singly tagged, which is the only reason this never fired. --points-at
+  # lists every tag on the commit; test for membership.
+  KIT_TAGS="$(git -C "$KIT_DIR" tag --points-at HEAD 2>/dev/null || true)"
+  KIT_BRANCH="$(git -C "$KIT_DIR" symbolic-ref -q --short HEAD 2>/dev/null || true)"
+  KIT_DIRTY="$(git -C "$KIT_DIR" status --porcelain 2>/dev/null || true)"
+
+  if [ -n "$KIT_BRANCH" ]; then
+    # Checked FIRST, ahead of both the tag and the dirty test: a branch is the operator's own
+    # work, so it is never replaced and never refused, and that has to hold whatever its HEAD
+    # currently points at. A branch that happens to sit on the pinned commit is still a branch —
+    # the next commit moves it — so it warns from the moment it exists rather than going quiet
+    # until it diverges. Deliberately a warning and not an error: pointing vendor/ at a kit branch
+    # is how the kit is co-developed. Say so loudly, because it links a different kit than the pin
+    # claims and About's "Built with · DragonKit vX.Y.Z" row would then misreport it.
+    echo "WARNING: vendor/dragon-kit is on branch '$KIT_BRANCH', not a checkout of the pinned" >&2
+    echo "         $DRAGONKIT_TAG; building against it as-is (this is how the kit is co-developed)." >&2
+    echo "         About's \"Built with · DragonKit vX.Y.Z\" row will report that branch's kit, not" >&2
+    echo "         the pin. Remove vendor/dragon-kit to build against the pinned tag." >&2
+  elif [ -n "$KIT_DIRTY" ]; then
+    # Dirtiness outranks the tag. The tag names a COMMIT, not the working tree on top of it, so a
+    # modified or untracked file at the pin is a kit no version identifies while About still says
+    # the pin — which is exactly the misreport the identify-before-you-trust rule exists to stop.
+    # Re-cloning would throw the edits away and building would link something unidentifiable, so
+    # do neither; the operator decides. (A branch never reaches here: see above.)
+    echo "ERROR: vendor/dragon-kit is detached with uncommitted changes, so the DragonKit it" >&2
+    echo "       would build cannot be identified. Refused even when HEAD carries $DRAGONKIT_TAG:" >&2
+    echo "       the tag names the commit, not the edited tree, and About would still report" >&2
+    echo "       $DRAGONKIT_TAG for a kit that is not it. Put the changes on a branch to" >&2
+    echo "       co-develop the kit, or discard them: rm -rf $KIT_DIR" >&2
+    exit 1
+  elif printf '%s\n' "$KIT_TAGS" | grep -qxF "$DRAGONKIT_TAG"; then
+    : # At the pin, detached and clean — the common case. Use it, silently.
+  elif [ -n "$KIT_TAGS" ]; then
+    # A RECOGNISED older tag with a clean tree: an established workspace left on an older pin.
+    # Nothing here is the operator's — the checkout is reproduced exactly by cloning that tag from
+    # the remote — so bring it to the pin rather than failing the build. Only this case is
+    # refreshed automatically.
+    KIT_AT="$(printf '%s' "$KIT_TAGS" | tr '\n' ' ')"
+    echo "==> vendor/dragon-kit is at ${KIT_AT% }, not the pinned $DRAGONKIT_TAG; re-cloning at the pin"
+    KIT_NEEDS_CLONE=1
+  else
+    # Detached, clean, and on no tag at all. A clean tree does NOT prove the commit is published:
+    # it is equally a local commit made on a detached HEAD, which nothing but this directory
+    # holds, and re-cloning would silently destroy it. Deciding otherwise needs a round-trip to
+    # the kit remote to ask whether the commit exists there, which is a network call this script
+    # should not make just to classify a directory — so stop and let the operator say.
+    echo "ERROR: vendor/dragon-kit is detached at commit $(git -C "$KIT_DIR" rev-parse --short HEAD) and carries no tag," >&2
+    echo "       so the DragonKit it would build cannot be identified. A clean tree does not make" >&2
+    echo "       that commit disposable — it may be local work no remote has — so it is neither" >&2
+    echo "       built against nor re-cloned over. Put it on a branch to co-develop the kit, or" >&2
+    echo "       remove the checkout to rebuild at the pin: rm -rf $KIT_DIR" >&2
+    exit 1
+  fi
+fi
+
+if [ -n "$KIT_NEEDS_CLONE" ]; then
+  # Clone alongside, swap only on success: `rm -rf` first would leave a workspace with no kit at
+  # all when the clone then fails. Re-cloning rather than `git checkout "$DRAGONKIT_TAG"` because
+  # this is a --depth 1 --branch <tag> clone, which holds no object for any other tag.
+  #
+  # A UNIQUE staging dir, not a fixed "dragon-kit.incoming": that fixed path is one this run does
+  # not own. A second build running concurrently, or the leftovers of an interrupted one, share
+  # it — and the `rm -rf` that cleared it would delete a clone another process was writing into,
+  # or hand this run a half-written tree as if it were a finished clone. mktemp keeps it beside
+  # KIT_DIR so the swap stays a same-filesystem rename; the trap removes it on any exit path.
+  mkdir -p "$(dirname "$KIT_DIR")"
+  KIT_STAGING="$(mktemp -d "$KIT_DIR.incoming.XXXXXX")"
+  trap 'rm -rf "$KIT_STAGING"' EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+  if ! git clone --depth 1 --branch "$DRAGONKIT_TAG" "$DRAGONKIT_URL" "$KIT_STAGING"; then
+    echo "ERROR: could not clone DragonKit $DRAGONKIT_TAG from $DRAGONKIT_URL. The existing" >&2
+    echo "       checkout (if any) was left untouched and was NOT built against. Fix the network" >&2
+    echo "       or credentials and re-run, or start clean: rm -rf $KIT_DIR" >&2
+    exit 1
+  fi
+  rm -rf "$KIT_DIR"
+  mv "$KIT_STAGING" "$KIT_DIR"
+  trap - EXIT INT TERM
+fi

--- a/tools/resolve-dragon-kit.sh
+++ b/tools/resolve-dragon-kit.sh
@@ -25,6 +25,7 @@
 #                             the remote confirms the tag, and ONLY when the path is a real
 #                             directory. The repository is never replaced.
 #   ...the same, via a SYMLINK -> ERROR, stop (that checkout belongs to someone else)
+#   ...the same, in a WORKTREE -> ERROR, stop (so does that one, and its refs are shared)
 #   detached, clean, no tag-> ERROR, stop
 #   not a git checkout     -> ERROR, stop
 #   a file, a socket, a dangling symlink -> ERROR, stop
@@ -218,6 +219,36 @@ else
       echo "       own, which you linked in from elsewhere and may have open right now — so it is" >&2
       echo "       left exactly as it is. Check that checkout out at $DRAGONKIT_TAG yourself, or" >&2
       echo "       remove the link and re-run to clone the pin here: rm $KIT_DIR" >&2
+      exit 1
+    fi
+
+    # NOR A LINKED WORKTREE, refused for the same reason and caught by a different test, because a
+    # symlink is not how this route arrives. `git worktree add` leaves a REAL DIRECTORY whose .git
+    # is a FILE holding "gitdir: ...", so `-d` up at the top is true and the `-L` above is false,
+    # and this branch walked straight into someone else's repository. Twice over: a worktree SHARES
+    # refs/tags with the clone that owns it, so the fetch writes refs/tags/$DRAGONKIT_TAG into that
+    # clone, and the checkout then moves the worktree's HEAD. Reproduced against the round-5 script
+    # — the owning clone's tags read [v3.0.1] before the run and [v3.0.1 v3.1.0] after, the worktree
+    # left detached at v3.1.0, status 0. The layout is not contrived: ice-2 and yahoo-keykey-2 both
+    # keep linked worktrees inside their own repo roots.
+    #
+    # `-f` on .git also catches a git SUBMODULE, which wears the same .git file. That is correct
+    # rather than incidental — it points into the superproject's modules store, so the write lands
+    # in a repository this build does not own just the same.
+    #
+    # Narrow like the symlink guard above, and checked here for the same two reasons: only the state
+    # that WRITES is refused, and refusing before the ls-remote costs no round-trip. A worktree that
+    # already IS the pin is used silently and one on a branch still warns and builds, because
+    # holding the kit in a worktree is an ordinary way to co-develop it.
+    if [ -f "$KIT_DIR/.git" ]; then
+      KIT_OWNER="$(git -C "$KIT_DIR" rev-parse --git-common-dir)"
+      echo "ERROR: $KIT_DIR is a linked git worktree of $KIT_OWNER," >&2
+      echo "       and it is at $KIT_AT, not the pinned $DRAGONKIT_TAG. Refreshing it means fetching" >&2
+      echo "       into it and moving its HEAD, in a repository this build does not own — and a" >&2
+      echo "       worktree shares its refs with the clone that owns it, so $DRAGONKIT_TAG would be" >&2
+      echo "       written into that clone as well. It is left exactly as it is. Check the worktree" >&2
+      echo "       out at $DRAGONKIT_TAG yourself, or remove it and re-run to clone the pin here:" >&2
+      echo "       git -C $KIT_OWNER worktree remove $KIT_DIR" >&2
       exit 1
     fi
 

--- a/tools/resolve-dragon-kit.sh
+++ b/tools/resolve-dragon-kit.sh
@@ -17,13 +17,21 @@
 # App/AboutConfig.swift failed to compile until the operator guessed that vendor/dragon-kit
 # had to be deleted by hand.
 #
-#   on a branch            -> WARNING, build against it (kit co-development; never touched)
+#   branch, clean, @pin    -> silent, build (it IS the pin; About reports it accurately)
+#   on a branch, otherwise -> WARNING, build against it (kit co-development; never replaced)
 #   detached + dirty       -> ERROR, stop
 #   detached, clean, @pin  -> silent, build (the common case)
-#   detached, clean, @tag  -> re-clone at the pin, and say so
+#   detached, clean, @tag  -> re-clone at the pin, but ONLY once the remote confirms the tag
 #   detached, clean, no tag-> ERROR, stop
 #   not a git checkout     -> ERROR, stop
 #   absent                 -> clone at the pin (the fresh-CI path)
+#
+# OFFLINE CONSEQUENCE, deliberate: refreshing a stale tagged checkout takes one round-trip to the
+# kit remote, so with no network (or no credentials) that case now STOPS the build instead of
+# re-cloning. A local `git tag` is not evidence of publication, and the only way to tell the two
+# apart is to ask the remote; erring the other way deletes commits that exist nowhere else. The
+# remedy is in the error text and is always the same: rm -rf vendor/dragon-kit rebuilds at the pin.
+# Every other path stays offline, so ordinary builds are unaffected.
 set -euo pipefail
 
 KIT_DIR="$1"
@@ -56,19 +64,32 @@ else
   KIT_TAGS="$(git -C "$KIT_DIR" tag --points-at HEAD 2>/dev/null || true)"
   KIT_BRANCH="$(git -C "$KIT_DIR" symbolic-ref -q --short HEAD 2>/dev/null || true)"
   KIT_DIRTY="$(git -C "$KIT_DIR" status --porcelain 2>/dev/null || true)"
+  KIT_AT_PIN=""
+  if printf '%s\n' "$KIT_TAGS" | grep -qxF "$DRAGONKIT_TAG"; then KIT_AT_PIN=1; fi
 
   if [ -n "$KIT_BRANCH" ]; then
-    # Checked FIRST, ahead of both the tag and the dirty test: a branch is the operator's own
-    # work, so it is never replaced and never refused, and that has to hold whatever its HEAD
-    # currently points at. A branch that happens to sit on the pinned commit is still a branch —
-    # the next commit moves it — so it warns from the moment it exists rather than going quiet
-    # until it diverges. Deliberately a warning and not an error: pointing vendor/ at a kit branch
-    # is how the kit is co-developed. Say so loudly, because it links a different kit than the pin
-    # claims and About's "Built with · DragonKit vX.Y.Z" row would then misreport it.
-    echo "WARNING: vendor/dragon-kit is on branch '$KIT_BRANCH', not a checkout of the pinned" >&2
-    echo "         $DRAGONKIT_TAG; building against it as-is (this is how the kit is co-developed)." >&2
-    echo "         About's \"Built with · DragonKit vX.Y.Z\" row will report that branch's kit, not" >&2
-    echo "         the pin. Remove vendor/dragon-kit to build against the pinned tag." >&2
+    # Checked FIRST, ahead of both the dirty and the tag tests: a branch is the operator's own
+    # work, so it is NEVER replaced and never refused, whatever its HEAD points at.
+    #
+    # What it does is warn — but not unconditionally. A CLEAN branch sitting exactly on the pinned
+    # commit is silent: its content is the pin byte for byte, so the kit is fully identified and
+    # About's "Built with · DragonKit vX.Y.Z" row is accurate. Warning there anyway (as this script
+    # briefly did, on the argument that the next commit will move the branch) is a warning about
+    # what the checkout might become, and one that fires on a correct workspace every build is one
+    # operators learn to scroll past — including on the day it means something.
+    #
+    # The warning starts the moment the branch stops BEING the pin — uncommitted changes, or HEAD
+    # somewhere else — because from then on the build links a kit the pin does not name while
+    # About still reports the pin. Deliberately a warning and not an error: pointing vendor/ at a
+    # kit branch is how the kit is co-developed.
+    if [ -n "$KIT_AT_PIN" ] && [ -z "$KIT_DIRTY" ]; then
+      : # A branch, but its HEAD is the pinned commit and the tree is clean. Use it, silently.
+    else
+      echo "WARNING: vendor/dragon-kit is on branch '$KIT_BRANCH', not a checkout of the pinned" >&2
+      echo "         $DRAGONKIT_TAG; building against it as-is (this is how the kit is co-developed)." >&2
+      echo "         About's \"Built with · DragonKit vX.Y.Z\" row will report that branch's kit, not" >&2
+      echo "         the pin. Remove vendor/dragon-kit to build against the pinned tag." >&2
+    fi
   elif [ -n "$KIT_DIRTY" ]; then
     # Dirtiness outranks the tag. The tag names a COMMIT, not the working tree on top of it, so a
     # modified or untracked file at the pin is a kit no version identifies while About still says
@@ -81,22 +102,80 @@ else
     echo "       $DRAGONKIT_TAG for a kit that is not it. Put the changes on a branch to" >&2
     echo "       co-develop the kit, or discard them: rm -rf $KIT_DIR" >&2
     exit 1
-  elif printf '%s\n' "$KIT_TAGS" | grep -qxF "$DRAGONKIT_TAG"; then
+  elif [ -n "$KIT_AT_PIN" ]; then
     : # At the pin, detached and clean — the common case. Use it, silently.
   elif [ -n "$KIT_TAGS" ]; then
-    # A RECOGNISED older tag with a clean tree: an established workspace left on an older pin.
-    # Nothing here is the operator's — the checkout is reproduced exactly by cloning that tag from
-    # the remote — so bring it to the pin rather than failing the build. Only this case is
-    # refreshed automatically.
-    KIT_AT="$(printf '%s' "$KIT_TAGS" | tr '\n' ' ')"
-    echo "==> vendor/dragon-kit is at ${KIT_AT% }, not the pinned $DRAGONKIT_TAG; re-cloning at the pin"
-    KIT_NEEDS_CLONE=1
+    # An older tag with a clean tree: an established workspace left on an older pin. This is the
+    # ONLY state replaced automatically — and replacing means `rm -rf`, so it is allowed only
+    # after the remote has confirmed the checkout is reproducible.
+    #
+    # A tag at HEAD is NOT that confirmation on its own. `git tag` writes a ref in this clone and
+    # contacts nothing, so a tag is exactly as local as the commit under it: an operator who
+    # committed on a detached HEAD and tagged it had that commit deleted by the re-clone below —
+    # the same data loss the untagged case further down exists to prevent, one step further in.
+    # The NAME is no evidence either: `v9.9.9` is as easy to write locally as `local-only`, so
+    # nothing here keys off a vX.Y.Z pattern. Only the remote can answer, so ask it.
+    #
+    # One round-trip, and only on this branch: every other path stays offline and fast. (Round 2
+    # declined to add a network call for the UNTAGGED case, where the answer is knowable locally
+    # and the checkout is simply refused. Here the whole question IS whether a remote has this
+    # commit, so the round-trip is the point rather than a shortcut.)
+    #
+    # Both refs/tags/X and refs/tags/X^{} are requested. For an ANNOTATED tag, ls-remote reports
+    # refs/tags/X as the tag OBJECT's id and only refs/tags/X^{} as the commit it peels to, so
+    # comparing HEAD against the unpeeled line alone would never match and every annotated release
+    # would be refused as unpublished. Verified against git: for an annotated tag those two lines
+    # carry different ids, and the peeled one is the commit.
+    #
+    # HEAD may carry SEVERAL tags — dragon-kit dual-tags vX.Y.Z and sample-vX.Y.Z onto one commit,
+    # 808d5a7 being a live example — so any one of them resolving to this commit on the remote
+    # settles it. Asking for all of them in a single ls-remote keeps it to one round-trip and makes
+    # "could not reach the remote" a single unambiguous failure rather than a per-tag guess.
+    KIT_HEAD="$(git -C "$KIT_DIR" rev-parse HEAD)"
+    KIT_AT="$(printf '%s' "$KIT_TAGS" | tr '\n' ' ')"; KIT_AT="${KIT_AT% }"
+    KIT_TAG_REFS=()
+    while IFS= read -r kit_tag; do
+      [ -n "$kit_tag" ] || continue
+      KIT_TAG_REFS+=("refs/tags/$kit_tag" "refs/tags/$kit_tag^{}")
+    done <<<"$KIT_TAGS"
+
+    # git's own diagnosis goes to stderr ahead of ours on purpose — "Could not read from remote
+    # repository" and "Repository not found" send the operator to different remedies.
+    if ! KIT_REMOTE_REFS="$(git ls-remote --tags "$DRAGONKIT_URL" "${KIT_TAG_REFS[@]}")"; then
+      echo "ERROR: vendor/dragon-kit is at $KIT_AT, not the pinned $DRAGONKIT_TAG, and $KIT_AT could" >&2
+      echo "       not be looked up on $DRAGONKIT_URL (offline, DNS, or credentials — git's own" >&2
+      echo "       error is above). Refreshing this checkout means DELETING it, and a tag is not" >&2
+      echo "       proof of publication until the remote says so, so it is preserved instead." >&2
+      echo "       With no network a stale checkout stops the build rather than refreshing; that" >&2
+      echo "       is the safe direction, because guessing the other way destroys commits no" >&2
+      echo "       remote has. Reconnect and re-run, or discard the checkout to rebuild at the" >&2
+      echo "       pin: rm -rf $KIT_DIR" >&2
+      exit 1
+    fi
+    # Only refs for tags AT HEAD were requested, so any line whose object id is HEAD is one of
+    # them resolving to this very commit — which is precisely the proof required, and it reads the
+    # same for a lightweight tag (id on refs/tags/X) and an annotated one (id on refs/tags/X^{}).
+    if printf '%s\n' "$KIT_REMOTE_REFS" | awk -v sha="$KIT_HEAD" '$1 == sha { found = 1 } END { exit !found }'; then
+      echo "==> vendor/dragon-kit is at $KIT_AT, not the pinned $DRAGONKIT_TAG; re-cloning at the pin"
+      KIT_NEEDS_CLONE=1
+    else
+      echo "ERROR: vendor/dragon-kit is at $KIT_AT, not the pinned $DRAGONKIT_TAG, but no tag on its" >&2
+      echo "       HEAD resolves to commit $(git -C "$KIT_DIR" rev-parse --short HEAD) on $DRAGONKIT_URL." >&2
+      echo "       Either the tag was never pushed, or it has been moved or recreated since — a" >&2
+      echo "       local \`git tag\` contacts no remote, so a tag at HEAD proves no more about this" >&2
+      echo "       commit than a clean tree does, and re-cloning could destroy the only copy of it." >&2
+      echo "       Push the tag if it is meant to be published, put the commit on a branch to" >&2
+      echo "       co-develop the kit, or discard the checkout to rebuild at the pin:" >&2
+      echo "       rm -rf $KIT_DIR" >&2
+      exit 1
+    fi
   else
     # Detached, clean, and on no tag at all. A clean tree does NOT prove the commit is published:
     # it is equally a local commit made on a detached HEAD, which nothing but this directory
-    # holds, and re-cloning would silently destroy it. Deciding otherwise needs a round-trip to
-    # the kit remote to ask whether the commit exists there, which is a network call this script
-    # should not make just to classify a directory — so stop and let the operator say.
+    # holds, and re-cloning would silently destroy it. The round-trip that rescues the tagged case
+    # above cannot help here — ls-remote answers about ref NAMES and this HEAD has none, so the
+    # only remaining question would be whether the bare commit id is fetchable, which is neither
+    # cheap nor permitted on every remote. Stop and let the operator say.
     echo "ERROR: vendor/dragon-kit is detached at commit $(git -C "$KIT_DIR" rev-parse --short HEAD) and carries no tag," >&2
     echo "       so the DragonKit it would build cannot be identified. A clean tree does not make" >&2
     echo "       that commit disposable — it may be local work no remote has — so it is neither" >&2

--- a/tools/resolve-dragon-kit.sh
+++ b/tools/resolve-dragon-kit.sh
@@ -22,18 +22,34 @@
 #   detached + dirty       -> ERROR, stop
 #   detached, clean, @pin  -> silent, build (the common case)
 #   detached, clean, @tag  -> fetch the pin INTO this repository and detach at it, but ONLY once
-#                             the remote confirms the tag. The repository is never replaced.
+#                             the remote confirms the tag, and ONLY when the path is a real
+#                             directory. The repository is never replaced.
+#   ...the same, via a SYMLINK -> ERROR, stop (that checkout belongs to someone else)
 #   detached, clean, no tag-> ERROR, stop
 #   not a git checkout     -> ERROR, stop
-#   absent                 -> clone at the pin (the fresh-CI path)
+#   a file, a socket, a dangling symlink -> ERROR, stop
+#   genuinely absent       -> clone AT that path (the fresh-CI path)
 #
-# A STALE CHECKOUT IS UPDATED IN PLACE; only the ABSENT case ever creates a repository, and no case
-# deletes one. `rm -rf "$KIT_DIR"` was the whole bug: verifying HEAD against the remote proves that
-# HEAD is reproducible and nothing more — it says nothing about the other branches, tags, stashes,
-# reflog entries and unreachable objects in that repository, and no amount of verification can,
-# because none of them are reachable from HEAD. An operator sitting on a published stale tag with
-# an unpushed local branch beside it watched the resolver verify, re-clone and exit 0, having
-# deleted the branch and its only commit.
+# THE INVARIANT, and it is the whole point of this script:
+#
+#     it may UPDATE a verified repository in place, or CREATE a genuinely absent one.
+#     It must never delete or replace an existing filesystem object.
+#
+# Every round of this bug has been a way to delete something. `rm -rf "$KIT_DIR"` on a stale
+# checkout was the first: verifying HEAD against the remote proves that HEAD is reproducible and
+# nothing more — it says nothing about the other branches, tags, stashes, reflog entries and
+# unreachable objects in that repository, and no amount of verification can, because none of them
+# are reachable from HEAD. An operator sitting on a published stale tag with an unpushed local
+# branch beside it watched the resolver verify, re-clone and exit 0, having deleted the branch and
+# its only commit.
+#
+# The SAME `rm -rf` then survived one round longer on the create path, because the classification
+# above it asked `[ ! -d "$KIT_DIR" ]` — "not a DIRECTORY", which is also true of a regular file
+# and of a dangling symlink. A plain file at vendor/dragon-kit was therefore classified as absent
+# and deleted: before_type=Regular File, after_type=Directory, status 0. So the delete is not
+# narrowed here, it is GONE — this script runs no `rm` and no `mv` at all, and
+# tools/test-resolve-dragon-kit.sh asserts that structurally rather than trusting the next reader
+# to notice.
 #
 # OFFLINE CONSEQUENCE, deliberate: refreshing a stale tagged checkout takes one round-trip to the
 # kit remote, so with no network (or no credentials) that case STOPS the build instead of
@@ -49,9 +65,42 @@ DRAGONKIT_URL="$3"
 
 KIT_NEEDS_CLONE=""
 KIT_NEEDS_REFRESH=""
-if [ ! -d "$KIT_DIR" ]; then
+if [ ! -e "$KIT_DIR" ] && [ ! -L "$KIT_DIR" ]; then
+  # GENUINELY ABSENT — nothing there at all — and it takes BOTH tests to say so.
+  #
+  # `-e` alone is not enough: it follows the link, so a DANGLING symlink reads as absent, and the
+  # clone would then quietly create the link's target somewhere else in the filesystem.
+  # `-d` alone (what this asked until the create path was fixed) is worse still: "not a directory"
+  # is true of a regular file, and the clone branch it selected ended in `rm -rf "$KIT_DIR"`.
   echo "==> Cloning DragonKit $DRAGONKIT_TAG into vendor/ (not committed)"
   KIT_NEEDS_CLONE=1
+elif [ ! -e "$KIT_DIR" ]; then
+  # -L true and -e false: a DANGLING SYMLINK. Almost always an operator's link to a DragonKit
+  # checkout they have since moved or deleted, which makes it a statement of intent about where
+  # the kit lives — the one thing that must not be answered by silently populating it.
+  echo "ERROR: $KIT_DIR is a symlink to $(readlink "$KIT_DIR")," >&2
+  echo "       which does not exist, so there is no DragonKit checkout there to identify. The link" >&2
+  echo "       is left exactly as it is: this script never deletes or replaces what it finds at" >&2
+  echo "       that path, and cloning into it would create the link's TARGET instead, somewhere" >&2
+  echo "       else entirely. Point it at a DragonKit checkout, or remove the link and re-run to" >&2
+  echo "       clone the pin: rm $KIT_DIR" >&2
+  exit 1
+elif [ ! -d "$KIT_DIR" ]; then
+  # Something is there and it is not a directory: a regular file, a socket, a symlink to one.
+  # Whatever it is, this script did not put it there and cannot prove what depends on it.
+  if [ -L "$KIT_DIR" ]; then
+    KIT_WHAT="a symlink to $(readlink "$KIT_DIR"), which is not a directory"
+  elif [ -f "$KIT_DIR" ]; then
+    KIT_WHAT="a regular file"
+  else
+    KIT_WHAT="not a directory"
+  fi
+  echo "ERROR: $KIT_DIR is $KIT_WHAT, so the DragonKit the build" >&2
+  echo "       would link cannot be identified. It is left exactly as it is — this script never" >&2
+  echo "       deletes or replaces what it finds at that path, and an earlier version of it that" >&2
+  echo "       did read a plain file as \"absent\" and cleared it without a word. Move or remove it" >&2
+  echo "       yourself, then re-run to clone $DRAGONKIT_TAG there." >&2
+  exit 1
 else
   # Test for .git rather than asking git: `git -C <dir>` walks UP to the first enclosing
   # repository, so on a vendor/dragon-kit that is a plain directory (an interrupted clone) every
@@ -146,6 +195,32 @@ else
     # "could not reach the remote" a single unambiguous failure rather than a per-tag guess.
     KIT_HEAD="$(git -C "$KIT_DIR" rev-parse HEAD)"
     KIT_AT="$(printf '%s' "$KIT_TAGS" | tr '\n' ' ')"; KIT_AT="${KIT_AT% }"
+
+    # NOT THROUGH A SYMLINK. This is the only state that WRITES to an existing checkout, and a
+    # symlinked vendor/dragon-kit is a repository this build does not own — an operator's own kit
+    # clone, linked in from wherever they keep it, quite possibly open in another window or shared
+    # by a second app's workspace. Fetching into it and detaching its HEAD moves state in a
+    # repository nobody asked this script to touch, and unlike the refresh of a checkout the script
+    # created itself, there is nothing here that can put it back.
+    #
+    # Only THIS state is refused. The two symlinked states that merely READ stay exactly as they
+    # were: a clean checkout at the pin is used silently, and a branch still warns and builds,
+    # because a link to a co-development kit is precisely how the kit is co-developed.
+    #
+    # Checked before the ls-remote below, so a refusal costs no round-trip. (A symlink further UP
+    # the path — a symlinked vendor/ holding a real dragon-kit directory — is not detected; `-L`
+    # answers about the last component only. Resolving the whole path instead would misfire
+    # constantly on macOS, where /tmp and /var are themselves symlinks.)
+    if [ -L "$KIT_DIR" ]; then
+      echo "ERROR: $KIT_DIR is a symlink to $(readlink "$KIT_DIR")," >&2
+      echo "       and that checkout is at $KIT_AT, not the pinned $DRAGONKIT_TAG. Refreshing it" >&2
+      echo "       means fetching into it and moving its HEAD — in a repository this build does not" >&2
+      echo "       own, which you linked in from elsewhere and may have open right now — so it is" >&2
+      echo "       left exactly as it is. Check that checkout out at $DRAGONKIT_TAG yourself, or" >&2
+      echo "       remove the link and re-run to clone the pin here: rm $KIT_DIR" >&2
+      exit 1
+    fi
+
     KIT_TAG_REFS=()
     while IFS= read -r kit_tag; do
       [ -n "$kit_tag" ] || continue
@@ -253,31 +328,35 @@ if [ -n "$KIT_NEEDS_REFRESH" ]; then
 fi
 
 if [ -n "$KIT_NEEDS_CLONE" ]; then
-  # Reached ONLY when there was no checkout at all — the one state with no repository to lose, and
-  # so the only one this script is willing to create a directory for. A stale checkout is refreshed
-  # in place above and never arrives here.
+  # Reached ONLY when nothing whatsoever was at that path — no directory, no file, not even a
+  # dangling symlink — which is the one state with nothing to lose, and so the only one this script
+  # is willing to create anything for. A stale checkout is refreshed in place above and never
+  # arrives here.
   #
-  # Clone alongside, swap only on success: clearing the path first would leave a workspace with no
-  # kit at all when the clone then fails, and would delete anything a concurrent run had put there
-  # in the meantime.
+  # CLONED STRAIGHT INTO $KIT_DIR, not staged beside it and swapped in. The staging dance existed
+  # only to make `rm -rf "$KIT_DIR"; mv ...` survivable, and both of those are gone, so there is
+  # nothing left for it to make safe — it would now be a rename over a path this run has stopped
+  # claiming to own.
   #
-  # A UNIQUE staging dir, not a fixed "dragon-kit.incoming": that fixed path is one this run does
-  # not own. A second build running concurrently, or the leftovers of an interrupted one, share
-  # it — and the `rm -rf` that cleared it would delete a clone another process was writing into,
-  # or hand this run a half-written tree as if it were a finished clone. mktemp keeps it beside
-  # KIT_DIR so the swap stays a same-filesystem rename; the trap removes it on any exit path.
+  # Cloning direct also hands the last word to git, which is the point: git refuses a destination
+  # that already exists and is not an empty directory, and deletes nothing when it does. So if
+  # anything appears here between the classification above and this line — a concurrent build, an
+  # operator dropping a file in — the clone FAILS and that thing survives, where the delete-then-
+  # swap would have destroyed it and reported success. Verified against git: with a regular file at
+  # the destination the clone exits 128 and the file keeps its inode and its contents.
+  #
+  # No cleanup trap, and none needed: git removes what IT created if the clone fails (verified —
+  # a --branch that does not exist leaves no destination behind), and what git did not create is
+  # exactly what this script must not remove.
   mkdir -p "$(dirname "$KIT_DIR")"
-  KIT_STAGING="$(mktemp -d "$KIT_DIR.incoming.XXXXXX")"
-  trap 'rm -rf "$KIT_STAGING"' EXIT
-  trap 'exit 130' INT
-  trap 'exit 143' TERM
-  if ! git clone --depth 1 --branch "$DRAGONKIT_TAG" "$DRAGONKIT_URL" "$KIT_STAGING"; then
+  if ! git clone --depth 1 --branch "$DRAGONKIT_TAG" "$DRAGONKIT_URL" "$KIT_DIR"; then
     echo "ERROR: could not clone DragonKit $DRAGONKIT_TAG from $DRAGONKIT_URL. The existing" >&2
-    echo "       checkout (if any) was left untouched and was NOT built against. Fix the network" >&2
-    echo "       or credentials and re-run, or start clean: rm -rf $KIT_DIR" >&2
+    echo "       checkout (if any) was left untouched and was NOT built against, and nothing at" >&2
+    echo "       $KIT_DIR was deleted or replaced: that path is only ever cloned into when it is" >&2
+    echo "       empty, and git refuses a destination something else has taken rather than clearing" >&2
+    echo "       it. So if git's error above names an existing destination, look at what is there —" >&2
+    echo "       that is another process or a stray file, not a network fault. Otherwise fix the" >&2
+    echo "       network or credentials and re-run." >&2
     exit 1
   fi
-  rm -rf "$KIT_DIR"
-  mv "$KIT_STAGING" "$KIT_DIR"
-  trap - EXIT INT TERM
 fi

--- a/tools/resolve-dragon-kit.sh
+++ b/tools/resolve-dragon-kit.sh
@@ -26,6 +26,7 @@
 #                             directory. The repository is never replaced.
 #   ...the same, via a SYMLINK -> ERROR, stop (that checkout belongs to someone else)
 #   ...the same, in a WORKTREE -> ERROR, stop (so does that one, and its refs are shared)
+#   ...or a SUBMODULE, likewise -> ERROR, stop (same again — but never told to `worktree remove`)
 #   detached, clean, no tag-> ERROR, stop
 #   not a git checkout     -> ERROR, stop
 #   a file, a socket, a dangling symlink -> ERROR, stop
@@ -232,23 +233,54 @@ else
     # left detached at v3.1.0, status 0. The layout is not contrived: ice-2 and yahoo-keykey-2 both
     # keep linked worktrees inside their own repo roots.
     #
-    # `-f` on .git also catches a git SUBMODULE, which wears the same .git file. That is correct
-    # rather than incidental — it points into the superproject's modules store, so the write lands
-    # in a repository this build does not own just the same.
+    # `-f` on .git also catches a git SUBMODULE and a --separate-git-dir checkout, which wear the
+    # same .git file. Catching them is correct rather than incidental — that file points into the
+    # superproject's modules store, or into a git directory kept elsewhere, so the write lands in a
+    # repository this build does not own just the same.
     #
     # Narrow like the symlink guard above, and checked here for the same two reasons: only the state
     # that WRITES is refused, and refusing before the ls-remote costs no round-trip. A worktree that
     # already IS the pin is used silently and one on a branch still warns and builds, because
     # holding the kit in a worktree is an ordinary way to co-develop it.
     if [ -f "$KIT_DIR/.git" ]; then
-      KIT_OWNER="$(git -C "$KIT_DIR" rev-parse --git-common-dir)"
-      echo "ERROR: $KIT_DIR is a linked git worktree of $KIT_OWNER," >&2
-      echo "       and it is at $KIT_AT, not the pinned $DRAGONKIT_TAG. Refreshing it means fetching" >&2
-      echo "       into it and moving its HEAD, in a repository this build does not own — and a" >&2
-      echo "       worktree shares its refs with the clone that owns it, so $DRAGONKIT_TAG would be" >&2
-      echo "       written into that clone as well. It is left exactly as it is. Check the worktree" >&2
-      echo "       out at $DRAGONKIT_TAG yourself, or remove it and re-run to clone the pin here:" >&2
-      echo "       git -C $KIT_OWNER worktree remove $KIT_DIR" >&2
+      # WHICH gitfile layout decides the REMEDY, and round 6 printed the wrong one. It called every
+      # match a "linked git worktree" and handed out `git worktree remove`, which a submodule
+      # refuses — "is not a working tree", exit 128. Reproduced on a real submodule. The refusal was
+      # never the defect and does not change here; the sentence describing it was, and an error that
+      # sends the operator to a failing command is precisely the failure this script's unusually
+      # long error text exists to prevent (the incident that started all of this was an operator
+      # having to GUESS that vendor/dragon-kit needed deleting by hand).
+      #
+      # git tells the layouts apart. For a LINKED WORKTREE --git-dir is that worktree's private
+      # <common>/worktrees/<name> while --git-common-dir stays the owning clone's .git, so the two
+      # DIFFER. For a submodule and for --separate-git-dir the git dir IS the common dir and they
+      # are equal. Verified against git across all three layouts, plus an ordinary clone as a
+      # control. Both are asked for with --path-format=absolute so the comparison cannot be decided
+      # by one of them coming back relative and the other not.
+      KIT_GITDIR="$(git -C "$KIT_DIR" rev-parse --path-format=absolute --git-dir)"
+      KIT_OWNER="$(git -C "$KIT_DIR" rev-parse --path-format=absolute --git-common-dir)"
+      if [ "$KIT_GITDIR" != "$KIT_OWNER" ]; then
+        echo "ERROR: $KIT_DIR is a linked git worktree of $KIT_OWNER," >&2
+        echo "       and it is at $KIT_AT, not the pinned $DRAGONKIT_TAG. Refreshing it means fetching" >&2
+        echo "       into it and moving its HEAD, in a repository this build does not own — and a" >&2
+        echo "       worktree shares its refs with the clone that owns it, so $DRAGONKIT_TAG would be" >&2
+        echo "       written into that clone as well. It is left exactly as it is. Check the worktree" >&2
+        echo "       out at $DRAGONKIT_TAG yourself, or remove it and re-run to clone the pin here:" >&2
+        echo "       git -C $KIT_OWNER worktree remove $KIT_DIR" >&2
+      else
+        # A submodule or a --separate-git-dir checkout. No command is offered, because the correct
+        # one depends on which of those it is and on how the owning repository is set up — and the
+        # round-6 defect was offering one anyway.
+        echo "ERROR: $KIT_DIR is a gitfile-backed checkout: its .git is a file" >&2
+        echo "       pointing at $KIT_GITDIR," >&2
+        echo "       which makes it a submodule or a --separate-git-dir checkout rather than a clone" >&2
+        echo "       this build made. It is at $KIT_AT, not the pinned $DRAGONKIT_TAG, and refreshing" >&2
+        echo "       it means fetching into that git directory and moving its HEAD," >&2
+        echo "       in a repository this build does not own. It is left exactly as it is. Check it" >&2
+        echo "       out at $DRAGONKIT_TAG through the repository that owns it — for a submodule," >&2
+        echo "       the superproject — or detach it from that repository so this path is an" >&2
+        echo "       ordinary checkout, and re-run." >&2
+      fi
       exit 1
     fi
 

--- a/tools/test-resolve-dragon-kit.sh
+++ b/tools/test-resolve-dragon-kit.sh
@@ -608,6 +608,14 @@ that "the pin was not written into the owning clone's shared ref store" test -z 
 that "every ref in the owning clone is byte-for-byte unchanged" test "$(git -C "$owner" show-ref | sort)" = "$refs_before"
 that "no fetch was attempted at all" test ! -e "$wt_gitdir/FETCH_HEAD"
 no_leftovers "$kit"
+# The round-6 defect was a remedy that did not RUN — every gitfile-backed checkout was handed
+# `git worktree remove`, and on a submodule that exits 128. So the command is asserted verbatim and
+# then executed, rather than trusting that a plausible-looking string works. This layout is the only
+# one that gets a `worktree remove` at all; the submodule case below asserts it is never offered
+# there. Left until last in this case because it consumes the fixture.
+wt_common="$(git -C "$kit" rev-parse --path-format=absolute --git-common-dir)"
+that "the printed remedy names the owning clone and this worktree" test "$(grep -o 'git -C .* worktree remove .*' "$ERR")" = "git -C $wt_common worktree remove $kit"
+that "and that command actually runs" git -C "$wt_common" worktree remove "$kit"
 
 start "a linked worktree that IS the pin is still used silently (the guard is narrow)"
 # Placement, not just presence: the same test one level up — beside the `.git` existence check that
@@ -624,6 +632,43 @@ run "$kit"
 status_is 0
 quiet                                            # reading a worktree is fine; writing to one is not
 that "the worktree is untouched" test "$(head_sha "$kit")" = "$before"
+
+start "a stale SUBMODULE is refused too, and is not described as a worktree"
+# Round 6's guard was RIGHT to catch this — a submodule's .git is a file as well, and it points into
+# the superproject's modules store, so refreshing it writes into a repository this build does not
+# own. What was wrong was the sentence: every gitfile-backed checkout was called a "linked git
+# worktree" and handed `git worktree remove`, which a submodule refuses with "is not a working
+# tree", exit 128. Reproduced on a real submodule against 8b29e54. So this case asserts the refusal
+# AND that the operator is not sent to a command that cannot work.
+super="$WORK/submodule-super"
+git init -q -b main "$super"
+: > "$super/README"; git -C "$super" add README; git -C "$super" commit -qm "superproject"
+# -c protocol.file.allow=always: git refuses a file:// submodule by default (CVE-2022-39253).
+git -c protocol.file.allow=always -C "$super" submodule add -q "$REMOTE_URL" vendor/dragon-kit
+git -C "$super" commit -qm "vendor DragonKit as a submodule"
+kit="$super/vendor/dragon-kit"
+git -C "$kit" checkout -q --detach "refs/tags/$OLD_TAG"
+git -C "$kit" tag -d "$PIN" >/dev/null          # a submodule pinned before the bump: no $PIN yet
+module_dir="$(git -C "$kit" rev-parse --path-format=absolute --git-dir)"
+before="$(head_sha "$kit")"
+refs_before="$(git -C "$kit" show-ref | sort)"
+that "fixture: a real directory whose .git is a FILE, so the guard matches it" test -f "$kit/.git"
+that "fixture: and NOT a linked worktree — its git dir IS its common dir" test "$module_dir" = "$(git -C "$kit" rev-parse --path-format=absolute --git-common-dir)"
+that "fixture: which is the superproject's module store" test "${module_dir#"$(cd "$super" && pwd -P)"/.git/modules/}" = "vendor/dragon-kit"
+that "fixture: detached at the published $OLD_TAG, so verification would pass" test "$(head_tags "$kit")" = "$OLD_TAG"
+run "$kit"
+status_is 1
+stderr_has "is a gitfile-backed checkout"
+stderr_has "submodule or a --separate-git-dir checkout"
+stderr_has "in a repository this build does not"
+stderr_lacks "linked git worktree"          # it is not one, and round 6 said it was
+stderr_lacks "worktree remove"              # exits 128 here — never offer it
+that "HEAD did not move" test "$(head_sha "$kit")" = "$before"
+that "the pin was not written into the superproject's module store" test -z "$(git -C "$kit" tag -l "$PIN")"
+that "every ref in that module store is byte-for-byte unchanged" test "$(git -C "$kit" show-ref | sort)" = "$refs_before"
+that "no fetch was attempted at all" test ! -e "$module_dir/FETCH_HEAD"
+that "and the submodule is still a checkout, not replaced by a clone" test -f "$kit/.git"
+no_leftovers "$kit"
 
 start "a target that APPEARS during the fresh-clone path is never deleted"
 kit="$WORK/appearing-target/vendor/dragon-kit"

--- a/tools/test-resolve-dragon-kit.sh
+++ b/tools/test-resolve-dragon-kit.sh
@@ -18,6 +18,10 @@ set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 RESOLVER="$ROOT/tools/resolve-dragon-kit.sh"
 
+# Resolved once, BEFORE any case puts a shim on PATH: the concurrency case below drives the
+# resolver with a fake `git` in front, and that shim has to be able to reach the real one.
+REAL_GIT="$(command -v git)"
+
 # Hermetic git: the fixtures must not pick up the operator's ~/.gitconfig (commit.gpgsign, a
 # default branch name, an absent user identity on a CI runner).
 export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
@@ -107,6 +111,14 @@ run() {  # $1 = kit dir, $2 = pin (default $PIN), $3 = clone url (default $REMOT
   STATUS=$?
 }
 
+# As run(), with $1 prepended to PATH — for the case that needs a `git` shim in front of the real
+# one. In a subshell so the shim cannot leak into any later case.
+run_with_path() {  # $1 = dir to prepend to PATH, then as run()
+  local shim_dir="$1"; shift
+  ( PATH="$shim_dir:$PATH"; "$RESOLVER" "$1" "${2:-$PIN}" "${3:-$REMOTE_URL}" >"$OUT" 2>"$ERR" )
+  STATUS=$?
+}
+
 # that <description> <command...> — the command runs at the call site with normal expansion,
 # so an assertion reads as the shell condition it is.
 that() {
@@ -125,13 +137,35 @@ dump() { printf '\n          --- stdout ---\n%s\n          --- stderr ---\n%s' "
 head_sha()  { git -C "$1" rev-parse HEAD 2>/dev/null; }
 head_tags() { git -C "$1" tag --points-at HEAD 2>/dev/null | tr '\n' ' ' | sed 's/ $//'; }
 
+# `ls -di` rather than stat(1), whose flags differ between BSD and GNU. An inode is what a type
+# check cannot tell you: the reproduction that opened round 5 reported before_type=Regular File and
+# after_type=Directory, but a delete-then-recreate of the same TYPE would have read as untouched.
+# shellcheck disable=SC2012  # find prints inodes only on GNU (-printf '%i'); these paths are our
+# own mktemp fixtures, so ls's weakness with exotic filenames cannot bite here.
+inode() { ls -di "$1" 2>/dev/null | awk '{print $1}'; }
+
+# Lines of a shell script that RUN rm or mv, as opposed to naming one in a comment or printing one
+# as advice in an operator-facing message ("... start clean: rm -rf vendor/dragon-kit"). The
+# leading alternation is what makes it a command position and not the "rm" inside "perform"; the
+# quote in it catches `trap 'rm -rf ...'`.
+# shellcheck disable=SC2329  # invoked indirectly, as an argument to `that`
+destructive_lines() {
+  grep -nE "(^|[[:space:]]|[;&|(]|')(rm|mv)[[:space:]]" "$1" \
+    | grep -vE '^[0-9]+:[[:space:]]*#' \
+    | grep -vE '^[0-9]+:[[:space:]]*echo '
+}
+
 # Survival asserted by OBJECT ID, not by ref name: a branch or tag name can be recreated by a fresh
 # clone or by hand, but only the original repository still holds the object underneath it. This is
 # the assertion the owner's reproduction turned on, and the one a re-cloning resolver cannot pass.
 # shellcheck disable=SC2329  # invoked indirectly, as an argument to `that`
 holds_commit() { git -C "$1" rev-parse --verify -q "$2^{commit}" >/dev/null; }
 
-# No staging directory may survive a run, on any exit path — that is the cleanup trap's job.
+# No staging directory may exist after a run, on any exit path. Round 2 cloned beside KIT_DIR and
+# swapped, and this asserted the cleanup trap ran; the swap is gone (the clone lands directly in
+# KIT_DIR now, so there is no delete to make safe), and this asserts the mechanism has not crept
+# back — a stray dragon-kit.incoming in vendor/ means someone reintroduced a rename over a path
+# this script does not own.
 no_leftovers() {
   local leftovers; leftovers="$(find "$(dirname "$1")" -maxdepth 1 -name 'dragon-kit.incoming*' 2>/dev/null)"
   if [ -z "$leftovers" ]; then ok "no staging leftovers"; else bad "staging leftovers: $leftovers"; fi
@@ -256,15 +290,19 @@ stderr_has "checkout (if any) was left untouched and was NOT built against"
 that "no checkout was left behind" test ! -e "$kit"
 no_leftovers "$kit"
 
-start "staging is unique: a clone cannot delete a directory it does not own"
-kit="$WORK/unique-staging/vendor/dragon-kit"    # absent: the only state that stages a clone
+start "a fresh clone touches nothing beside its own destination"
+kit="$WORK/unique-staging/vendor/dragon-kit"    # absent: the only state that clones at all
 mkdir -p "$(dirname "$kit")"
-decoy="$(dirname "$kit")/dragon-kit.incoming"   # what a concurrent/interrupted run used to own
+# dragon-kit.incoming is the staging path round 2 used and round 5 retired. It stands in here for
+# any neighbour in vendor/ that is not this run's business — the leftovers of an interrupted build,
+# or a clone another process is writing into. Round 2 cleared this exact path by name.
+decoy="$(dirname "$kit")/dragon-kit.incoming"
 mkdir -p "$decoy"; echo "another run's clone" > "$decoy/sentinel"
 run "$kit"
 status_is 0
-that "the fixed-path staging dir was not clobbered" test -f "$decoy/sentinel"
+that "the neighbour was not clobbered" test -f "$decoy/sentinel"
 that "the clone still landed on $PIN" test "$(head_tags "$kit")" = "$PIN"
+that "and it landed at $kit itself, not staged and renamed in" test -d "$kit/.git"
 
 # ------------------------------------------------- a branch that IS the pin says nothing
 
@@ -439,6 +477,159 @@ that "the local $PIN tag was not overwritten" test "$(git -C "$kit" rev-parse -q
 that "HEAD did not move" test "$(head_sha "$kit")" = "$before"
 that "the local commit object survives" holds_commit "$kit" "$hidden"
 no_leftovers "$kit"
+
+# --------------------------- an existing filesystem object is NEVER deleted or replaced
+#
+# The bug these pin: round 4 fixed the refresh path and left the create path destructive. It
+# classified with `[ ! -d "$KIT_DIR" ]` — "not a DIRECTORY", which is true of a regular file and of
+# a dangling symlink, not just of an absent path — and the branch that selected ended in
+# `rm -rf "$KIT_DIR"; mv "$KIT_STAGING" "$KIT_DIR"`. The owner's reproduction against bd250ba, on a
+# plain file at vendor/dragon-kit: status=0, before_type=Regular File, after_type=Directory.
+#
+# The rule now, stated as one sentence because every previous round was a special case of it: the
+# resolver may UPDATE a verified repository in place, or CREATE a genuinely absent one, and must
+# never delete or replace an existing filesystem object.
+#
+# Preservation is asserted by INODE or by contents wherever a type check would miss a
+# delete-then-recreate — before_type/after_type is what caught this one, and it would not have
+# caught a file replaced by a file.
+
+start "a regular FILE at vendor/dragon-kit is preserved, and the build stops"
+kit="$WORK/regular-file/vendor/dragon-kit"
+mkdir -p "$(dirname "$kit")"
+printf 'not a checkout\n' > "$kit"
+before_ino="$(inode "$kit")"
+that "fixture: a regular file, which \`[ ! -d ]\` reads as absent" test -f "$kit"
+run "$kit"
+status_is 1
+stderr_has "is a regular file"
+stderr_has "deletes or replaces what it finds at that path"
+that "it is still a regular file, not a checkout" test -f "$kit"
+that "the same file — not deleted and recreated" test "$(inode "$kit")" = "$before_ino"
+that "with its contents intact" grep -q "not a checkout" "$kit"
+no_leftovers "$kit"
+
+start "a DANGLING symlink is preserved, and its target is not created"
+kit="$WORK/dangling-symlink/vendor/dragon-kit"
+mkdir -p "$(dirname "$kit")"
+target="$WORK/dangling-symlink/moved-away"
+ln -s "$target" "$kit"
+that "fixture: a symlink is there" test -L "$kit"
+that "fixture: and it resolves to nothing, so \`-e\` reads it as absent" test ! -e "$kit"
+run "$kit"
+status_is 1
+stderr_has "which does not exist"
+stderr_has "clone the pin: rm $kit"
+that "the link survives" test -L "$kit"
+that "still pointing where it did" test "$(readlink "$kit")" = "$target"
+that "and nothing was created at its target" test ! -e "$target"
+no_leftovers "$kit"
+
+start "a stale checkout reached through a SYMLINK is neither fetched into nor checked out"
+# The operator's own DragonKit clone, kept elsewhere and linked in — a repository this build does
+# not own. It sits on the PUBLISHED $OLD_TAG, so the remote verification would pass and an
+# unguarded resolver would refresh it: move its HEAD, and leave refs/tags/$PIN behind in it.
+ext="$WORK/external-stale-kit"
+git clone -q --depth 1 --branch "$OLD_TAG" "$REMOTE_URL" "$ext" 2>/dev/null
+kit="$WORK/symlinked-stale/vendor/dragon-kit"
+mkdir -p "$(dirname "$kit")"
+ln -s "$ext" "$kit"
+before="$(head_sha "$ext")"
+refs_before="$(git -C "$ext" show-ref | sort)"
+that "fixture: the link resolves to a checkout at the published $OLD_TAG" test "$(head_tags "$kit")" = "$OLD_TAG"
+run "$kit"
+status_is 1
+stderr_has "is a symlink to $ext,"
+stderr_has "in a repository this build does not"
+stderr_has "remove the link and re-run to clone the pin here: rm $kit"
+that "the target's HEAD did not move" test "$(head_sha "$ext")" = "$before"
+that "every ref in the target is byte-for-byte unchanged" test "$(git -C "$ext" show-ref | sort)" = "$refs_before"
+that "the pin was not fetched into it" test -z "$(git -C "$ext" tag -l "$PIN")"
+that "no fetch was attempted at all" test ! -e "$ext/.git/FETCH_HEAD"
+that "and the link itself survives" test -L "$kit"
+no_leftovers "$kit"
+
+start "a symlinked checkout that IS the pin is still used silently (the guard is narrow)"
+ext="$WORK/external-kit-at-pin"
+git clone -q --depth 1 --branch "$PIN" "$REMOTE_URL" "$ext" 2>/dev/null
+kit="$WORK/symlinked-at-pin/vendor/dragon-kit"
+mkdir -p "$(dirname "$kit")"
+ln -s "$ext" "$kit"
+before="$(head_sha "$ext")"
+run "$kit"
+status_is 0
+quiet                                            # reading a linked-in checkout is fine; writing is not
+that "the target is untouched" test "$(head_sha "$ext")" = "$before"
+
+start "a symlinked co-development BRANCH still warns and builds (the guard is narrow)"
+ext="$WORK/external-kit-branch"
+git clone -q --depth 1 --branch "$PIN" "$REMOTE_URL" "$ext" 2>/dev/null
+git -C "$ext" checkout -q -b kit-codev
+echo "local kit work" >> "$ext/VERSION"; git -C "$ext" commit -qam "co-development commit"
+kit="$WORK/symlinked-branch/vendor/dragon-kit"
+mkdir -p "$(dirname "$kit")"
+ln -s "$ext" "$kit"
+before="$(head_sha "$ext")"
+run "$kit"
+status_is 0
+stderr_has "WARNING: vendor/dragon-kit is on branch 'kit-codev', not a checkout of the pinned"
+that "still on the branch" test "$(git -C "$ext" symbolic-ref --short HEAD)" = "kit-codev"
+that "and the co-development commit is untouched" test "$(head_sha "$ext")" = "$before"
+
+start "a target that APPEARS during the fresh-clone path is never deleted"
+kit="$WORK/appearing-target/vendor/dragon-kit"
+# The race the delete-then-swap lost, made deterministic: the classification sees an absent path,
+# and something exists by the time the clone runs. A `git` shim on PATH creates it at exactly that
+# moment — no sleeps, no background jobs — and the window it stands for is the real one. Round 4
+# `rm -rf`'d whatever was there after a successful clone and reported success.
+shim="$WORK/appearing-target-shim"
+mkdir -p "$shim"
+cat > "$shim/git" <<SHIM
+#!/bin/bash
+if [ "\$1" = clone ]; then printf 'another run got here first\n' > "$kit"; fi
+exec "$REAL_GIT" "\$@"
+SHIM
+chmod +x "$shim/git"
+run_with_path "$shim" "$kit"
+status_is 1
+stderr_has "ERROR: could not clone DragonKit $PIN from $REMOTE_URL"
+stderr_has "was deleted or replaced"
+that "what appeared is still there" test -f "$kit"
+that "with its contents intact" grep -q "another run got here first" "$kit"
+no_leftovers "$kit"
+
+start "a failed clone leaves the surrounding workspace exactly as it was"
+kit="$WORK/failed-clone-neighbours/vendor/dragon-kit"
+mkdir -p "$(dirname "$kit")"
+sibling="$(dirname "$kit")/sparkle"                  # vendor/ holds more than the kit
+mkdir -p "$sibling"; echo "vendored" > "$sibling/marker"
+decoy="$(dirname "$kit")/dragon-kit.incoming"        # an interrupted round-2 run's leftovers
+mkdir -p "$decoy"; echo "another run's clone" > "$decoy/sentinel"
+run "$kit" "$PIN" "$NO_PIN_URL"
+status_is 1
+that "no half-made checkout was left behind" test ! -e "$kit"
+that "the vendored sibling survives" test -f "$sibling/marker"
+that "and so does a leftover this run does not own" test -f "$decoy/sentinel"
+
+start "the resolver contains no path that deletes or replaces vendor/dragon-kit"
+# Structural, and deliberately not behavioural. The cases above can only cover states someone
+# thought of, and each of the four rounds of this bug was a state nobody had: an unidentified
+# checkout, a locally tagged commit, a repository with an unpushed branch beside HEAD, a plain
+# file. `rm` and `mv` are the two primitives all four needed, so assert the script RUNS neither and
+# the whole class is shut, including the next state nobody has thought of.
+that "the resolver runs no rm and no mv" test -z "$(destructive_lines "$RESOLVER")"
+# Not vacuous: the same grep, over a file that has the three shapes this script has actually worn.
+probe="$WORK/destructive-probe.sh"
+cat > "$probe" <<'PROBE'
+  rm -rf "$KIT_DIR"
+  mv "$KIT_STAGING" "$KIT_DIR"
+  trap 'rm -rf "$KIT_STAGING"' EXIT
+PROBE
+that "precondition: the grep finds all three when they ARE there" test "$(destructive_lines "$probe" | wc -l | tr -d ' ')" = "3"
+# And the resolver is not passing merely because the words are absent: it still PRINTS that remedy
+# on every error path, which is the distinction the grep has to draw.
+# shellcheck disable=SC2016  # a literal $KIT_DIR is the point — this greps the script's text
+that "precondition: and it still prints \"rm -rf \$KIT_DIR\" as advice" grep -qF -- 'rm -rf $KIT_DIR' "$RESOLVER"
 
 # ---------------------------------------------------------------- summary
 

--- a/tools/test-resolve-dragon-kit.sh
+++ b/tools/test-resolve-dragon-kit.sh
@@ -82,6 +82,20 @@ fixture() {  # $1 = workspace name, $2 = tag; echoes the kit dir
   printf '%s' "$kit"
 }
 
+# The owner's reproduction, as a fixture: a checkout that is detached, clean and sitting on a
+# PUBLISHED stale tag — so the remote verification passes and the refresh goes ahead — which also
+# holds a branch and a commit that exist in no remote and are reachable from nothing but that
+# branch. Sets $kit and $hidden rather than echoing, because a command substitution would run it
+# in a subshell and lose $hidden.
+stale_with_local_work() {  # $1 = workspace name; sets $kit and $hidden
+  kit="$(fixture "$1" "$OLD_TAG")"
+  git -C "$kit" checkout -q -b hidden-work
+  echo "work no remote has" >> "$kit/VERSION"
+  git -C "$kit" commit -qam "unpushed local commit"
+  hidden="$(git -C "$kit" rev-parse HEAD)"
+  git -C "$kit" checkout -q --detach "refs/tags/$OLD_TAG"   # back to the published stale tag
+}
+
 # ---------------------------------------------------------------- harness
 
 start() { CASES=$((CASES + 1)); printf '\n[%d] %s\n' "$CASES" "$1"; }
@@ -110,6 +124,12 @@ dump() { printf '\n          --- stdout ---\n%s\n          --- stderr ---\n%s' "
 
 head_sha()  { git -C "$1" rev-parse HEAD 2>/dev/null; }
 head_tags() { git -C "$1" tag --points-at HEAD 2>/dev/null | tr '\n' ' ' | sed 's/ $//'; }
+
+# Survival asserted by OBJECT ID, not by ref name: a branch or tag name can be recreated by a fresh
+# clone or by hand, but only the original repository still holds the object underneath it. This is
+# the assertion the owner's reproduction turned on, and the one a re-cloning resolver cannot pass.
+# shellcheck disable=SC2329  # invoked indirectly, as an argument to `that`
+holds_commit() { git -C "$1" rev-parse --verify -q "$2^{commit}" >/dev/null; }
 
 # No staging directory may survive a run, on any exit path — that is the cleanup trap's job.
 no_leftovers() {
@@ -152,7 +172,7 @@ start "a clean checkout at an older tag is refreshed to the pin"
 kit="$(fixture stale-tag "$OLD_TAG")"
 run "$kit"
 status_is 0
-stdout_has "==> vendor/dragon-kit is at $OLD_TAG, not the pinned $PIN; re-cloning at the pin"
+stdout_has "==> vendor/dragon-kit is at $OLD_TAG, not the pinned $PIN; fetching the pin into it"
 that "checkout is now at $PIN" test "$(head_tags "$kit")" = "$PIN"
 no_leftovers "$kit"
 
@@ -224,28 +244,27 @@ stderr_has "Refused even when HEAD carries $PIN"
 that "untracked file preserved" test -f "$kit/NOTES.txt"
 that "checkout untouched" test "$(head_sha "$kit")" = "$before"
 
-start "a failed clone leaves the existing checkout intact"
-kit="$(fixture failed-clone "$OLD_TAG")"        # stale, so a re-clone is attempted
-before="$(head_sha "$kit")"
-# Against a remote that answers but has no $PIN: the stale tag verifies, and the clone that
-# follows then fails for real. An unreachable URL would now stop at the verification step and
-# never reach the clone at all — case 18 covers that path.
+start "a failed clone leaves no half-made checkout behind (the absent path)"
+kit="$WORK/failed-clone/vendor/dragon-kit"      # absent, so a clone is attempted
+# Against a remote that answers but has no $PIN. This is the ONLY path that still clones: a stale
+# checkout is refreshed in place and never reaches the clone, so its own failure mode is a fetch
+# that fails — covered among the update-in-place cases at the end.
 run "$kit" "$PIN" "$NO_PIN_URL"
 status_is 1
 stderr_has "ERROR: could not clone DragonKit $PIN from $NO_PIN_URL"
 stderr_has "checkout (if any) was left untouched and was NOT built against"
-that "existing checkout still at $OLD_TAG" test "$(head_tags "$kit")" = "$OLD_TAG"
-that "existing checkout unchanged" test "$(head_sha "$kit")" = "$before"
+that "no checkout was left behind" test ! -e "$kit"
 no_leftovers "$kit"
 
-start "staging is unique: a re-clone cannot delete a directory it does not own"
-kit="$(fixture unique-staging "$OLD_TAG")"
+start "staging is unique: a clone cannot delete a directory it does not own"
+kit="$WORK/unique-staging/vendor/dragon-kit"    # absent: the only state that stages a clone
+mkdir -p "$(dirname "$kit")"
 decoy="$(dirname "$kit")/dragon-kit.incoming"   # what a concurrent/interrupted run used to own
 mkdir -p "$decoy"; echo "another run's clone" > "$decoy/sentinel"
 run "$kit"
 status_is 0
 that "the fixed-path staging dir was not clobbered" test -f "$decoy/sentinel"
-that "re-clone still landed on $PIN" test "$(head_tags "$kit")" = "$PIN"
+that "the clone still landed on $PIN" test "$(head_tags "$kit")" = "$PIN"
 
 # ------------------------------------------------- a branch that IS the pin says nothing
 
@@ -274,14 +293,17 @@ that "checkout untouched — a branch is never replaced" test "$(head_sha "$kit"
 
 start "a published LIGHTWEIGHT stale tag verifies against the remote and is refreshed"
 kit="$(fixture published-lightweight "$OLD_TAG")"
+: > "$kit/.git/keykey-same-repo-sentinel"       # survives only if this .git is never replaced
 run "$kit"
 status_is 0
-stdout_has "==> vendor/dragon-kit is at $OLD_TAG, not the pinned $PIN; re-cloning at the pin"
+stdout_has "==> vendor/dragon-kit is at $OLD_TAG, not the pinned $PIN; fetching the pin into it"
 that "checkout is now at $PIN" test "$(head_tags "$kit")" = "$PIN"
+that "the same repository was updated, not a new one" test -f "$kit/.git/keykey-same-repo-sentinel"
 no_leftovers "$kit"
 
 start "a published ANNOTATED stale tag is refreshed too (the naive ls-remote compare fails here)"
 kit="$(fixture published-annotated "$ANNOT_TAG")"
+: > "$kit/.git/keykey-same-repo-sentinel"
 unpeeled="$(git ls-remote --tags "$REMOTE_URL" "refs/tags/$ANNOT_TAG" | awk '{print $1}')"
 # Asserted as a PRECONDITION so this case cannot pass vacuously: if refs/tags/$ANNOT_TAG ever
 # starts reporting the commit itself, the fixture has stopped reproducing the hazard and should
@@ -289,8 +311,9 @@ unpeeled="$(git ls-remote --tags "$REMOTE_URL" "refs/tags/$ANNOT_TAG" | awk '{pr
 that "precondition: refs/tags/$ANNOT_TAG reports a tag object, not the commit" test "$unpeeled" != "$(head_sha "$kit")"
 run "$kit"
 status_is 0
-stdout_has "==> vendor/dragon-kit is at $ANNOT_TAG, not the pinned $PIN; re-cloning at the pin"
+stdout_has "==> vendor/dragon-kit is at $ANNOT_TAG, not the pinned $PIN; fetching the pin into it"
 that "checkout is now at $PIN" test "$(head_tags "$kit")" = "$PIN"
+that "the same repository was updated, not a new one" test -f "$kit/.git/keykey-same-repo-sentinel"
 no_leftovers "$kit"
 
 start "a LOCAL-ONLY tag stops the build, and the commit under it survives"
@@ -335,6 +358,86 @@ stderr_has "With no network a stale checkout stops the build rather than refresh
 stderr_has "pin: rm -rf $kit"
 that "existing checkout still at $OLD_TAG" test "$(head_tags "$kit")" = "$OLD_TAG"
 that "the commit survives" test "$(head_sha "$kit")" = "$before"
+no_leftovers "$kit"
+
+# ------------------------------------------- a stale checkout is UPDATED IN PLACE, never replaced
+#
+# The bug these pin: the refresh above was `rm -rf` plus a fresh clone. Verifying HEAD against the
+# remote made that safe for HEAD and for nothing else — a repository's other branches, tags,
+# stashes and reflogs are not reachable from HEAD, so no verification could ever speak for them,
+# and they went with the directory. Reproduced by the owner against 13f7150 on a checkout that was
+# detached and clean at a published stale tag with an unpushed branch beside it: the resolver
+# verified, re-cloned, exited 0, and the branch and its commit were gone.
+#
+# Every case here asserts the surviving OBJECT, not just the ref name.
+
+start "an unpushed local BRANCH and its commit survive a successful refresh"
+stale_with_local_work hidden-branch
+that "fixture: detached and clean at the published $OLD_TAG" test "$(head_tags "$kit")" = "$OLD_TAG"
+that "fixture: and holding a branch no remote has" test "$(git -C "$kit" rev-parse -q --verify refs/heads/hidden-work)" = "$hidden"
+run "$kit"
+status_is 0
+stdout_has "==> vendor/dragon-kit is at $OLD_TAG, not the pinned $PIN; fetching the pin into it"
+that "the refresh landed on $PIN" test "$(head_tags "$kit")" = "$PIN"
+that "the branch ref survives" test "$(git -C "$kit" rev-parse -q --verify refs/heads/hidden-work)" = "$hidden"
+that "and so does the commit object under it" holds_commit "$kit" "$hidden"
+no_leftovers "$kit"
+
+start "a local TAG elsewhere in the repository survives a successful refresh"
+stale_with_local_work local-tag-elsewhere
+git -C "$kit" tag scratch-2026-08 "$hidden"
+git -C "$kit" branch -q -D hidden-work          # the tag is now the ONLY ref holding that commit
+run "$kit"
+status_is 0
+that "the refresh landed on $PIN" test "$(head_tags "$kit")" = "$PIN"
+that "the unrelated tag still points where it did" test "$(git -C "$kit" rev-parse -q --verify refs/tags/scratch-2026-08)" = "$hidden"
+that "and so does the commit object under it" holds_commit "$kit" "$hidden"
+
+start "the refreshed checkout ends DETACHED at the pin, with the pin's tag ref present locally"
+kit="$(fixture ends-detached "$OLD_TAG")"
+run "$kit"
+status_is 0
+that "HEAD is detached, not on a branch" test -z "$(git -C "$kit" symbolic-ref -q --short HEAD)"
+that "HEAD is the pinned commit" test "$(head_sha "$kit")" = "$(git -C "$kit" rev-parse --verify "refs/tags/$PIN^{commit}")"
+that "refs/tags/$PIN is a local ref, not a bare FETCH_HEAD" git -C "$kit" show-ref --verify --quiet "refs/tags/$PIN"
+that "so --points-at HEAD names the pin" test "$(head_tags "$kit")" = "$PIN"
+that "and the tree is clean" test -z "$(git -C "$kit" status --porcelain)"
+# Not an inference — run the resolver again. A refresh that detached at an unnamed commit would
+# leave the NEXT build stopping on "carries no tag"; the silent at-the-pin path is the proof.
+run "$kit"
+status_is 0
+quiet
+
+start "a FAILED fetch leaves HEAD and every local ref exactly as they were"
+stale_with_local_work failed-fetch
+git -C "$kit" tag scratch-2026-08 "$hidden"
+before="$(head_sha "$kit")"
+refs_before="$(git -C "$kit" show-ref | sort)"
+# $NO_PIN_URL answers the verification lookup for $OLD_TAG but carries no $PIN, so the refresh gets
+# past verification and then fails at the fetch itself — the half-moved case.
+run "$kit" "$PIN" "$NO_PIN_URL"
+status_is 1
+stderr_has "ERROR: could not fetch DragonKit $PIN into $kit"
+stderr_has "Nothing was deleted and HEAD did not move"
+that "HEAD did not move" test "$(head_sha "$kit")" = "$before"
+that "still at $OLD_TAG, which is a usable kit" test "$(head_tags "$kit")" = "$OLD_TAG"
+that "every local ref is byte-for-byte unchanged" test "$(git -C "$kit" show-ref | sort)" = "$refs_before"
+that "the hidden commit object survives" holds_commit "$kit" "$hidden"
+no_leftovers "$kit"
+
+start "a repository already holding a DIFFERENT $PIN tag is preserved, not clobbered"
+stale_with_local_work moved-pin
+git -C "$kit" tag "$PIN" "$hidden"              # the pin's NAME, re-pointed at local work
+pin_before="$(git -C "$kit" rev-parse -q --verify "refs/tags/$PIN")"
+before="$(head_sha "$kit")"
+that "fixture: the local $PIN names the local commit, not the remote's" test "$pin_before" != "$(git ls-remote --tags "$REMOTE_URL" "refs/tags/$PIN" | awk '{print $1}')"
+run "$kit"
+status_is 1
+stderr_has "ERROR: could not fetch DragonKit $PIN into $kit"
+stderr_has "carries a DIFFERENT $PIN"
+that "the local $PIN tag was not overwritten" test "$(git -C "$kit" rev-parse -q --verify "refs/tags/$PIN")" = "$pin_before"
+that "HEAD did not move" test "$(head_sha "$kit")" = "$before"
+that "the local commit object survives" holds_commit "$kit" "$hidden"
 no_leftovers "$kit"
 
 # ---------------------------------------------------------------- summary

--- a/tools/test-resolve-dragon-kit.sh
+++ b/tools/test-resolve-dragon-kit.sh
@@ -576,6 +576,55 @@ stderr_has "WARNING: vendor/dragon-kit is on branch 'kit-codev', not a checkout 
 that "still on the branch" test "$(git -C "$ext" symbolic-ref --short HEAD)" = "kit-codev"
 that "and the co-development commit is untouched" test "$(head_sha "$ext")" = "$before"
 
+start "a stale checkout that is a linked WORKTREE is neither fetched into nor checked out"
+# The route the symlink guard cannot see, and the sixth way found into a repository this build does
+# not own. `git worktree add` leaves a REAL DIRECTORY whose .git is a FILE holding "gitdir: ...", so
+# `-d` further up is true and `-L` beside this guard is false, and the refresh went straight ahead.
+# The harm is the symlink case's exactly, twice over: a worktree SHARES refs/tags with the clone
+# that owns it, so the fetch writes the pin's tag into that clone, and the checkout then moves the
+# worktree's HEAD. Reproduced against 6995a0b — owning clone's tags [v3.0.1] before the run and
+# [v3.0.1 v3.1.0] after, worktree left detached at v3.1.0, status 0. Nor is the layout contrived:
+# ice-2 and yahoo-keykey-2 both keep linked worktrees inside their own repo roots.
+owner="$WORK/worktree-owner"
+# A FULL clone: `git worktree add` needs the ref history, and an operator's own kit clone is one.
+git clone -q --branch "$OLD_TAG" "$REMOTE_URL" "$owner" 2>/dev/null
+git -C "$owner" tag -d "$PIN" >/dev/null         # an operator whose kit predates the pin
+kit="$WORK/worktree-stale/vendor/dragon-kit"
+mkdir -p "$(dirname "$kit")"
+git -C "$owner" worktree add -q --detach "$kit" "refs/tags/$OLD_TAG"
+wt_gitdir="$(git -C "$kit" rev-parse --absolute-git-dir)"   # FETCH_HEAD is per-worktree, not shared
+before="$(head_sha "$kit")"
+refs_before="$(git -C "$owner" show-ref | sort)"
+that "fixture: a real directory, not a symlink, so the guard above cannot see it" test ! -L "$kit"
+that "fixture: whose .git is a FILE rather than a directory" test -f "$kit/.git"
+that "fixture: detached at the published $OLD_TAG, so verification would pass" test "$(head_tags "$kit")" = "$OLD_TAG"
+run "$kit"
+status_is 1
+stderr_has "is a linked git worktree of"
+stderr_has "shares its refs with the clone that"
+stderr_has "in a repository this build does not"
+that "the worktree's HEAD did not move" test "$(head_sha "$kit")" = "$before"
+that "the pin was not written into the owning clone's shared ref store" test -z "$(git -C "$owner" tag -l "$PIN")"
+that "every ref in the owning clone is byte-for-byte unchanged" test "$(git -C "$owner" show-ref | sort)" = "$refs_before"
+that "no fetch was attempted at all" test ! -e "$wt_gitdir/FETCH_HEAD"
+no_leftovers "$kit"
+
+start "a linked worktree that IS the pin is still used silently (the guard is narrow)"
+# Placement, not just presence: the same test one level up — beside the `.git` existence check that
+# every state passes through — would refuse this one too, and a worktree is an ordinary way to hold
+# a kit checkout. Only the state that WRITES is refused, exactly as with the symlink.
+owner="$WORK/worktree-owner-at-pin"
+git clone -q --branch "$PIN" "$REMOTE_URL" "$owner" 2>/dev/null
+kit="$WORK/worktree-at-pin/vendor/dragon-kit"
+mkdir -p "$(dirname "$kit")"
+git -C "$owner" worktree add -q --detach "$kit" "refs/tags/$PIN"
+before="$(head_sha "$kit")"
+that "fixture: a linked worktree, whose .git is a file" test -f "$kit/.git"
+run "$kit"
+status_is 0
+quiet                                            # reading a worktree is fine; writing to one is not
+that "the worktree is untouched" test "$(head_sha "$kit")" = "$before"
+
 start "a target that APPEARS during the fresh-clone path is never deleted"
 kit="$WORK/appearing-target/vendor/dragon-kit"
 # The race the delete-then-swap lost, made deterministic: the classification sees an absent path,

--- a/tools/test-resolve-dragon-kit.sh
+++ b/tools/test-resolve-dragon-kit.sh
@@ -32,7 +32,7 @@ PIN="v3.1.0"          # what most cases pin against
 DUAL_PIN="v3.2.0"     # a pin whose commit also carries a sample-* tag
 OLD_TAG="v3.0.1"      # an older release, for the stale-workspace cases
 
-CASES=0 FAILURES=0 CASE_NAME=""
+CASES=0 FAILURES=0
 
 # ---------------------------------------------------------------- fixtures
 
@@ -67,31 +67,37 @@ fixture() {  # $1 = workspace name, $2 = tag; echoes the kit dir
 
 # ---------------------------------------------------------------- harness
 
-start()  { CASE_NAME="$1"; CASES=$((CASES + 1)); printf '\n[%d] %s\n' "$CASES" "$1"; }
-ok()     { printf '     ok   %s\n' "$1"; }
-bad()    { printf '     FAIL %s\n' "$1"; FAILURES=$((FAILURES + 1)); }
+start() { CASES=$((CASES + 1)); printf '\n[%d] %s\n' "$CASES" "$1"; }
+ok()    { printf '     ok   %s\n' "$1"; }
+bad()   { printf '     FAIL %s\n' "$1"; FAILURES=$((FAILURES + 1)); }
 
 run() {  # $1 = kit dir, $2 = pin (default $PIN), $3 = clone url (default $REMOTE_URL)
   "$RESOLVER" "$1" "${2:-$PIN}" "${3:-$REMOTE_URL}" >"$OUT" 2>"$ERR"
   STATUS=$?
 }
 
-status_is()      { [ "$STATUS" -eq "$1" ] && ok "exit status $1" || bad "exit status: want $1, got $STATUS"; }
-stderr_has()     { grep -qF -- "$1" "$ERR" && ok "stderr: \"$1\"" || bad "stderr lacks \"$1\"$(dump)"; }
-stderr_lacks()   { grep -qF -- "$1" "$ERR" && bad "stderr should not mention \"$1\"$(dump)" || ok "stderr silent on \"$1\""; }
-stdout_has()     { grep -qF -- "$1" "$OUT" && ok "stdout: \"$1\"" || bad "stdout lacks \"$1\"$(dump)"; }
-quiet()          { [ ! -s "$OUT" ] && [ ! -s "$ERR" ] && ok "said nothing at all" || bad "expected silence$(dump)"; }
-is_true()        { eval "$1" && ok "$2" || bad "$2"; }
+# that <description> <command...> — the command runs at the call site with normal expansion,
+# so an assertion reads as the shell condition it is.
+that() {
+  local what="$1"; shift
+  if "$@"; then ok "$what"; else bad "$what"; fi
+}
+
+status_is()    { if [ "$STATUS" -eq "$1" ]; then ok "exit status $1"; else bad "exit status: want $1, got $STATUS"; fi; }
+stderr_has()   { if grep -qF -- "$1" "$ERR"; then ok "stderr: \"$1\""; else bad "stderr lacks \"$1\"$(dump)"; fi; }
+stderr_lacks() { if grep -qF -- "$1" "$ERR"; then bad "stderr should not mention \"$1\"$(dump)"; else ok "stderr silent on \"$1\""; fi; }
+stdout_has()   { if grep -qF -- "$1" "$OUT"; then ok "stdout: \"$1\""; else bad "stdout lacks \"$1\"$(dump)"; fi; }
+quiet()        { if [ ! -s "$OUT" ] && [ ! -s "$ERR" ]; then ok "said nothing at all"; else bad "expected silence$(dump)"; fi; }
 
 dump() { printf '\n          --- stdout ---\n%s\n          --- stderr ---\n%s' "$(sed 's/^/          /' "$OUT")" "$(sed 's/^/          /' "$ERR")"; }
 
 head_sha()  { git -C "$1" rev-parse HEAD 2>/dev/null; }
-head_tags() { git -C "$1" tag --points-at HEAD 2>/dev/null | tr '\n' ' '; }
+head_tags() { git -C "$1" tag --points-at HEAD 2>/dev/null | tr '\n' ' ' | sed 's/ $//'; }
 
 # No staging directory may survive a run, on any exit path — that is the cleanup trap's job.
 no_leftovers() {
   local leftovers; leftovers="$(find "$(dirname "$1")" -maxdepth 1 -name 'dragon-kit.incoming*' 2>/dev/null)"
-  [ -z "$leftovers" ] && ok "no staging leftovers" || bad "staging leftovers: $leftovers"
+  if [ -z "$leftovers" ]; then ok "no staging leftovers"; else bad "staging leftovers: $leftovers"; fi
 }
 
 build_remote
@@ -103,7 +109,7 @@ kit="$WORK/fresh/vendor/dragon-kit"          # note: vendor/ does not exist eith
 run "$kit"
 status_is 0
 stdout_has "==> Cloning DragonKit $PIN into vendor/ (not committed)"
-is_true '[ "$(head_tags "$kit")" = "'"$PIN"' " ]' "cloned checkout is at $PIN"
+that "cloned checkout is at $PIN" test "$(head_tags "$kit")" = "$PIN"
 no_leftovers "$kit"
 
 start "a checkout at the exact pinned tag is used silently"
@@ -112,25 +118,25 @@ before="$(head_sha "$kit")"
 run "$kit"
 status_is 0
 quiet
-is_true '[ "$(head_sha "$kit")" = "'"$before"'" ]' "checkout untouched"
+that "checkout untouched" test "$(head_sha "$kit")" = "$before"
 
 start "a dual-tagged pinned commit is recognised as the pin (git describe gets this wrong)"
 kit="$(fixture dual-tag "$DUAL_PIN")"
 before="$(head_sha "$kit")"
 described="$(git -C "$kit" describe --tags --exact-match HEAD 2>/dev/null)"
-is_true '[ "$(head_tags "$kit")" = "sample-v1.4.0 '"$DUAL_PIN"' " ]' "fixture HEAD carries both tag series"
-is_true '[ "$described" != "'"$DUAL_PIN"'" ]' "precondition: describe answers \"$described\", not the pin"
+that "fixture HEAD carries both tag series" test "$(head_tags "$kit")" = "sample-v1.4.0 $DUAL_PIN"
+that "precondition: describe answers \"$described\", not the pin" test "$described" != "$DUAL_PIN"
 run "$kit" "$DUAL_PIN"
 status_is 0
 quiet
-is_true '[ "$(head_sha "$kit")" = "'"$before"'" ]' "checkout untouched — not re-cloned every build"
+that "checkout untouched — not re-cloned every build" test "$(head_sha "$kit")" = "$before"
 
 start "a clean checkout at an older tag is refreshed to the pin"
 kit="$(fixture stale-tag "$OLD_TAG")"
 run "$kit"
 status_is 0
 stdout_has "==> vendor/dragon-kit is at $OLD_TAG, not the pinned $PIN; re-cloning at the pin"
-is_true '[ "$(head_tags "$kit")" = "'"$PIN"' " ]' "checkout is now at $PIN"
+that "checkout is now at $PIN" test "$(head_tags "$kit")" = "$PIN"
 no_leftovers "$kit"
 
 start "a plain directory inside a git repo is not mistaken for a checkout (git -C walks up)"
@@ -143,7 +149,7 @@ status_is 1
 stderr_has "exists but is not a git checkout"
 stderr_has "Remove it and re-run: rm -rf $kit"
 stderr_lacks "parent-branch-must-never-be-reported"
-is_true '[ -e "'"$kit"'/half-written-clone" ]' "directory left for the operator to remove"
+that "directory left for the operator to remove" test -e "$kit/half-written-clone"
 
 start "a diverged co-development branch warns and builds"
 kit="$(fixture codev-branch "$PIN")"
@@ -154,8 +160,8 @@ run "$kit"
 status_is 0
 stderr_has "WARNING: vendor/dragon-kit is on branch 'kit-codev', not a checkout of the pinned"
 stderr_has "Remove vendor/dragon-kit to build against the pinned tag."
-is_true '[ "$(git -C "'"$kit"'" symbolic-ref --short HEAD)" = "kit-codev" ]' "still on the branch"
-is_true '[ "$(head_sha "$kit")" = "'"$before"'" ]' "co-development commit preserved"
+that "still on the branch" test "$(git -C "$kit" symbolic-ref --short HEAD)" = "kit-codev"
+that "co-development commit preserved" test "$(head_sha "$kit")" = "$before"
 
 start "a dirty branch sitting on the pinned tag still warns and builds"
 kit="$(fixture codev-at-pin "$PIN")"
@@ -164,7 +170,7 @@ echo "uncommitted kit work" >> "$kit/VERSION"
 run "$kit"
 status_is 0
 stderr_has "WARNING: vendor/dragon-kit is on branch 'kit-codev', not a checkout of the pinned"
-is_true 'grep -q "uncommitted kit work" "'"$kit"'/VERSION"' "edit preserved — a branch is never replaced"
+that "edit preserved — a branch is never replaced" grep -q "uncommitted kit work" "$kit/VERSION"
 
 start "a dirty detached checkout stops the build"
 kit="$(fixture dirty-detached "$OLD_TAG")"
@@ -174,20 +180,20 @@ run "$kit"
 status_is 1
 stderr_has "ERROR: vendor/dragon-kit is detached with uncommitted changes"
 stderr_has "co-develop the kit, or discard them: rm -rf $kit"
-is_true 'grep -q "stray edit" "'"$kit"'/VERSION"' "edit preserved"
-is_true '[ "$(head_sha "$kit")" = "'"$before"'" ]' "not re-cloned over"
+that "edit preserved" grep -q "stray edit" "$kit/VERSION"
+that "not re-cloned over" test "$(head_sha "$kit")" = "$before"
 
 start "a clean but UNTAGGED detached commit stops the build (never discarded)"
 kit="$(fixture untagged-detached "$PIN")"
 echo "unpushed local kit commit" >> "$kit/VERSION"
 git -C "$kit" commit -qam "local commit on a detached HEAD"
 before="$(head_sha "$kit")"; short="$(git -C "$kit" rev-parse --short HEAD)"
-is_true '[ -z "$(head_tags "$kit")" ]' "fixture HEAD carries no tag and the tree is clean"
+that "fixture HEAD carries no tag and the tree is clean" test -z "$(head_tags "$kit")"
 run "$kit"
 status_is 1
 stderr_has "ERROR: vendor/dragon-kit is detached at commit $short and carries no tag,"
 stderr_has "that commit disposable — it may be local work no remote has"
-is_true '[ "$(head_sha "$kit")" = "'"$before"'" ]' "the local commit survives"
+that "the local commit survives" test "$(head_sha "$kit")" = "$before"
 no_leftovers "$kit"
 
 start "an untracked file at the pinned tag stops the build (About would misreport it)"
@@ -198,8 +204,8 @@ run "$kit"
 status_is 1
 stderr_has "ERROR: vendor/dragon-kit is detached with uncommitted changes"
 stderr_has "Refused even when HEAD carries $PIN"
-is_true '[ -f "'"$kit"'/NOTES.txt" ]' "untracked file preserved"
-is_true '[ "$(head_sha "$kit")" = "'"$before"'" ]' "checkout untouched"
+that "untracked file preserved" test -f "$kit/NOTES.txt"
+that "checkout untouched" test "$(head_sha "$kit")" = "$before"
 
 start "a failed clone leaves the existing checkout intact"
 kit="$(fixture failed-clone "$OLD_TAG")"        # stale, so a re-clone is attempted
@@ -208,8 +214,8 @@ run "$kit" "$PIN" "file://$WORK/no-such-remote"
 status_is 1
 stderr_has "ERROR: could not clone DragonKit $PIN from file://$WORK/no-such-remote"
 stderr_has "checkout (if any) was left untouched and was NOT built against"
-is_true '[ "$(head_tags "$kit")" = "'"$OLD_TAG"' " ]' "existing checkout still at $OLD_TAG"
-is_true '[ "$(head_sha "$kit")" = "'"$before"'" ]' "existing checkout unchanged"
+that "existing checkout still at $OLD_TAG" test "$(head_tags "$kit")" = "$OLD_TAG"
+that "existing checkout unchanged" test "$(head_sha "$kit")" = "$before"
 no_leftovers "$kit"
 
 start "staging is unique: a re-clone cannot delete a directory it does not own"
@@ -218,8 +224,8 @@ decoy="$(dirname "$kit")/dragon-kit.incoming"   # what a concurrent/interrupted 
 mkdir -p "$decoy"; echo "another run's clone" > "$decoy/sentinel"
 run "$kit"
 status_is 0
-is_true '[ -f "'"$decoy"'/sentinel" ]' "the fixed-path staging dir was not clobbered"
-is_true '[ "$(head_tags "$kit")" = "'"$PIN"' " ]' "re-clone still landed on $PIN"
+that "the fixed-path staging dir was not clobbered" test -f "$decoy/sentinel"
+that "re-clone still landed on $PIN" test "$(head_tags "$kit")" = "$PIN"
 
 # ---------------------------------------------------------------- summary
 

--- a/tools/test-resolve-dragon-kit.sh
+++ b/tools/test-resolve-dragon-kit.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+# Regression tests for tools/resolve-dragon-kit.sh — the block that decides whether the
+# vendor/dragon-kit in a workspace may be built against, refreshed, or refused.
+#
+#   ./tools/test-resolve-dragon-kit.sh
+#
+# Everything runs against throwaway local git repos under a mktemp workspace: no network, no
+# reliance on dragon-kit's real tag history, and the real vendor/dragon-kit is never touched. A
+# full run is about a second, which is the point — the states below differ only in git metadata,
+# and each one costs minutes to reach through tools/build-app.sh.
+#
+# Every case asserts the exit status AND the operator-facing message on the stream it belongs on.
+# The message is half the behaviour here: these errors are read by someone whose build just
+# stopped, and a wrong one sends them to the wrong remedy (the incident that started all of this
+# was an operator having to guess that vendor/dragon-kit needed deleting by hand).
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RESOLVER="$ROOT/tools/resolve-dragon-kit.sh"
+
+# Hermetic git: the fixtures must not pick up the operator's ~/.gitconfig (commit.gpgsign, a
+# default branch name, an absent user identity on a CI runner).
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+export GIT_AUTHOR_NAME="KeyKey Test" GIT_AUTHOR_EMAIL="test@example.invalid"
+export GIT_COMMITTER_NAME="KeyKey Test" GIT_COMMITTER_EMAIL="test@example.invalid"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/keykey-resolve-tests.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+OUT="$WORK/stdout" ERR="$WORK/stderr"
+
+PIN="v3.1.0"          # what most cases pin against
+DUAL_PIN="v3.2.0"     # a pin whose commit also carries a sample-* tag
+OLD_TAG="v3.0.1"      # an older release, for the stale-workspace cases
+
+CASES=0 FAILURES=0 CASE_NAME=""
+
+# ---------------------------------------------------------------- fixtures
+
+# A stand-in for the dragon-kit remote, carrying the same shape of tag history: a vX.Y.Z library
+# series, plus a sample-vX.Y.Z series that lands on some of the SAME commits. sample-v1.4.0 is
+# annotated and v3.2.0 lightweight so `git describe --exact-match` reliably prefers the sample
+# tag — that is the real hazard reproduced deterministically (dragon-kit's own 808d5a7 carries
+# v2.0.0 and sample-v1.2.0, and describe there answers sample-v1.2.0).
+build_remote() {
+  local r="$WORK/kit-remote"
+  git init -q -b main "$r"
+  printf 'kit %s\n' "$OLD_TAG" > "$r/VERSION"; git -C "$r" add VERSION
+  git -C "$r" commit -qm "kit $OLD_TAG"; git -C "$r" tag "$OLD_TAG"
+  printf 'kit %s\n' "$PIN" > "$r/VERSION"
+  git -C "$r" commit -qam "kit $PIN"; git -C "$r" tag "$PIN"
+  printf 'kit %s\n' "$DUAL_PIN" > "$r/VERSION"
+  git -C "$r" commit -qam "kit $DUAL_PIN"
+  git -C "$r" tag "$DUAL_PIN"
+  git -C "$r" tag -a sample-v1.4.0 -m "sample app 1.4.0"
+  # file:// so --depth 1 produces a real shallow clone instead of git's "local clone" shortcut.
+  REMOTE_URL="file://$r"
+}
+
+# A workspace whose vendor/dragon-kit is a shallow clone of <tag> — exactly what the build script
+# itself leaves behind: detached, clean, no branch.
+fixture() {  # $1 = workspace name, $2 = tag; echoes the kit dir
+  local kit="$WORK/$1/vendor/dragon-kit"
+  mkdir -p "$(dirname "$kit")"
+  git clone -q --depth 1 --branch "$2" "$REMOTE_URL" "$kit" 2>/dev/null
+  printf '%s' "$kit"
+}
+
+# ---------------------------------------------------------------- harness
+
+start()  { CASE_NAME="$1"; CASES=$((CASES + 1)); printf '\n[%d] %s\n' "$CASES" "$1"; }
+ok()     { printf '     ok   %s\n' "$1"; }
+bad()    { printf '     FAIL %s\n' "$1"; FAILURES=$((FAILURES + 1)); }
+
+run() {  # $1 = kit dir, $2 = pin (default $PIN), $3 = clone url (default $REMOTE_URL)
+  "$RESOLVER" "$1" "${2:-$PIN}" "${3:-$REMOTE_URL}" >"$OUT" 2>"$ERR"
+  STATUS=$?
+}
+
+status_is()      { [ "$STATUS" -eq "$1" ] && ok "exit status $1" || bad "exit status: want $1, got $STATUS"; }
+stderr_has()     { grep -qF -- "$1" "$ERR" && ok "stderr: \"$1\"" || bad "stderr lacks \"$1\"$(dump)"; }
+stderr_lacks()   { grep -qF -- "$1" "$ERR" && bad "stderr should not mention \"$1\"$(dump)" || ok "stderr silent on \"$1\""; }
+stdout_has()     { grep -qF -- "$1" "$OUT" && ok "stdout: \"$1\"" || bad "stdout lacks \"$1\"$(dump)"; }
+quiet()          { [ ! -s "$OUT" ] && [ ! -s "$ERR" ] && ok "said nothing at all" || bad "expected silence$(dump)"; }
+is_true()        { eval "$1" && ok "$2" || bad "$2"; }
+
+dump() { printf '\n          --- stdout ---\n%s\n          --- stderr ---\n%s' "$(sed 's/^/          /' "$OUT")" "$(sed 's/^/          /' "$ERR")"; }
+
+head_sha()  { git -C "$1" rev-parse HEAD 2>/dev/null; }
+head_tags() { git -C "$1" tag --points-at HEAD 2>/dev/null | tr '\n' ' '; }
+
+# No staging directory may survive a run, on any exit path — that is the cleanup trap's job.
+no_leftovers() {
+  local leftovers; leftovers="$(find "$(dirname "$1")" -maxdepth 1 -name 'dragon-kit.incoming*' 2>/dev/null)"
+  [ -z "$leftovers" ] && ok "no staging leftovers" || bad "staging leftovers: $leftovers"
+}
+
+build_remote
+
+# ---------------------------------------------------------------- cases
+
+start "absent vendor/dragon-kit is cloned at the pin (the fresh-CI path)"
+kit="$WORK/fresh/vendor/dragon-kit"          # note: vendor/ does not exist either
+run "$kit"
+status_is 0
+stdout_has "==> Cloning DragonKit $PIN into vendor/ (not committed)"
+is_true '[ "$(head_tags "$kit")" = "'"$PIN"' " ]' "cloned checkout is at $PIN"
+no_leftovers "$kit"
+
+start "a checkout at the exact pinned tag is used silently"
+kit="$(fixture at-pin "$PIN")"
+before="$(head_sha "$kit")"
+run "$kit"
+status_is 0
+quiet
+is_true '[ "$(head_sha "$kit")" = "'"$before"'" ]' "checkout untouched"
+
+start "a dual-tagged pinned commit is recognised as the pin (git describe gets this wrong)"
+kit="$(fixture dual-tag "$DUAL_PIN")"
+before="$(head_sha "$kit")"
+described="$(git -C "$kit" describe --tags --exact-match HEAD 2>/dev/null)"
+is_true '[ "$(head_tags "$kit")" = "sample-v1.4.0 '"$DUAL_PIN"' " ]' "fixture HEAD carries both tag series"
+is_true '[ "$described" != "'"$DUAL_PIN"'" ]' "precondition: describe answers \"$described\", not the pin"
+run "$kit" "$DUAL_PIN"
+status_is 0
+quiet
+is_true '[ "$(head_sha "$kit")" = "'"$before"'" ]' "checkout untouched — not re-cloned every build"
+
+start "a clean checkout at an older tag is refreshed to the pin"
+kit="$(fixture stale-tag "$OLD_TAG")"
+run "$kit"
+status_is 0
+stdout_has "==> vendor/dragon-kit is at $OLD_TAG, not the pinned $PIN; re-cloning at the pin"
+is_true '[ "$(head_tags "$kit")" = "'"$PIN"' " ]' "checkout is now at $PIN"
+no_leftovers "$kit"
+
+start "a plain directory inside a git repo is not mistaken for a checkout (git -C walks up)"
+parent="$WORK/parent-repo"
+git init -q -b parent-branch-must-never-be-reported "$parent"
+kit="$parent/vendor/dragon-kit"
+mkdir -p "$kit"; : > "$kit/half-written-clone"
+run "$kit"
+status_is 1
+stderr_has "exists but is not a git checkout"
+stderr_has "Remove it and re-run: rm -rf $kit"
+stderr_lacks "parent-branch-must-never-be-reported"
+is_true '[ -e "'"$kit"'/half-written-clone" ]' "directory left for the operator to remove"
+
+start "a diverged co-development branch warns and builds"
+kit="$(fixture codev-branch "$PIN")"
+git -C "$kit" checkout -q -b kit-codev
+echo "local kit work" >> "$kit/VERSION"; git -C "$kit" commit -qam "co-development commit"
+before="$(head_sha "$kit")"
+run "$kit"
+status_is 0
+stderr_has "WARNING: vendor/dragon-kit is on branch 'kit-codev', not a checkout of the pinned"
+stderr_has "Remove vendor/dragon-kit to build against the pinned tag."
+is_true '[ "$(git -C "'"$kit"'" symbolic-ref --short HEAD)" = "kit-codev" ]' "still on the branch"
+is_true '[ "$(head_sha "$kit")" = "'"$before"'" ]' "co-development commit preserved"
+
+start "a dirty branch sitting on the pinned tag still warns and builds"
+kit="$(fixture codev-at-pin "$PIN")"
+git -C "$kit" checkout -q -b kit-codev          # branch, but HEAD is exactly the pinned commit
+echo "uncommitted kit work" >> "$kit/VERSION"
+run "$kit"
+status_is 0
+stderr_has "WARNING: vendor/dragon-kit is on branch 'kit-codev', not a checkout of the pinned"
+is_true 'grep -q "uncommitted kit work" "'"$kit"'/VERSION"' "edit preserved — a branch is never replaced"
+
+start "a dirty detached checkout stops the build"
+kit="$(fixture dirty-detached "$OLD_TAG")"
+echo "stray edit" >> "$kit/VERSION"
+before="$(head_sha "$kit")"
+run "$kit"
+status_is 1
+stderr_has "ERROR: vendor/dragon-kit is detached with uncommitted changes"
+stderr_has "co-develop the kit, or discard them: rm -rf $kit"
+is_true 'grep -q "stray edit" "'"$kit"'/VERSION"' "edit preserved"
+is_true '[ "$(head_sha "$kit")" = "'"$before"'" ]' "not re-cloned over"
+
+start "a clean but UNTAGGED detached commit stops the build (never discarded)"
+kit="$(fixture untagged-detached "$PIN")"
+echo "unpushed local kit commit" >> "$kit/VERSION"
+git -C "$kit" commit -qam "local commit on a detached HEAD"
+before="$(head_sha "$kit")"; short="$(git -C "$kit" rev-parse --short HEAD)"
+is_true '[ -z "$(head_tags "$kit")" ]' "fixture HEAD carries no tag and the tree is clean"
+run "$kit"
+status_is 1
+stderr_has "ERROR: vendor/dragon-kit is detached at commit $short and carries no tag,"
+stderr_has "that commit disposable — it may be local work no remote has"
+is_true '[ "$(head_sha "$kit")" = "'"$before"'" ]' "the local commit survives"
+no_leftovers "$kit"
+
+start "an untracked file at the pinned tag stops the build (About would misreport it)"
+kit="$(fixture dirty-at-pin "$PIN")"
+echo "scratch" > "$kit/NOTES.txt"          # untracked, not modified: `git diff` would miss this
+before="$(head_sha "$kit")"
+run "$kit"
+status_is 1
+stderr_has "ERROR: vendor/dragon-kit is detached with uncommitted changes"
+stderr_has "Refused even when HEAD carries $PIN"
+is_true '[ -f "'"$kit"'/NOTES.txt" ]' "untracked file preserved"
+is_true '[ "$(head_sha "$kit")" = "'"$before"'" ]' "checkout untouched"
+
+start "a failed clone leaves the existing checkout intact"
+kit="$(fixture failed-clone "$OLD_TAG")"        # stale, so a re-clone is attempted
+before="$(head_sha "$kit")"
+run "$kit" "$PIN" "file://$WORK/no-such-remote"
+status_is 1
+stderr_has "ERROR: could not clone DragonKit $PIN from file://$WORK/no-such-remote"
+stderr_has "checkout (if any) was left untouched and was NOT built against"
+is_true '[ "$(head_tags "$kit")" = "'"$OLD_TAG"' " ]' "existing checkout still at $OLD_TAG"
+is_true '[ "$(head_sha "$kit")" = "'"$before"'" ]' "existing checkout unchanged"
+no_leftovers "$kit"
+
+start "staging is unique: a re-clone cannot delete a directory it does not own"
+kit="$(fixture unique-staging "$OLD_TAG")"
+decoy="$(dirname "$kit")/dragon-kit.incoming"   # what a concurrent/interrupted run used to own
+mkdir -p "$decoy"; echo "another run's clone" > "$decoy/sentinel"
+run "$kit"
+status_is 0
+is_true '[ -f "'"$decoy"'/sentinel" ]' "the fixed-path staging dir was not clobbered"
+is_true '[ "$(head_tags "$kit")" = "'"$PIN"' " ]' "re-clone still landed on $PIN"
+
+# ---------------------------------------------------------------- summary
+
+printf '\n----------------------------------------------------------------\n'
+if [ "$FAILURES" -eq 0 ]; then
+  printf 'PASS — %d cases, 0 failures\n' "$CASES"
+  exit 0
+fi
+printf 'FAIL — %d cases, %d failed assertion(s)\n' "$CASES" "$FAILURES"
+exit 1

--- a/tools/test-resolve-dragon-kit.sh
+++ b/tools/test-resolve-dragon-kit.sh
@@ -30,7 +30,8 @@ OUT="$WORK/stdout" ERR="$WORK/stderr"
 
 PIN="v3.1.0"          # what most cases pin against
 DUAL_PIN="v3.2.0"     # a pin whose commit also carries a sample-* tag
-OLD_TAG="v3.0.1"      # an older release, for the stale-workspace cases
+OLD_TAG="v3.0.1"      # an older release (LIGHTWEIGHT), for the stale-workspace cases
+ANNOT_TAG="v3.0.2"    # an older release published as an ANNOTATED tag
 
 CASES=0 FAILURES=0
 
@@ -41,11 +42,19 @@ CASES=0 FAILURES=0
 # annotated and v3.2.0 lightweight so `git describe --exact-match` reliably prefers the sample
 # tag — that is the real hazard reproduced deterministically (dragon-kit's own 808d5a7 carries
 # v2.0.0 and sample-v1.2.0, and describe there answers sample-v1.2.0).
+#
+# BOTH tag object kinds are published here. A stale checkout is now verified against the remote
+# before it may be replaced, and `git ls-remote refs/tags/X` answers with the TAG OBJECT's id for
+# an annotated tag and the COMMIT's id for a lightweight one — so a check that compares only the
+# unpeeled line works on v3.0.1 and silently refuses every annotated release. v3.0.2 is annotated
+# for exactly that reason.
 build_remote() {
   local r="$WORK/kit-remote"
   git init -q -b main "$r"
   printf 'kit %s\n' "$OLD_TAG" > "$r/VERSION"; git -C "$r" add VERSION
   git -C "$r" commit -qm "kit $OLD_TAG"; git -C "$r" tag "$OLD_TAG"
+  printf 'kit %s\n' "$ANNOT_TAG" > "$r/VERSION"
+  git -C "$r" commit -qam "kit $ANNOT_TAG"; git -C "$r" tag -a "$ANNOT_TAG" -m "kit $ANNOT_TAG"
   printf 'kit %s\n' "$PIN" > "$r/VERSION"
   git -C "$r" commit -qam "kit $PIN"; git -C "$r" tag "$PIN"
   printf 'kit %s\n' "$DUAL_PIN" > "$r/VERSION"
@@ -54,6 +63,14 @@ build_remote() {
   git -C "$r" tag -a sample-v1.4.0 -m "sample app 1.4.0"
   # file:// so --depth 1 produces a real shallow clone instead of git's "local clone" shortcut.
   REMOTE_URL="file://$r"
+
+  # A second remote that ANSWERS a lookup but carries no $PIN — what a never-pushed or mistyped
+  # pin looks like. Needed because a stale checkout is verified against the remote BEFORE anything
+  # is deleted, so reaching the clone at all now requires the lookup to have succeeded first.
+  local np="$WORK/kit-remote-no-pin.git"
+  git clone -q --bare "$r" "$np"
+  git -C "$np" tag -d "$PIN" >/dev/null
+  NO_PIN_URL="file://$np"
 }
 
 # A workspace whose vendor/dragon-kit is a shallow clone of <tag> — exactly what the build script
@@ -210,9 +227,12 @@ that "checkout untouched" test "$(head_sha "$kit")" = "$before"
 start "a failed clone leaves the existing checkout intact"
 kit="$(fixture failed-clone "$OLD_TAG")"        # stale, so a re-clone is attempted
 before="$(head_sha "$kit")"
-run "$kit" "$PIN" "file://$WORK/no-such-remote"
+# Against a remote that answers but has no $PIN: the stale tag verifies, and the clone that
+# follows then fails for real. An unreachable URL would now stop at the verification step and
+# never reach the clone at all — case 18 covers that path.
+run "$kit" "$PIN" "$NO_PIN_URL"
 status_is 1
-stderr_has "ERROR: could not clone DragonKit $PIN from file://$WORK/no-such-remote"
+stderr_has "ERROR: could not clone DragonKit $PIN from $NO_PIN_URL"
 stderr_has "checkout (if any) was left untouched and was NOT built against"
 that "existing checkout still at $OLD_TAG" test "$(head_tags "$kit")" = "$OLD_TAG"
 that "existing checkout unchanged" test "$(head_sha "$kit")" = "$before"
@@ -226,6 +246,96 @@ run "$kit"
 status_is 0
 that "the fixed-path staging dir was not clobbered" test -f "$decoy/sentinel"
 that "re-clone still landed on $PIN" test "$(head_tags "$kit")" = "$PIN"
+
+# ------------------------------------------------- a branch that IS the pin says nothing
+
+start "a clean branch sitting exactly on the pinned commit is silent"
+kit="$(fixture branch-at-pin "$PIN")"
+git -C "$kit" checkout -q -b kit-codev          # a branch, but HEAD is the pinned commit, clean
+before="$(head_sha "$kit")"
+that "precondition: on a branch, clean, and at the pin" test "$(git -C "$kit" symbolic-ref --short HEAD)" = "kit-codev"
+run "$kit"
+status_is 0
+quiet                                            # its content IS the pin, so About is accurate
+that "still on the branch" test "$(git -C "$kit" symbolic-ref --short HEAD)" = "kit-codev"
+that "checkout untouched — a branch is never replaced" test "$(head_sha "$kit")" = "$before"
+
+# --------------------------------------- remote verification before a stale tag is replaced
+#
+# The bug these pin: a tag at HEAD was taken as proof the commit was published and reproducible,
+# so a clean detached commit tagged locally — `git tag local-only`, never pushed — was re-cloned
+# over and DESTROYED. `git tag` contacts no remote, so a tag says nothing a clean tree had not
+# already said. A stale tagged checkout may now be replaced only once the remote confirms that a
+# tag at HEAD resolves to that exact commit.
+#
+# The preserving cases all assert that the original commit still resolves afterwards. That is the
+# assertion that actually catches this class: the reproduction turned on the commit surviving, not
+# on the exit status. Grouped at the end so the numbering of the earlier cases stays put.
+
+start "a published LIGHTWEIGHT stale tag verifies against the remote and is refreshed"
+kit="$(fixture published-lightweight "$OLD_TAG")"
+run "$kit"
+status_is 0
+stdout_has "==> vendor/dragon-kit is at $OLD_TAG, not the pinned $PIN; re-cloning at the pin"
+that "checkout is now at $PIN" test "$(head_tags "$kit")" = "$PIN"
+no_leftovers "$kit"
+
+start "a published ANNOTATED stale tag is refreshed too (the naive ls-remote compare fails here)"
+kit="$(fixture published-annotated "$ANNOT_TAG")"
+unpeeled="$(git ls-remote --tags "$REMOTE_URL" "refs/tags/$ANNOT_TAG" | awk '{print $1}')"
+# Asserted as a PRECONDITION so this case cannot pass vacuously: if refs/tags/$ANNOT_TAG ever
+# starts reporting the commit itself, the fixture has stopped reproducing the hazard and should
+# say so rather than going quietly green.
+that "precondition: refs/tags/$ANNOT_TAG reports a tag object, not the commit" test "$unpeeled" != "$(head_sha "$kit")"
+run "$kit"
+status_is 0
+stdout_has "==> vendor/dragon-kit is at $ANNOT_TAG, not the pinned $PIN; re-cloning at the pin"
+that "checkout is now at $PIN" test "$(head_tags "$kit")" = "$PIN"
+no_leftovers "$kit"
+
+start "a LOCAL-ONLY tag stops the build, and the commit under it survives"
+kit="$(fixture local-only-tag "$PIN")"
+echo "unpushed local kit commit" >> "$kit/VERSION"
+git -C "$kit" commit -qam "local commit on a detached HEAD"
+git -C "$kit" tag v9.9.9        # release-SHAPED on purpose: a name is not evidence of publication
+before="$(head_sha "$kit")"; short="$(git -C "$kit" rev-parse --short HEAD)"
+that "fixture: HEAD carries a tag the remote has never heard of" test "$(head_tags "$kit")" = "v9.9.9"
+that "fixture: and the tree is clean" test -z "$(git -C "$kit" status --porcelain)"
+run "$kit"
+status_is 1
+stderr_has "ERROR: vendor/dragon-kit is at v9.9.9, not the pinned $PIN, but no tag on its"
+stderr_has "HEAD resolves to commit $short on $REMOTE_URL"
+stderr_has "Either the tag was never pushed, or it has been moved or recreated since"
+that "the local commit survives" test "$(head_sha "$kit")" = "$before"
+that "and its object is still readable" git -C "$kit" cat-file -e "$before^{commit}"
+no_leftovers "$kit"
+
+start "a locally MOVED tag whose remote commit differs stops the build and preserves it"
+kit="$(fixture moved-tag "$OLD_TAG")"
+echo "local kit work" >> "$kit/VERSION"
+git -C "$kit" commit -qam "local commit"
+git -C "$kit" tag -f "$OLD_TAG" >/dev/null 2>&1   # a real release NAME, re-pointed at local work
+before="$(head_sha "$kit")"
+remote_sha="$(git ls-remote --tags "$REMOTE_URL" "refs/tags/$OLD_TAG" | awk '{print $1}')"
+that "fixture: the remote's $OLD_TAG is a different commit" test "$remote_sha" != "$before"
+run "$kit"
+status_is 1
+stderr_has "ERROR: vendor/dragon-kit is at $OLD_TAG, not the pinned $PIN, but no tag on its"
+that "the local commit survives" test "$(head_sha "$kit")" = "$before"
+that "and its object is still readable" git -C "$kit" cat-file -e "$before^{commit}"
+no_leftovers "$kit"
+
+start "an unreachable remote stops the build and preserves the checkout (the offline cost)"
+kit="$(fixture offline "$OLD_TAG")"
+before="$(head_sha "$kit")"
+run "$kit" "$PIN" "file://$WORK/no-such-remote"
+status_is 1
+stderr_has "ERROR: vendor/dragon-kit is at $OLD_TAG, not the pinned $PIN, and $OLD_TAG could"
+stderr_has "With no network a stale checkout stops the build rather than refreshing"
+stderr_has "pin: rm -rf $kit"
+that "existing checkout still at $OLD_TAG" test "$(head_tags "$kit")" = "$OLD_TAG"
+that "the commit survives" test "$(head_sha "$kit")" = "$before"
+no_leftovers "$kit"
 
 # ---------------------------------------------------------------- summary
 


### PR DESCRIPTION
> **Status — approved at `eac15c24b65215ec91a8640fbd3a446983e6cff0`.** Seven rounds of review, each
> of which found a deeper way to destroy something the build did not own. The resolver is now
> non-destructive by construction: it may **update** a verified repository in place, or **create** a
> genuinely absent one, and it never deletes or replaces an existing filesystem object. It runs no
> `rm` and no `mv` at all — a structural test asserts that, rather than trusting the next reader to
> notice.

Post-merge review findings on #87, fixed forward. What lands:

- **`tools/resolve-dragon-kit.sh`** — the `vendor/dragon-kit` resolution block, split out of
  `tools/build-app.sh` so it can be exercised on its own. The rule it serves: an existing checkout
  is reused only once it has been **identified**, because the About pane reports the pinned tag as
  "Built with · DragonKit vX.Y.Z" whatever the binary actually linked.
- **`tools/test-resolve-dragon-kit.sh`** — the regression suite, **34 cases**, offline, about a
  second, against throwaway local git repos.
- **`App/AboutConfig.swift`** — the Cangjie licence phrase restored in full,
  `Freely redistributable without restriction`, which is a wider grant than the
  `Freely redistributable` an earlier correction had shortened it to.

This branch pins **`DRAGONKIT_TAG="v3.2.0"`** in `tools/build-app.sh`. The R10 conformance violation
quoted in the historical rounds below is therefore **resolved** — conformance now passes with no
violations.

## Final state — what the resolver does with each checkout

| `vendor/dragon-kit` is… | Result |
|---|---|
| **Absent** — neither `-e` nor `-L` | **Clones at the pin.** The only path that creates anything. |
| A **regular file**, socket, or other non-directory | **ERROR, stops.** Preserved — asserted by inode, not by type. |
| A **dangling symlink** | **ERROR, stops.** The link survives, and its target is not created. |
| A directory that is **not a git checkout** | **ERROR, stops.** |
| On a **branch**, clean, at the pin | Silent, builds. Its content *is* the pin, so About is accurate. |
| On a **branch**, otherwise — dirty or diverged | WARNING, builds. Never replaced, never refused: this is how the kit is co-developed. |
| **Detached + dirty**, including at the pin | **ERROR, stops.** The tag names the commit, not the edited tree. |
| **Detached, clean, at the pin** | Silent, builds. The common case. |
| **Detached, clean, at an older tag the remote confirms** — an ordinary **owned** checkout | **Refreshes IN PLACE.** Fetches the pin into that same repository and detaches at it; every other branch, tag, stash, reflog entry and unreachable object survives. |
| …the same, but reached through a **SYMLINK** | **ERROR, stops.** That repository belongs to someone else. |
| …the same, but a **linked WORKTREE** | **ERROR, stops.** Its refs are shared with the clone that owns it. |
| …the same, but a **SUBMODULE** or a `--separate-git-dir` checkout | **ERROR, stops.** Its git dir belongs to the superproject, or lives elsewhere. |
| **Detached, clean, at another tag, unverifiable** | **ERROR, stops** and preserves. A local `git tag` contacts no remote, so it is not proof of publication. |
| **Detached, clean, no tag** | **ERROR, stops.** A clean tree does not make a commit disposable. |

Only an **ordinary owned checkout** is ever refreshed in place. The three "not ours" layouts —
symlinked, linked worktree, submodule / separate-git-dir — are **refused**, and refused *only in the
state that writes*. Reading them is unchanged: one that already **is** the pin is used silently, and
one on a **branch** still warns and builds, because linking or worktree-ing a kit checkout is an
ordinary way to co-develop it.

## Final verification — run at `eac15c2`

| Check | Result |
|---|---|
| `./tools/test-resolve-dragon-kit.sh` | **PASS — 34 cases, 0 failures** |
| `swift test --package-path Packages/KeyKeyEngine -Xswiftc -warnings-as-errors` | **193 tests, 1 skipped, 0 failures** |
| `swift test --package-path Packages/KeyKeyApp -Xswiftc -warnings-as-errors` | **66 tests, 0 failures** |
| `shellcheck tools/resolve-dragon-kit.sh tools/test-resolve-dragon-kit.sh` | **clean** |
| `./tools/build-app.sh --build-lm` | **successful** — `YahooKeyKey2.app`, ad-hoc signed |
| `dragon-conformance.py --app . --kit ~/git/dragon-kit` | **PASS — no violations** |
| GitHub **test** check | **green** |
| GitHub **conformance** check | **green** |

## Round 7 — the gitfile layouts are told apart, and no invalid remedy is printed

Round 6's guard was right to catch a submodule and wrong about what to call it. `-f "$KIT_DIR/.git"`
covers three layouts that all wear a `.git` **file** — a linked worktree, a submodule, and a
`--separate-git-dir` checkout — but every one of them was described as a "linked git worktree" and
handed:

```
git -C <common-dir> worktree remove <kit-dir>
```

which a submodule refuses with `fatal: '…' is not a working tree`, **exit 128**. Reproduced on a
real submodule against `8b29e54`.

**No resolver behaviour changed.** All three layouts are still refused, HEAD still does not move,
and no ref is written into a repository this build does not own. Only the message changed — because
an error that sends the operator to a failing command is precisely the failure this script's
unusually long error text exists to prevent. The incident that started all of this was an operator
having to *guess* that `vendor/dragon-kit` needed deleting by hand.

### How the layouts are distinguished

git already knows. For a **linked worktree**, `--git-dir` is that worktree's private
`<common>/worktrees/<name>` while `--git-common-dir` stays the owning clone's `.git`, so the two
**differ**. For a **submodule** and for **`--separate-git-dir`**, the git dir *is* the common dir.
Both are asked for with `--path-format=absolute`, so the comparison cannot be decided by one coming
back relative and the other not.

Verified against git across all three layouts, plus an ordinary clone as a control:

| Layout | `.git` is a file | dirs differ | Classified as |
|---|---|---|---|
| linked worktree | yes | yes | linked worktree |
| submodule | yes | no | gitfile-backed |
| `--separate-git-dir` | yes | no | gitfile-backed |
| ordinary clone | no | no | never reaches the guard |

A worktree keeps its message and its `worktree remove`, unchanged and still valid. Anything else
gets accurate wording naming the actual git dir and is pointed at the repository that owns it, with
**no command offered** — the correct one depends on which layout it is and how the owning repository
is set up, and offering one anyway was the defect.

### Cases: 33 → 34

| # | Case | What it pins |
|---|---|---|
| 31 | a stale **submodule** is refused, and is not described as a worktree | a real `git submodule add` (with `protocol.file.allow`, since git refuses a `file://` submodule by default). Asserts refusal, HEAD unmoved, the pin **not** written into the superproject's module store, every ref there byte-for-byte unchanged, no `FETCH_HEAD` — and that stderr contains **neither** `linked git worktree` **nor** `worktree remove` |

Case 29 (the linked worktree) was also strengthened: it now asserts the printed remedy **verbatim**
and then **runs it**, exit 0. A plausible-looking command string is exactly what round 6 shipped, and
executing it is the only assertion that would have caught this.

## Round 6 — a linked worktree is a sixth route into someone else's repository

The round-5 symlink guard could not see this one, because a symlink is not how it arrives.
`git worktree add` leaves a **real directory** whose `.git` is a **file** holding `gitdir: …`, so
`-d` at the top is true and `-L` beside the guard is false, and the refresh walked straight in. The
harm is the symlink case's, twice over: a worktree **shares** `refs/tags` with the clone that owns
it, so the fetch writes the pin into that clone, and the checkout then moves the worktree's HEAD.

Reproduced against `6995a0b`:

```
operator's clone tags BEFORE: [v3.0.1]
resolver exit=0
operator's clone tags AFTER:  [v3.0.1 v3.1.0]   <- ref written into a repo we don't own
worktree HEAD:                [v3.1.0]          <- their HEAD moved
```

Not a contrived layout: **ice-2 and yahoo-keykey-2 both keep linked worktrees inside their own repo
roots**, so this was live for the setup that reported it.

The guard is one test beside the symlink one, in the only state that writes, and refused before the
`ls-remote` so it costs no round-trip. `-f .git` catches a submodule and a `--separate-git-dir`
checkout by the same test, which is correct — those point into the superproject's modules store or a
git directory kept elsewhere, equally not ours. (Round 7 above fixes how each is *described*.)

### Cases: 31 → 33

| # | Case | What it pins |
|---|---|---|
| 29 | a stale checkout that is a **linked worktree** is neither fetched into nor checked out | the owning clone's HEAD unmoved, its refs byte-for-byte unchanged, `refs/tags/<pin>` never written into its shared ref store, no fetch attempted. Failed 8 assertions against `6995a0b` |
| 30 | a linked worktree that **is** the pin is still used silently | **placement**, not just presence: the same test one level up — beside the `.git`-existence check every state passes through — would refuse this one too |

---

# Historical record — rounds 5 to 1

> **Everything below is the round-by-round history and is kept for the reasoning, not for the
> status.** Case counts, verification output and conformance results quoted in these sections were
> true *at the time of that round* and are superseded by **Final state** and **Final verification**
> above. In particular: the suite is **34 cases**, not 31, and conformance **PASSes** — the R10
> failure recorded below was resolved when this branch took `DRAGONKIT_TAG="v3.2.0"`.

## Round 5 — round 4 fixed the refresh path and left the create path destructive

### The P1

The owner's reproduction against `bd250ba`, on a **regular file** at `vendor/dragon-kit`:

```
status=0   before_type=Regular File   after_type=Directory   after_is_git=true
```

The file was deleted and replaced, silently, exit 0. Two independent causes in four lines:

```sh
if [ ! -d "$KIT_DIR" ]; then KIT_NEEDS_CLONE=1 ...
rm -rf "$KIT_DIR"
mv "$KIT_STAGING" "$KIT_DIR"
```

`[ ! -d ]` means **"not a directory"**, not "absent" — true of a regular file, true of a dangling
symlink. And the `rm -rf` destroys whatever is at that path *at the moment it runs*, including
anything another process created after the classification, which is exactly what the comment
sitting directly above it promised would not happen.

### The rule, because each of four rounds has been a special case of it

> The resolver may **update** a verified repository in place, or **create** a genuinely absent one.
> It must never delete or replace an existing filesystem object.

- **The `rm -rf` is gone — not narrowed.** So is the `mv`, and with it round 2's unique-staging
  dance: that mechanism existed only to make delete-and-swap survivable, and there is no delete
  left to make survivable. The script now runs no `rm` and no `mv` at all.
- **Absent means neither `-e` nor `-L`.** `-e` alone follows the link, so a dangling symlink reads
  as absent and cloning "into" it would create the link's *target*, somewhere else entirely.
- **An existing non-directory, or a dangling symlink, stops the build** with a non-zero status and
  a message naming what is there (`a regular file`, `a symlink to <target>, which is not a
  directory`) and what to do about it.
- **The fresh clone lands directly in `$KIT_DIR`.** That hands the last word to git, which refuses
  a destination that already exists and is not empty, and deletes nothing when it does. So a target
  appearing between the classification and the clone now produces a *failed clone* rather than a
  silent success over someone else's file. A partial failed clone is strictly better than deleting
  state the resolver cannot prove it owns — and in practice git removes what it created anyway
  (verified: a `--branch` that does not exist leaves no destination behind).
- **A stale checkout reached through a symlink is no longer refreshed.** Fetching into it and
  detaching its HEAD moves state in a repository this build does not own — an operator's own kit
  clone, linked in from wherever they keep it. Only that state is refused; the two symlinked states
  that merely *read* are unchanged: at the pin it is used silently, on a branch it still warns and
  builds, because a link to a co-development kit is how the kit is co-developed. Checked before the
  `ls-remote`, so a refusal costs no round-trip.
- **Round 4's in-place fetch for ordinary existing repositories is untouched.**

### Suite: 23 → 31 cases (176 assertions) — *historical; the merged suite is **34 cases***

New, and each one fails against `bd250ba`:

| # | Case | What it pins |
|---|---|---|
| 24 | a regular **file** is preserved, and the build stops | the owner's reproduction; asserted by **inode** and contents, because `before_type`/`after_type` would not have noticed a file replaced by a file |
| 25 | a **dangling symlink** is preserved | the link survives, still points where it did, **and nothing is created at its target** |
| 26 | a **symlinked stale external repository** | HEAD unmoved, `show-ref` byte-identical, `refs/tags/<pin>` never arrives, no `FETCH_HEAD` at all — and the fixture sits on a *published* tag, so remote verification would have passed |
| 29 | a target **appearing during the fresh clone** | deterministic, not timed: a `git` shim on `PATH` creates the file at the instant `clone` runs. Round 4 `rm -rf`'d it and reported success |
| 31 | **structural**: the resolver runs no `rm` and no `mv` | the behavioural cases can only cover states someone thought of, and all four rounds were states nobody had. Grep excludes comments and `echo` lines; two preconditions prove it is not vacuous — it finds all three destructive shapes when planted, and the resolver still *prints* `rm -rf $KIT_DIR` as advice |

Also new, and passing on both revisions on purpose — they pin that the symlink guard is **narrow**
and that the fresh-clone path stays neighbourly:

| # | Case |
|---|---|
| 27 | a symlinked checkout that **is** the pin is still used silently |
| 28 | a symlinked co-development **branch** still warns and builds |
| 30 | a failed clone leaves pre-existing siblings in `vendor/` untouched |

Case 12 was retitled (`staging is unique` → `a fresh clone touches nothing beside its own
destination`) because there is no staging any more; its assertions are unchanged and it gained one:
the clone landed at `$KIT_DIR` itself rather than being renamed in.

### Discrimination against `bd250ba`

All 23 pre-existing cases pass on both revisions. Against `bd250ba` the suite reports
**25 failed assertions**, in cases 24, 25, 26, 29 and 31. Sample:

```
[24] a regular FILE at vendor/dragon-kit is preserved, and the build stops
     FAIL exit status: want 1, got 0
     FAIL it is still a regular file, not a checkout
     FAIL the same file — not deleted and recreated
[26] a stale checkout reached through a SYMLINK is neither fetched into nor checked out
     FAIL the target's HEAD did not move
     FAIL every ref in the target is byte-for-byte unchanged
     FAIL the pin was not fetched into it
[31] the resolver contains no path that deletes or replaces vendor/dragon-kit
     FAIL the resolver runs no rm and no mv
```

### Verification *(historical — round 5; see **Final verification** at the top for the merged result)*

```
./tools/test-resolve-dragon-kit.sh                                        PASS — 31 cases, 0 failures
swift test --package-path Packages/KeyKeyEngine -Xswiftc -warnings-as-errors   193 tests, 0 failures
swift test --package-path Packages/KeyKeyApp    -Xswiftc -warnings-as-errors    66 tests, 0 failures
./tools/build-app.sh                                                      exit 0, no warnings/errors
shellcheck tools/resolve-dragon-kit.sh                                    clean
shellcheck tools/test-resolve-dragon-kit.sh                               clean
```

The common paths still make no network call. Both network-capable steps of the build were re-run
under `sandbox-exec` with IP traffic denied, against the real remotes: `fetch-sparkle.sh` exits 0
("already cached") and `resolve-dragon-kit.sh` exits 0 in silence on an at-the-pin checkout. (The
*whole* build cannot be run under that sandbox — `sandbox-exec` breaks Swift's macro plugin server
even with no deny rules at all, verified as a control — so the two steps were isolated instead. The
only other `git` uses in `build-app.sh` are `rev-list --count` and `log -1`, both local.)

**Conformance — RESOLVED since this round.** Round 5 recorded `FAIL — R10 tools/build-app.sh:
pinned to DragonKit 3.1.0 but 3.2.0 is released`, deliberately left for the propagation task. This
branch now pins `DRAGONKIT_TAG="v3.2.0"` and conformance **PASSes with no violations** — see
**Final verification** at the top.

### Residual risk, stated plainly

- **A symlink higher up the path is not detected.** `-L` answers about the last component only, so a
  symlinked `vendor/` holding a real `dragon-kit` directory would still be refreshed in place.
  Resolving the whole path instead would misfire constantly on macOS, where `/tmp` and `/var` are
  themselves symlinks; noted in the code rather than papered over.
- **`rm -rf $KIT_DIR` remains the printed remedy** on the paths that stop. On a symlinked checkout
  that is safe (it removes the link, not the target) but the wording does not say so.
- **The in-place refresh still writes to the repository it was given**, when that repository is a
  real directory. That is the design: `git fetch` plus `checkout --detach` on a tree already proven
  clean, no `--force`, no `--depth`. It moves HEAD, and HEAD's previous position stays in the
  reflog.

## Round 4 — `rm -rf "$KIT_DIR"` was the bug

### The P1

Round 3 made the *verification* stricter and left the destructive primitive in place. Verifying HEAD
proves only that **HEAD** is reproducible. It says nothing about the other branches, tags, reflogs,
stashes or unreachable objects in that repository — and no amount of verification can, because none
of them are reachable from HEAD. The owner's reproduction against `13f7150`:

1. `vendor/dragon-kit` detached and clean at a **published** stale tag, so remote verification **passes**
2. the same repository also holds a separate **unpushed local branch and commit**
3. run the resolver → verifies, re-clones, **exit 0**
4. `local_branch_survives=no`, `local_commit_survives=no`

### The fix — update in place, never replace

A stale tagged checkout that passes remote verification is now **refreshed inside the repository
that is already there**: the pinned tag is fetched into it and HEAD is detached at it. Nothing is
deleted, replaced or moved, so every unrelated branch, tag, reflog entry, stash and object survives.
**Only the genuinely absent checkout still clones** — the one state with no repository to lose.

Three details, each of which would itself lose local state if done casually:

- **No `--force` on the tag refspec.** `refs/tags/$PIN:refs/tags/$PIN` without it fails outright when
  the repository already holds a *different* `$PIN` — a locally moved or recreated pin — and **that
  failure is the correct outcome**. Clobbering that ref would destroy exactly the kind of local work
  this round is about. Verified against git: `! [rejected] v3.1.0 -> v3.1.0 (would clobber existing
  tag)`, exit 1, local ref untouched. An identical tag already present is a no-op success, so a full
  clone that already carries the pin refreshes normally.
- **No `--depth`.** The absent path clones `--depth 1`, so this fetch may have to deepen a shallow
  repository — deepening is additive. Passing `--depth` against a **full** clone would truncate its
  history instead, which is local-state loss by another name.
- **The tag REF has to land, not just the commit.** The resolver identifies a checkout with
  `git tag --points-at HEAD`, so detaching at a bare `FETCH_HEAD` would make the *very next* build
  stop on "carries no tag". Hence a named refspec plus a check that the name resolves locally
  afterwards — and case [21] proves it end-to-end by running the resolver a **second** time and
  requiring the silent at-the-pin path.

If the fetch or the checkout fails, the build stops with the failing step named and the previous
checkout still usable — HEAD does not move and nothing is half-moved:

```
ERROR: could not fetch DragonKit v3.1.0 into <KIT_DIR> (git's own error is
       above). Nothing was deleted and HEAD did not move: the checkout is still at
       v3.0.1 and still holds every branch, tag and commit it held before.
       If the fetch was refused as "would clobber existing tag", this repository already
       carries a DIFFERENT v3.1.0 — a pin moved or recreated locally — and it is
       kept rather than overwritten. Settle that tag, reconnect if this was the network,
       or discard the checkout to rebuild at the pin: rm -rf <KIT_DIR>
```

### The verification still earns its round-trip

It is no longer standing between the operator and an `rm -rf`, so why keep it? Because a refresh
still **moves HEAD off the commit that is there now**. On a detached HEAD that commit is reachable
from nothing else, so moving away strands it in the reflog — not destroyed, but not safe either, and
not something to do behind the operator's back. Local-only and moved tags therefore still stop and
preserve, and the offline behaviour is unchanged. The error text was corrected to say *strands* and
*moves HEAD off* rather than *deletes*, because it no longer deletes.

| Checkout | Result |
|---|---|
| Branch, clean, at the pin | Silent, builds |
| Branch, otherwise — dirty or diverged | WARNING, builds. Never replaced, never refused. |
| Detached + dirty, including at the pin | ERROR, stops |
| Detached, clean, at the pin | Silent, builds |
| Detached, clean, at another tag, **verified on the remote** | **Fetches the pin INTO it and detaches there** (changed this round) |
| Detached, clean, at another tag, **unverifiable** | ERROR, stops and preserves |
| Detached, clean, no tag | ERROR, stops |
| Not a git checkout | ERROR, stops |
| Absent | Clones at the pin — the only path that still clones |

### Suite: 18 → 23 cases

Five new cases, all asserting survival **by object id** — `git rev-parse --verify <sha>^{commit}` on
the hidden commit. That is the assertion that actually catches this bug class: a branch or tag *name*
can be recreated by a fresh clone, but only the original repository still holds the object underneath
it, and the owner's reproduction turned on exactly that.

```
[19] an unpushed local BRANCH and its commit survive a successful refresh
     ok   fixture: detached and clean at the published v3.0.1
     ok   fixture: and holding a branch no remote has
     ok   exit status 0
     ok   stdout: "==> vendor/dragon-kit is at v3.0.1, not the pinned v3.1.0; fetching the pin into it"
     ok   the refresh landed on v3.1.0
     ok   the branch ref survives
     ok   and so does the commit object under it
     ok   no staging leftovers

[20] a local TAG elsewhere in the repository survives a successful refresh
     ok   exit status 0
     ok   the refresh landed on v3.1.0
     ok   the unrelated tag still points where it did
     ok   and so does the commit object under it

[21] the refreshed checkout ends DETACHED at the pin, with the pin's tag ref present locally
     ok   exit status 0
     ok   HEAD is detached, not on a branch
     ok   HEAD is the pinned commit
     ok   refs/tags/v3.1.0 is a local ref, not a bare FETCH_HEAD
     ok   so --points-at HEAD names the pin
     ok   and the tree is clean
     ok   exit status 0
     ok   said nothing at all

[22] a FAILED fetch leaves HEAD and every local ref exactly as they were
     ok   exit status 1
     ok   stderr: "ERROR: could not fetch DragonKit v3.1.0 into <WORK>/failed-fetch/vendor/dragon-kit"
     ok   stderr: "Nothing was deleted and HEAD did not move"
     ok   HEAD did not move
     ok   still at v3.0.1, which is a usable kit
     ok   every local ref is byte-for-byte unchanged
     ok   the hidden commit object survives
     ok   no staging leftovers

[23] a repository already holding a DIFFERENT v3.1.0 tag is preserved, not clobbered
     ok   fixture: the local v3.1.0 names the local commit, not the remote's
     ok   exit status 1
     ok   stderr: "ERROR: could not fetch DragonKit v3.1.0 into <WORK>/moved-pin/vendor/dragon-kit"
     ok   stderr: "carries a DIFFERENT v3.1.0"
     ok   the local v3.1.0 tag was not overwritten
     ok   HEAD did not move
     ok   the local commit object survives
     ok   no staging leftovers

----------------------------------------------------------------
PASS — 23 cases, 0 failures
```

Case [22] asserts **every** local ref, not just HEAD: `git show-ref | sort` is captured before the
run and compared after it.

Two existing cases had their premise moved rather than deleted, because the paths they guarded moved:
**[11] a failed clone** and **[12] unique staging** both used a *stale* fixture, which no longer
reaches the clone at all. Both now run on the **absent** path — the only path that still clones — so
the failed-clone message and the "a clone cannot delete a directory it does not own" guarantee stay
asserted, and the stale path's own failure mode (a failed *fetch*) is case [22]. Cases [14] and [15],
the published lightweight and annotated stale tags, still refresh; both now also assert a sentinel
file inside `.git` survives, which is a direct proof that the **same repository** was updated rather
than a new one put in its place.

### Discrimination: the suite fails against `13f7150`

```
[4]  FAIL stdout lacks "==> vendor/dragon-kit is at v3.0.1, not the pinned v3.1.0; fetching the pin into it"
[14] FAIL stdout lacks "==> … fetching the pin into it"
     FAIL the same repository was updated, not a new one
[15] FAIL stdout lacks "==> … fetching the pin into it"
     FAIL the same repository was updated, not a new one
[19] FAIL stdout lacks "==> … fetching the pin into it"
     FAIL the branch ref survives
     FAIL and so does the commit object under it
[20] FAIL the unrelated tag still points where it did
     FAIL and so does the commit object under it
[22] FAIL stderr lacks "ERROR: could not fetch DragonKit v3.1.0 into <WORK>/failed-fetch/vendor/dragon-kit"
     FAIL stderr lacks "Nothing was deleted and HEAD did not move"
[23] FAIL exit status: want 1, got 0
     FAIL stderr lacks "ERROR: could not fetch DragonKit v3.1.0 into <WORK>/moved-pin/vendor/dragon-kit"
     FAIL stderr lacks "carries a DIFFERENT v3.1.0"
     FAIL the local v3.1.0 tag was not overwritten
     FAIL HEAD did not move
     FAIL the local commit object survives
FAIL — 23 cases, 18 failed assertion(s)
```

`[19] the branch ref survives` / `and so does the commit object under it` **is the owner's
reproduction**, and it is the assertion that matters. `[23]` is the second data-loss path: the old
code exits **0** and takes the local commit and the moved pin tag with it. Cases [1]–[13], [16]–[18]
and [21] stay green under both resolvers — [21] because a re-clone also lands detached at the pin,
which is the other half of the check: the fix did not disturb the behaviour it was preserving.

### Verification

```
$ ./tools/test-resolve-dragon-kit.sh
PASS — 23 cases, 0 failures

$ swift test --package-path Packages/KeyKeyApp -Xswiftc -warnings-as-errors
Executed 66 tests, with 0 failures (0 unexpected)

$ swift test --package-path Packages/KeyKeyEngine -Xswiftc -warnings-as-errors
Executed 193 tests, with 0 failures (0 unexpected)

$ ./tools/build-app.sh
build exit=0    warning|error|fatal lines in output: 0
==> Done: /Users/teddychan/git/yahoo-keykey-2/build/YahooKeyKey2.app

$ shellcheck tools/resolve-dragon-kit.sh tools/test-resolve-dragon-kit.sh
(clean, exit 0)
```

**The common path is offline, proved rather than asserted.** The whole build was re-run with a `git`
shim on `PATH` that refuses `clone`, `fetch`, `ls-remote`, `pull`, `push` and `submodule`:

```
$ PATH="$SHIM:$PATH" ./tools/build-app.sh
build-under-shim exit=0
NETWORK-GIT-BLOCKED occurrences: 0
```

and the at-the-pin path answers silently against an unroutable URL:

```
$ ./tools/resolve-dragon-kit.sh vendor/dragon-kit v3.1.0 https://invalid.invalid/nope
exit=0    (no output)
```

`vendor/dragon-kit` restored to `v3.1.0`, detached, clean, no `.incoming*` leftovers.

**Conformance FAILS, and it is not this branch.** *(Historical — round 4. Resolved: the branch now
pins `v3.2.0`, and conformance PASSes.)* DragonKit **v3.2.0** was published today at
15:27 (+0800), after this PR's previous head:

```
$ python3 ~/git/dragon-kit/Scripts/dragon-conformance.py --app . --kit ~/git/dragon-kit
FAIL — 1 violation(s):
  R10  tools/build-app.sh: pinned to DragonKit 3.1.0 but 3.2.0 is released
```

The identical single violation is produced by a pristine `origin/main` tree, which contains none of
these changes. Bumping the pin is the DragonKit propagation task, not this one; **R10 is the only
violation, so nothing in this branch introduces a conformance failure.**

### Residual risk, stated plainly

- **The last `rm -rf "$KIT_DIR"` has a narrow TOCTOU.** It now runs only on the absent path, but it
  runs after the clone, so a repository created *between* the "is it absent?" test and the swap —
  by a concurrent build, or by hand during a slow clone — would still be removed. Left alone
  deliberately: the brief said to keep that path unchanged, and what it can delete there is another
  run's fresh clone of the pin rather than operator work. Say the word and it becomes a guard.
- **A refresh still moves HEAD**, which strands a detached commit in the reflog. That is what the
  remote verification exists to prevent, and it is why it was kept.
- **A symlinked `vendor/dragon-kit` is now followed rather than unlinked.** `[ -d ]` follows
  symlinks, so a kit symlinked in from elsewhere previously had the *symlink* removed and replaced;
  it is now fetched into and detached, i.e. the real repository is updated. Non-destructive and
  arguably what the symlink asked for, but it is a change in behaviour.
- **`ls-remote` and the tag fetch are exercised against local `file://` remotes only**, by design —
  no case in the suite touches the network. Peeling, refspec handling and the "would clobber" refusal
  are git-side rather than transport-side, so GitHub over HTTPS should answer identically.
- **Pre-existing, untouched:** the `KIT_DIR` comment and `.gitignore` still describe the pin as
  "tag v1.2.1", stale by several majors.

---


## Round 3 — a local tag is not proof of publication

### The P1

`resolve-dragon-kit.sh`'s stale-tag arm treated a tag at HEAD as proof the commit was published
and therefore reproducible, and re-cloned over it. **`git tag` is purely local** — it writes a ref
in this clone and contacts nothing — so a tag says nothing a clean tree had not already said. The
owner's reproduction:

1. clean detached local commit in `vendor/dragon-kit`
2. `git tag local-only` (never pushed)
3. run the resolver
4. exit **0**, re-cloned at the pin, and the only copy of that commit was **destroyed**

Same data-loss class as the untagged detached case round 2 fixed, one step further in.

### The fix

A stale tagged checkout may now be replaced **only after the remote confirms** that a tag at HEAD
resolves to that exact commit. It **stops and preserves** when the lookup fails (offline, DNS,
auth), when the tag is absent from the remote, or when the remote's commit differs.

**Annotated tags are the trap a naive check falls into.** `ls-remote` reports `refs/tags/X` as the
**tag object's** id and only `refs/tags/X^{}` as the commit it peels to. Verified against git:

```
$ git ls-remote --tags file://$R refs/tags/annot-1
be5b6f6…	refs/tags/annot-1          <- the TAG OBJECT, never equal to any commit
$ git ls-remote --tags file://$R refs/tags/annot-1 'refs/tags/annot-1^{}'
be5b6f6…	refs/tags/annot-1
732d905…	refs/tags/annot-1^{}       <- the commit; this is what HEAD must match
```

Comparing the unpeeled line alone would match no annotated tag ever, so **every annotated release
would be refused as unpublished** — dragon-kit's `sample-v*` series among them. Both refs are
requested.

HEAD may carry **more than one** tag (`808d5a7` is both `v2.0.0` and `sample-v1.2.0`), so any one
of them resolving to this commit settles it. All of them go in a **single** `ls-remote`, which
keeps it to one round-trip and makes "could not reach the remote" one unambiguous failure rather
than a per-tag guess. Since only refs for tags at HEAD are requested, *any* returned line whose
object id is HEAD is the proof — which reads identically for lightweight (id on `refs/tags/X`) and
annotated (id on `refs/tags/X^{}`).

Nothing keys off a `vX.Y.Z` **name**: `v9.9.9` is as easy to write locally as `local-only`, and
case [16] uses a release-shaped name for exactly that reason.

The round-trip runs **only on this branch**, so the common paths stay offline and fast. (Round 2's
brief said not to add a network call to distinguish the *untagged* case, where the answer is
knowable locally; here the whole question is whether a remote has this commit, so the round-trip is
the point.) The pinned tag itself is never checked — if HEAD carries `$DRAGONKIT_TAG` the checkout
is already what a re-clone would produce.

### The offline consequence, stated plainly

With no network a stale tagged checkout now **STOPS** the build instead of refreshing. That is the
safe direction — guessing the other way deletes commits nothing else holds — but the operator is
told why and what to do, in the header comment and in the error itself:

```
ERROR: vendor/dragon-kit is at v3.0.1, not the pinned v3.1.0, and v3.0.1 could
       not be looked up on <URL> (offline, DNS, or credentials — git's own
       error is above). Refreshing this checkout means DELETING it, and a tag is not
       proof of publication until the remote says so, so it is preserved instead.
       With no network a stale checkout stops the build rather than refreshing; that
       is the safe direction, because guessing the other way destroys commits no
       remote has. Reconnect and re-run, or discard the checkout to rebuild at the
       pin: rm -rf <KIT_DIR>
```

git's own diagnosis is left on stderr **ahead** of ours on purpose: "Could not read from remote
repository" and "Repository not found" send the operator to different remedies.

### Policy adjustment: a clean branch at the pin is silent again

Restored for one state. A clean branch sitting **exactly on the pinned commit** is silent: its
content is the pin byte for byte, so the kit is fully identified and About is accurate at that
moment. Round 2 warned there on the argument that the next commit moves the branch — but that is a
warning about what the checkout might *become*, and one that fires on a correct workspace every
build is one operators learn to scroll past, including on the day it means something.

A branch warns once it is **dirty OR its HEAD leaves the pin**, and a branch is **never replaced,
in any state**.

| Checkout | Result |
|---|---|
| Branch, clean, at the pin | **Silent, builds** (changed this round) |
| Branch, otherwise — dirty or diverged | WARNING, builds. Never replaced, never refused. |
| Detached + dirty, including at the pin | ERROR, stops |
| Detached, clean, at the pin | Silent, builds |
| Detached, clean, at another tag, **verified on the remote** | Re-clones at the pin, says so |
| Detached, clean, at another tag, **unverifiable** | **ERROR, stops and preserves** (new) |
| Detached, clean, no tag | ERROR, stops |
| Not a git checkout | ERROR, stops |
| Absent | Clones at the pin |

Note the owner's brief referred to "cases 3 and 7" as encoding the old behaviour. In the suite as
merged, neither did: case 3 is the dual-tag detection and case 7 is a *dirty* branch at the pin,
which still warns under the new policy and passes unchanged. No existing case covered a **clean**
branch at the pin at all, so that behaviour was untested in both directions — it is now case [13].

### Suite: 12 → 18 cases

All five required regression cases, plus the policy case. Fixtures are throwaway local git repos
(a bare repo on disk serves as a `DRAGONKIT_URL`), so the suite stays offline, deterministic and
~1s. **Every preserving case asserts the original commit still resolves afterwards** — that is the
assertion that actually catches this class; the reproduction turned on the commit surviving, not on
the exit status.

One existing case needed its premise moved: **[11] a failed clone** pointed at an unreachable URL,
which now stops at the *lookup* and never reaches the clone. It now runs against a remote that
answers but has no `$PIN` tag — what a never-pushed or mistyped pin looks like — so the clone is
genuinely attempted and genuinely fails, and the behaviour it guards (a failed clone leaves the
checkout intact) is still asserted. The unreachable-URL path is case [18].

Case [15] asserts as a **precondition** that `refs/tags/v3.0.2` reports a tag object rather than
the commit, so if that ever stops being true the suite says the fixture has stopped reproducing the
hazard instead of passing vacuously.

```
[13] a clean branch sitting exactly on the pinned commit is silent
     ok   precondition: on a branch, clean, and at the pin
     ok   exit status 0
     ok   said nothing at all
     ok   still on the branch
     ok   checkout untouched — a branch is never replaced

[14] a published LIGHTWEIGHT stale tag verifies against the remote and is refreshed
     ok   exit status 0
     ok   stdout: "==> vendor/dragon-kit is at v3.0.1, not the pinned v3.1.0; re-cloning at the pin"
     ok   checkout is now at v3.1.0
     ok   no staging leftovers

[15] a published ANNOTATED stale tag is refreshed too (the naive ls-remote compare fails here)
     ok   precondition: refs/tags/v3.0.2 reports a tag object, not the commit
     ok   exit status 0
     ok   stdout: "==> vendor/dragon-kit is at v3.0.2, not the pinned v3.1.0; re-cloning at the pin"
     ok   checkout is now at v3.1.0
     ok   no staging leftovers

[16] a LOCAL-ONLY tag stops the build, and the commit under it survives
     ok   fixture: HEAD carries a tag the remote has never heard of
     ok   fixture: and the tree is clean
     ok   exit status 1
     ok   stderr: "ERROR: vendor/dragon-kit is at v9.9.9, not the pinned v3.1.0, but no tag on its"
     ok   stderr: "HEAD resolves to commit b5e2616 on file://<WORK>/kit-remote"
     ok   stderr: "Either the tag was never pushed, or it has been moved or recreated since"
     ok   the local commit survives
     ok   and its object is still readable
     ok   no staging leftovers

[17] a locally MOVED tag whose remote commit differs stops the build and preserves it
     ok   fixture: the remote's v3.0.1 is a different commit
     ok   exit status 1
     ok   stderr: "ERROR: vendor/dragon-kit is at v3.0.1, not the pinned v3.1.0, but no tag on its"
     ok   the local commit survives
     ok   and its object is still readable
     ok   no staging leftovers

[18] an unreachable remote stops the build and preserves the checkout (the offline cost)
     ok   exit status 1
     ok   stderr: "ERROR: vendor/dragon-kit is at v3.0.1, not the pinned v3.1.0, and v3.0.1 could"
     ok   stderr: "With no network a stale checkout stops the build rather than refreshing"
     ok   stderr: "pin: rm -rf <WORK>/offline/vendor/dragon-kit"
     ok   existing checkout still at v3.0.1
     ok   the commit survives
     ok   no staging leftovers

----------------------------------------------------------------
PASS — 18 cases, 0 failures
```

Cases [1]–[12] all still pass; full output in the verification run below.

### Discrimination: the new cases fail against `26f1839`

A green suite that would also pass the bug it exists to catch is worth nothing. The new suite,
dropped on top of head `26f1839`'s resolver:

```
[13] a clean branch sitting exactly on the pinned commit is silent
     FAIL expected silence
          WARNING: vendor/dragon-kit is on branch 'kit-codev', not a checkout of the pinned …

[16] a LOCAL-ONLY tag stops the build, and the commit under it survives
     FAIL exit status: want 1, got 0
     FAIL stderr lacks "ERROR: vendor/dragon-kit is at v9.9.9, not the pinned v3.1.0, but no tag on its"
     FAIL stderr lacks "HEAD resolves to commit 49ce6c1 on file://<WORK>/kit-remote"
     FAIL stderr lacks "Either the tag was never pushed, or it has been moved or recreated since"
     FAIL the local commit survives
fatal: Not a valid object name 49ce6c12c5aa91b00d1e9bfd2ab9fe952d33a771^{commit}
     FAIL and its object is still readable

[17] a locally MOVED tag whose remote commit differs stops the build and preserves it
     FAIL exit status: want 1, got 0
     FAIL stderr lacks "ERROR: vendor/dragon-kit is at v3.0.1, not the pinned v3.1.0, but no tag on its"
     FAIL the local commit survives
fatal: Not a valid object name 128bb1a482da5923a2a3441f04e8da4d035d02e9^{commit}
     FAIL and its object is still readable

[18] an unreachable remote stops the build and preserves the checkout (the offline cost)
     FAIL stderr lacks "ERROR: vendor/dragon-kit is at v3.0.1, not the pinned v3.1.0, and v3.0.1 could"
     FAIL stderr lacks "With no network a stale checkout stops the build rather than refreshing"
     FAIL stderr lacks "pin: rm -rf <WORK>/offline/vendor/dragon-kit"
FAIL — 18 cases, 14 failed assertion(s)
```

`fatal: Not a valid object name …^{commit}` in [16] and [17] **is the data loss** — the assertion
fails because the object it names no longer exists in the repository. The old code exits 0 and
destroys the commit.

Cases [14] and [15] pass under **both** resolvers, which is the other half of the check: the fix
did not break the refresh path it was narrowing. [18] is interesting — the old code reaches the
clone, fails there, and happens to preserve the checkout, so the *status* matches by luck while
every operator-facing message is the wrong one. Cases [1]–[12] stay green under both.

### Verification

```
$ ./tools/test-resolve-dragon-kit.sh
PASS — 18 cases, 0 failures

$ swift test --package-path Packages/KeyKeyApp -Xswiftc -warnings-as-errors
Executed 66 tests, with 0 failures (0 unexpected)

$ swift test --package-path Packages/KeyKeyEngine -Xswiftc -warnings-as-errors
Executed 193 tests, with 0 failures (0 unexpected)

$ ./tools/build-app.sh
EXIT=0    stdout warning|error lines: 0    stderr warning|error lines: 0
==> Done: /Users/teddychan/git/yahoo-keykey-2/build/YahooKeyKey2.app

$ python3 ~/git/dragon-kit/Scripts/dragon-conformance.py --app . --kit ~/git/dragon-kit
DragonKit conformance — Yahoo! KeyKey 2 (62 Swift files, 45 kit types)
PASS — no violations.

$ shellcheck tools/resolve-dragon-kit.sh tools/test-resolve-dragon-kit.sh
(clean, exit 0)
```

The `build-app.sh` run above is also evidence the common path stays offline: `vendor/dragon-kit` is
at the pin, the resolver said nothing, and no lookup was made. `vendor/dragon-kit` restored to
`v3.1.0`, detached and clean, no `.incoming*` leftovers.

### Not verified / for your call

- **The `ls-remote` behaviour is verified against local `file://` remotes only.** Peeling and
  pattern matching are git-side, not transport-side, so GitHub over HTTPS should answer the same
  refs — but no case in the suite touches the network, by design.
- **A remote that answers but rejects the pin tag is simulated** with a bare repo minus the tag,
  not with a real auth failure.
- **The layout opinion from round 1 still stands unverified** — I can't run the UI.
- **Pre-existing, untouched:** the `KIT_DIR` comment and `.gitignore` both still describe the pin
  as "tag v1.2.1". Stale by several majors, unrelated to these findings.

---

## Round 2 — review findings

### 1. A clean, untagged detached HEAD is no longer discarded

A clean working tree does not prove its detached commit is published or reproducible. Round 1
folded "a different tag" and "a bare detached commit" into one clean-and-therefore-disposable
case and re-cloned over both, which silently destroys a local commit nothing but that directory
holds.

Only a **recognised stale TAGGED** checkout is refreshed automatically now. An untagged detached
HEAD stops:

```
ERROR: vendor/dragon-kit is detached at commit 9b36d54 and carries no tag,
       so the DragonKit it would build cannot be identified. A clean tree does not make
       that commit disposable — it may be local work no remote has — so it is neither
       built against nor re-cloned over. Put it on a branch to co-develop the kit, or
       remove the checkout to rebuild at the pin: rm -rf <KIT_DIR>
```

No network round-trip was added to tell published from unpublished — that is precisely the call
this script should not make just to classify a directory, so it hands the decision back instead.

### 2. Dirty content at the pinned tag no longer builds silently

Tag membership was tested before dirtiness, so modified **or untracked** files on top of `v3.1.0`
were built silently while About reported `v3.1.0`. The tag names the commit, not the working tree
on top of it.

Order is now **branch → dirty → tag**, which settles both halves at once:

| Checkout | Result |
|---|---|
| On a branch — any HEAD, clean or dirty | WARNING, builds. Never replaced, never refused. |
| Detached + dirty, **including at the pin** | ERROR, stops |
| Detached, clean, at the pin | Silent, builds |
| Detached, clean, at another tag | Re-clones at the pin, says so |
| Detached, clean, no tag | ERROR, stops (finding 1) |
| Not a git checkout | ERROR, stops |
| Absent | Clones at the pin |

Moving the branch test to the front also answers the open question I left last round: a branch
sitting exactly on the pinned commit is still a branch — the next commit moves it — so it now
warns from the moment it exists rather than going quiet until it diverges.

### 3. Unique staging directory

`dragon-kit.incoming` is a fixed path this run does not own. A concurrent build shares it, and the
`rm -rf` that cleared it would delete a clone another process was still writing into — or hand
this run a half-written tree as a finished clone. Now `mktemp -d "$KIT_DIR.incoming.XXXXXX"`
(beside `KIT_DIR`, so the swap stays a same-filesystem rename) with a trap that removes it on
every exit path, including SIGINT/SIGTERM.

### The block moved to `tools/resolve-dragon-kit.sh`

Split out so the states can be driven without a swiftc build — they differ only in git metadata
and cost minutes each through `build-app.sh`. `DRAGONKIT_TAG` deliberately stays in
`build-app.sh`: the DragonKit propagation SOP and `.github/workflows/tests.yml` both read the pin
out of that file with a grep.

## `tools/test-resolve-dragon-kit.sh` — the regression suite

Twelve cases against throwaway local git repos: no network, no dependence on dragon-kit's real
tag history, the real `vendor/dragon-kit` never touched, ~1s. Wired into `tests.yml` ahead of the
Swift suites. Each case asserts the exit status **and** the operator-facing message on the stream
it belongs on — the message is half the behaviour when the reader is someone whose build just
stopped, and the incident that started all of this was an operator having to guess that
`vendor/dragon-kit` needed deleting by hand.

The dual-tag fixture is built deliberately: `sample-v1.4.0` annotated and `v3.2.0` lightweight on
one commit, so `git describe --exact-match` reliably prefers the sample tag. The case asserts that
as a **precondition**, so if git's tie-break ever changes the suite says the fixture stopped
reproducing the hazard rather than passing vacuously.

```
[1] absent vendor/dragon-kit is cloned at the pin (the fresh-CI path)
     ok   exit status 0
     ok   stdout: "==> Cloning DragonKit v3.1.0 into vendor/ (not committed)"
     ok   cloned checkout is at v3.1.0
     ok   no staging leftovers

[2] a checkout at the exact pinned tag is used silently
     ok   exit status 0
     ok   said nothing at all
     ok   checkout untouched

[3] a dual-tagged pinned commit is recognised as the pin (git describe gets this wrong)
     ok   fixture HEAD carries both tag series
     ok   precondition: describe answers "sample-v1.4.0", not the pin
     ok   exit status 0
     ok   said nothing at all
     ok   checkout untouched — not re-cloned every build

[4] a clean checkout at an older tag is refreshed to the pin
     ok   exit status 0
     ok   stdout: "==> vendor/dragon-kit is at v3.0.1, not the pinned v3.1.0; re-cloning at the pin"
     ok   checkout is now at v3.1.0
     ok   no staging leftovers

[5] a plain directory inside a git repo is not mistaken for a checkout (git -C walks up)
     ok   exit status 1
     ok   stderr: "exists but is not a git checkout"
     ok   stderr: "Remove it and re-run: rm -rf <WORK>/parent-repo/vendor/dragon-kit"
     ok   stderr silent on "parent-branch-must-never-be-reported"
     ok   directory left for the operator to remove

[6] a diverged co-development branch warns and builds
     ok   exit status 0
     ok   stderr: "WARNING: vendor/dragon-kit is on branch 'kit-codev', not a checkout of the pinned"
     ok   stderr: "Remove vendor/dragon-kit to build against the pinned tag."
     ok   still on the branch
     ok   co-development commit preserved

[7] a dirty branch sitting on the pinned tag still warns and builds
     ok   exit status 0
     ok   stderr: "WARNING: vendor/dragon-kit is on branch 'kit-codev', not a checkout of the pinned"
     ok   edit preserved — a branch is never replaced

[8] a dirty detached checkout stops the build
     ok   exit status 1
     ok   stderr: "ERROR: vendor/dragon-kit is detached with uncommitted changes"
     ok   stderr: "co-develop the kit, or discard them: rm -rf <WORK>/dirty-detached/vendor/dragon-kit"
     ok   edit preserved
     ok   not re-cloned over

[9] a clean but UNTAGGED detached commit stops the build (never discarded)
     ok   fixture HEAD carries no tag and the tree is clean
     ok   exit status 1
     ok   stderr: "ERROR: vendor/dragon-kit is detached at commit 9b36d54 and carries no tag,"
     ok   stderr: "that commit disposable — it may be local work no remote has"
     ok   the local commit survives
     ok   no staging leftovers

[10] an untracked file at the pinned tag stops the build (About would misreport it)
     ok   exit status 1
     ok   stderr: "ERROR: vendor/dragon-kit is detached with uncommitted changes"
     ok   stderr: "Refused even when HEAD carries v3.1.0"
     ok   untracked file preserved
     ok   checkout untouched

[11] a failed clone leaves the existing checkout intact
     ok   exit status 1
     ok   stderr: "ERROR: could not clone DragonKit v3.1.0 from file://<WORK>/no-such-remote"
     ok   stderr: "checkout (if any) was left untouched and was NOT built against"
     ok   existing checkout still at v3.0.1
     ok   existing checkout unchanged
     ok   no staging leftovers

[12] staging is unique: a re-clone cannot delete a directory it does not own
     ok   exit status 0
     ok   the fixed-path staging dir was not clobbered
     ok   re-clone still landed on v3.1.0

----------------------------------------------------------------
PASS — 12 cases, 0 failures
```

**The suite was checked against the pre-fix logic**, because a green suite that would also pass
the bug it is meant to catch is worth nothing. Round 1's resolver dropped in place:

```
[6] a diverged co-development branch warns and builds
     FAIL stderr lacks "WARNING: vendor/dragon-kit is on branch 'kit-codev', not a checkout of the pinned"
[7] a dirty branch sitting on the pinned tag still warns and builds
     FAIL stderr lacks "WARNING: vendor/dragon-kit is on branch 'kit-codev', not a checkout of the pinned"
[8] a dirty detached checkout stops the build
     FAIL stderr lacks "ERROR: vendor/dragon-kit is detached with uncommitted changes"
[9] a clean but UNTAGGED detached commit stops the build (never discarded)
     FAIL exit status: want 1, got 0
     FAIL stderr lacks "ERROR: vendor/dragon-kit is detached at commit 47faa86 and carries no tag,"
     FAIL stderr lacks "that commit disposable — it may be local work no remote has"
     FAIL the local commit survives
[10] an untracked file at the pinned tag stops the build (About would misreport it)
     FAIL exit status: want 1, got 0
     FAIL stderr lacks "ERROR: vendor/dragon-kit is detached with uncommitted changes"
     FAIL stderr lacks "Refused even when HEAD carries v3.1.0"
[12] staging is unique: a re-clone cannot delete a directory it does not own
     FAIL the fixed-path staging dir was not clobbered
FAIL — 12 cases, 11 failed assertion(s)
```

`[9] the local commit survives` failing is finding 1 exactly: the old code exits 0 **and destroys
the commit**. Cases 1-5 and 11 stay green under both, which is the other half of the check — the
three fixes did not disturb the dual-tag detection, the direct `.git` test, or the failed-clone
preservation.

The one case round 1 could not force, **a failed clone**, is now a real run: the clone URL points
at a non-existent local repo, so it fails without the network.

---

## Round 1 (unchanged, and confirmed by the suite above)

### Finding 1 [P2] — `tools/build-app.sh` kept a stale `vendor/dragon-kit`

The block cloned on first use and, when an existing checkout didn't match the pin, printed a
WARNING and built against it anyway. An established workspace still on v3.0.1 therefore kept
compiling against a kit with no `Attribution(name:license:)`, and `App/AboutConfig.swift` failed
to build until someone worked out that `vendor/dragon-kit` had to be deleted by hand. The
checkout is now identified before it is trusted.

**Re-clone, not `git checkout <tag>`** — `vendor/` is a `--depth 1 --branch <tag>` clone and holds
no object for any other tag. The clone is staged and swapped in only on success, so a failed clone
leaves the existing checkout intact instead of deleting the workspace's only kit.

### The third bug, which the review didn't mention: `git describe`

The staleness test used `git describe --tags --exact-match`. dragon-kit carries two tag series on
the same commits — `vX.Y.Z` for the library, `sample-vX.Y.Z` for its sample app — and `describe`
prints exactly one name, so on a dual-tagged commit it can name the series we are not pinning
against. Live in the tag history, not merely latent:

```
$ git -C ~/git/dragon-kit tag --points-at 808d5a7
sample-v1.2.0
v2.0.0
$ git -C ~/git/dragon-kit describe --tags --exact-match 808d5a7
sample-v1.2.0
```

A pin of `v2.0.0` would have read a perfectly correct checkout as stale on **every single build**.
`v3.1.0` happens to be singly tagged, which is the only reason nobody has hit it. Replaced with
`git tag --points-at HEAD` plus a membership test; case [3] pins it.

### A fourth bug, found while testing the above

`git -C <dir>` **walks up** to the first enclosing repository, so asking
`git -C "$KIT_DIR" rev-parse --git-dir` succeeds on a plain `vendor/dragon-kit` directory because
it finds *yahoo-keykey-2*. The branch check then reported this repo's own branch and the build
went ahead against a directory with no kit in it. The guard tests for `$KIT_DIR/.git` directly.
Case [5] pins it, and asserts the parent repo's branch name never appears in the output.

### Finding 2 [P3] — `App/AboutConfig.swift` truncated the licence text

The value read `"Freely redistributable"` while the comment directly above it,
`docs/THIRD-PARTY-NOTICES.md` and `Resources/CANGJIE-DATA-LICENSE.txt` all quote the upstream
table header as `LICENSE = Freely redistributable without restriction`. Restored to the exact
phrase, and `ConfigContentTests` re-pinned to it — still as a name → licence **pair**, so a
dropped or role-labelled name still fails.

## Verification (round 2)

```
$ ./tools/test-resolve-dragon-kit.sh
PASS — 12 cases, 0 failures

$ swift test --package-path Packages/KeyKeyApp -Xswiftc -warnings-as-errors
Executed 66 tests, with 0 failures (0 unexpected)

$ swift test --package-path Packages/KeyKeyEngine -Xswiftc -warnings-as-errors
Executed 193 tests, with 0 failures (0 unexpected)

$ ./tools/build-app.sh
EXIT=0    stdout warning|error lines: 0    stderr warning|error lines: 0
==> Done: /Users/teddychan/git/yahoo-keykey-2/build/YahooKeyKey2.app

$ python3 ~/git/dragon-kit/Scripts/dragon-conformance.py --app . --kit ~/git/dragon-kit
DragonKit conformance — Yahoo! KeyKey 2 (62 Swift files, 45 kit types)
PASS — no violations.
```

`vendor/dragon-kit` restored to `v3.1.0`, detached and clean, with no `.incoming*` leftovers.

## Not verified / for your call (rounds 1-2)

- **The layout opinion from round 1 still stands unverified** — I can't run the UI. The kit renders
  credits as `LabeledContent(row.label) { Text(row.value) }` in a Form, and `SettingsWindowController`
  has `minSize` 720 × 480. Label + value is ~59 characters against the ~44 the "Based on · Yahoo!
  KeyKey by ninjapanda · zonble" row already renders in the same column. Worth a glance next time
  the pane is open.
- **The suite tests the resolver, not the swiftc build.** "Warn and build" is asserted as exit 0
  plus the warning plus an untouched checkout; that the build then succeeds is covered by the one
  real `./tools/build-app.sh` run above.
- **Pre-existing, untouched:** the `KIT_DIR` comment and `.gitignore` both still describe the pin
  as "tag v1.2.1". Stale by several majors, unrelated to these findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




