### PR TITLE
chore(release): 2.11.1

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.10.0</string>
+	<string>2.11.1</string>
 	<key>CFBundleVersion</key>
 	<string>23</string>
 	<key>ComponentInputModeDict</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 A plain-language list of changes in each version, newest first.
 
+## 2.11.1
+
+- **Nothing new — this is a version number fix.** A 2.11.0 was tagged but never released: the
+  build checks that the version being released matches the version recorded in the app, the two
+  did not match, and it stopped. Rather than reuse a version number that already has a failed
+  build attached to it, the next release is 2.11.1. There is no change to the app itself.
+
 ## 2.10.0
 
 - **New: the selection box can be read by VoiceOver.** The nine candidates are drawn as one


### PR DESCRIPTION
## Why

`App/Info.plist` is the **version of record** in this repo. Neither `tools/package-release.sh` nor `tools/package-installer.sh` stamps it — both *read* it via `plutil` — and `.github/workflows/release.yml` passes `assert_tag_matches_plist: true` to `teddychan/dragon-release-ci@v5`.

The `v2.11.0` tag (ce33d27) was pushed while the plist still read `2.10.0`. The "Assert tag version == CFBundleShortVersionString" step did its job and stopped the run on 2026-08-08, so **nothing was published** — no GitHub Release, not even a draft. The latest published release and the Homebrew cask are both still 2.10.0.

`CLAUDE.md`'s rule is: never delete and re-push a release tag to retry — bump the plist and push a fresh tag. So this skips the dead 2.11.0 and goes to **2.11.1**. The `v2.11.0` tag is left in place.

## Changes

- `App/Info.plist` — `CFBundleShortVersionString` `2.10.0` → `2.11.1`.
- `CHANGELOG.md` — a `## 2.11.1` section saying plainly that there is no user-visible change and why the number moves.

No DragonKit pin change: keykey consumes the kit as a local path dependency (`Packages/KeyKeyApp/Package.swift` → `.package(path: "../../vendor/dragon-kit")`), with `tools/build-app.sh` cloning `DRAGONKIT_TAG="v3.2.0"` into `vendor/`. There is no SwiftPM version range to express here, so `DRAGONKIT_TAG` and the path dependency are untouched.

No tag is pushed by this PR — releasing is handled separately.

## Version-consistency check

`git grep -F 2.10.0` over tracked files, after the bump:

| Hit | Verdict |
|---|---|
| `CHANGELOG.md:5` — `## 2.10.0` heading | Correct — history of the shipped release. |
| `App/{en,zh-Hant}.lproj/Localizable.strings:31` — `/* What's New pane (2.10.0) */` | A section comment, not user-visible. |
| `Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift:74` | Narrative comment about the bug this arrangement fixed. |

Nothing hardcodes the app version any more: `WhatsNewConfig` passes no version and `DragonAbout` reads `CFBundleShortVersionString`, so both surfaces follow the plist. `ConfigContentTests.testWhatsNewVersionTracksTheBundleAndIsPrefixed` computes its expectation from the same bundle, so it does not need updating.

## Noted, not changed

The What's New pane's *entries* still describe 2.10.0 (`WhatsNewConfig.date` is `"2026-08-07"`), while its heading will now read `v2.11.1` because the version tracks the bundle. That is the honest state of a version-only release — there is nothing new to list — but flagging it since `WhatsNewConfig`'s own doc comment says the entries and the date are what must be kept in sync with `CHANGELOG.md` on release. Changing it would mean inventing copy and re-pinning the counts in `ConfigContentTests`, so it is deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)