### PR TITLE
docs(build): stop naming a DragonKit version in the pin comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ Packages/KeyKeyApp/.build/
 Resources/data.txt
 .lm-build/
 build/
-# Pinned DragonKit checkout (tag v1.2.1); recreated by cloning, not committed.
+# Pinned DragonKit checkout (tag: DRAGONKIT_TAG in tools/build-app.sh); recreated by
+# cloning, not committed.
 vendor/

--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -31,9 +31,10 @@ MODULE_DIR="$BUILD/modules"
 EXECUTABLE_NAME="YahooKeyKey2"
 ENTITLEMENTS="$APP_SRC/YahooKeyKey2.entitlements"
 SPARKLE_CACHE="$ROOT/build/sparkle"
-# Pinned DragonKit checkout (tag v1.2.1). Cloned under vendor/ (see the adoption notes); its
-# SwiftPM build produces the DragonKit / DragonKitUpdates modules and the DragonKit resource
-# bundle. Never copied into App/ sources.
+# Pinned DragonKit checkout. Cloned under vendor/ (see the adoption notes) at the tag in
+# DRAGONKIT_TAG below — that assignment is the pin, so it is not repeated here. Its SwiftPM
+# build produces the DragonKit / DragonKitUpdates modules and the DragonKit resource bundle.
+# Never copied into App/ sources.
 KIT_DIR="$ROOT/vendor/dragon-kit"
 
 SDK="$(xcrun --show-sdk-path)"


### PR DESCRIPTION
## What

Two comments described the vendored DragonKit checkout as **"tag v1.2.1"**, stale by several major versions:

- `tools/build-app.sh` — the comment above `KIT_DIR=`
- `.gitignore` — the comment above `vendor/`

The authoritative pin is `DRAGONKIT_TAG` in `tools/build-app.sh`, which is currently `v3.2.0`. Both comments now point at that assignment instead of repeating a number, so they can't drift again on the next bump.

## Why not just update the number

It already drifted mid-task: the pin was `v3.1.0` when this was reported and `v3.2.0` by the time the branch was cut off `origin/main` (#88). A version repeated in prose is a second source of truth that nothing verifies — `build-app.sh` already notes that `DRAGONKIT_TAG` "stays HERE" because the propagation SOP and `.github/workflows/tests.yml` both read the pin out of that line.

## Verification

Comment-only — no executable line changed (`bash -n` clean; the diff touches only `#` lines).

`./tools/build-app.sh --build-lm` runs green end to end: engine compiled, DragonKit `v3.2.0` resolved and built, app linked, Sparkle embedded, bundle ad-hoc signed.

> A plain `./tools/build-app.sh` stops at `ERROR: Resources/data.txt missing` on this checkout — that is the documented clean-checkout behaviour (the LM is gitignored and generated), unrelated to this change, and `--build-lm` clears it.

No tag pushed, nothing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)