### PR TITLE
chore: pin DragonKit 3.2.0

### DIFF
--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -81,7 +81,7 @@ echo "==> Building DragonKit (SwiftPM, release) in pinned checkout"
 # package's own tools version (6.1) — a separate compilation from the app's -swift-version 5.
 # Clone the pinned tag on first use (e.g. a fresh CI checkout); vendor/ is gitignored, never
 # committed. Idempotent: an existing checkout (local dev) is reused as-is.
-DRAGONKIT_TAG="v3.1.0"
+DRAGONKIT_TAG="v3.2.0"
 if [ ! -d "$KIT_DIR" ]; then
   echo "==> Cloning DragonKit $DRAGONKIT_TAG into vendor/ (not committed)"
   git clone --depth 1 --branch "$DRAGONKIT_TAG" https://github.com/teddychan/dragon-kit "$KIT_DIR"


### PR DESCRIPTION
Focused pin propagation, deliberately separate from #88 so a version bump isn't folded into a
safety fix. #88 will rebase onto this.

`tools/build-app.sh`: `DRAGONKIT_TAG="v3.1.0"` → `"v3.2.0"`. One line.

R10 requires the declared pin to be at least the newest kit tag, and v3.2.0 shipped today. That
release scheduled DragonKit's post-exit Homebrew cleanup behind a successful `NSWorkspace.recycle`
— it doesn't affect this app, which sets no `homebrewCask`, but it's the release the other apps
are moving to.

## Verification

| | |
|---|---|
| `./tools/build-app.sh` | exit 0 |
| `vendor/dragon-kit` after a forced re-resolve | `v3.2.0` |
| KeyKeyApp | **66 tests, 0 failures** |
| KeyKeyEngine | **193 tests, 0 failures** |
| DragonKit conformance | **PASS — no violations** (was `R10 … 3.1.0 but 3.2.0 is released`) |

Two notes on how that was verified, because both misled me first:

- **A fresh clone cannot build this repo** — `Resources/data.txt` is generated by
  `tools/build-lm.sh` and isn't committed, so a clean clone fails with
  `ERROR: Resources/data.txt missing`. Verified in the working checkout instead.
- The build prints `warning: refs/tags/v3.2.0 … is not a commit!`. That's git's noise when
  shallow-cloning an **annotated** tag — reproduced identically against `v3.1.0`, so it's
  pre-existing and not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)