### PR TITLE
fix(uninstall): clear Homebrew's receipt, and only from the build brew installed

### DIFF
--- a/App/AppMenuController.swift
+++ b/App/AppMenuController.swift
@@ -73,9 +73,48 @@ final class AppMenuController {
     // be the literal "Application Support/YahooKeyKey2", which the release IME and the .debug
     // build shared — so uninstalling the debug build deleted the installed IME's learning data.
     // MAC-APP-RELEASE-LIFECYCLE.md: uninstall must never target the public bundle from Debug.
+    /// The bundle id Homebrew installed: the fallback for the running bundle's id below, and the
+    /// gate the cask token is issued against — deliberately not both at once, see
+    /// ``homebrewCaskToken``.
+    ///
+    /// A named constant because this app has carried three ids over its life:
+    /// `com.github.teddychan.inputmethod.YahooKeyKey2` through v1.7.0,
+    /// `com.dragonapp.yahoo-keykey` through v2.0.0, and this one since. The cask's `zap trash:`
+    /// still lists both legacy ids, so "which id is current" is not a question to answer by
+    /// retyping a literal.
+    static let releaseBundleID = "com.dragonapp.inputmethod.yahoo-keykey"
+
+    /// The Homebrew cask token, or `nil` when this bundle is not the one brew installed.
+    ///
+    /// KeyKey ships as the cask `yahoo-keykey-2` — the token declared by `Casks/yahoo-keykey-2.rb`
+    /// in teddychan/homebrew-tap, not inferred from the repo name. Homebrew never watches the
+    /// filesystem, so an IME that deletes itself leaves brew's receipt still claiming the cask is
+    /// installed and `Caskroom/yahoo-keykey-2/<version>/YahooKeyKey2.app` a dangling symlink;
+    /// `brew install --cask yahoo-keykey-2` then refuses outright — "already installed" — for an
+    /// app that isn't there, pointing at nothing that would fix it. Naming the token lets the kit's
+    /// post-exit shell run `brew uninstall --cask --force yahoo-keykey-2` and clear that record.
+    /// The cask installs to `~/Library/Input Methods/` rather than `/Applications`, which changes
+    /// nothing here: brew removes whatever its receipt points at.
+    ///
+    /// **Never a flat token.** `brew uninstall --cask` is not bundle-scoped, and
+    /// `Casks/yahoo-keykey-2.rb` carries `uninstall quit: "com.dragonapp.inputmethod.yahoo-keykey"`
+    /// — so from the local Debug build, which `tools/build-app.sh` re-ids
+    /// `…yahoo-keykey.debug` precisely so it cannot reach the installed IME's learning data or
+    /// updater, a flat token would quit and delete the installed IME instead.
+    ///
+    /// The comparison is the kit's ``UninstallConfig/caskToken(_:ifBundleIs:actual:)`` rather than
+    /// a local `==`, because it has to fail closed on the case hand-written versions got wrong: a
+    /// debug id, another app's id and a *missing* id all return `nil`. Hence the raw
+    /// `Bundle.main.bundleIdentifier` — the default — never `uninstallConfig`'s fallen-back
+    /// `bundleID`, which answers the release id for the one build with no business authorising a
+    /// delete. ice-2 and the sample app each shipped that bug.
+    private var homebrewCaskToken: String? {
+        UninstallConfig.caskToken("yahoo-keykey-2", ifBundleIs: Self.releaseBundleID)
+    }
+
     private var uninstallConfig: UninstallConfig {
         let library = FileManager.default.homeDirectoryForCurrentUser.appending(path: "Library")
-        let bundleID = Bundle.main.bundleIdentifier ?? "com.dragonapp.inputmethod.yahoo-keykey"
+        let bundleID = Bundle.main.bundleIdentifier ?? Self.releaseBundleID
         return UninstallConfig(
             appName: AboutConfig.appName,
             bundleID: bundleID,
@@ -88,7 +127,8 @@ final class AppMenuController {
             extraCleanupPaths: [
                 SharedResources.supportDirectory,
                 library.appending(path: "Caches/\(bundleID)"),
-            ]
+            ],
+            homebrewCask: homebrewCaskToken
         )
     }
 


### PR DESCRIPTION
The third of three. ice-2 and dragon-sample-app already passed the cask token; [clipmenu-2#70](https://github.com/teddychan/clipmenu-2/pull/70) and [spectacle-2#31](https://github.com/teddychan/spectacle-2/pull/31) just did; this repo was the last one still leaving Homebrew's records untouched.

Uninstalling from Settings moved the IME to the Trash and stopped there — Homebrew never watches the filesystem, so its receipt still said the cask was installed and `Caskroom/yahoo-keykey-2/<version>/YahooKeyKey2.app` was a dangling symlink. `brew install --cask yahoo-keykey-2` then refused outright — *"already installed"* — for an app that wasn't there. The cask installs to `~/Library/Input Methods/` rather than `/Applications`, which changes nothing here: brew removes whatever its receipt points at.

## Why a flat token would be worse than none

`brew uninstall --cask --force` is **not bundle-scoped**, and `Casks/yahoo-keykey-2.rb` carries `uninstall quit: "com.dragonapp.inputmethod.yahoo-keykey"`. So from the local Debug build — which `tools/build-app.sh` re-ids `…yahoo-keykey.debug` precisely so it cannot reach the installed IME's learning data or its updater — a flat token would have quit and deleted **the installed IME**. That is the same defect 2.11.2 fixed for the data directory, arriving through the one route that isn't bundle-scoped.

The comparison is the kit's `UninstallConfig.caskToken(_:ifBundleIs:actual:)` rather than a local `==`, because it has to **fail closed**: a debug id, another app's id, and a *missing* id all return `nil`. Hence the raw `Bundle.main.bundleIdentifier` (the parameter's default), never `uninstallConfig`'s fallen-back `bundleID` — that one answers the release id for the build least entitled to authorise a delete. ice-2 and the sample app each shipped exactly that.

The release bundle id becomes a named constant. This app has carried **three** ids — `com.github.teddychan.inputmethod.YahooKeyKey2` through v1.7.0, `com.dragonapp.yahoo-keykey` through v2.0.0, the current one since — and the cask's `zap trash:` still lists both legacy ids. "Which id is current" is not a question to answer by retyping a literal.

## No app-side unit test, deliberately

This is the one repo where that's the right call. `Packages/KeyKeyApp` compiles only the sources symlinked into it, and `tools/build-app.sh` lists the app's sources **explicitly** on its `swiftc` line — so a testable helper would need a new file, a new symlink, **and an edit to the release compile invocation**, to cover two string literals with no app-specific logic. Not a trade worth making on a hand-rolled build.

DragonKit's own `UninstallSafetyTests` already pin `caskToken`'s four outcomes exhaustively. I verified this app's literals by resolving the kit's real function against its three ids:

```
com.dragonapp.inputmethod.yahoo-keykey        → "yahoo-keykey-2"  — brew uninstall WOULD run
com.dragonapp.inputmethod.yahoo-keykey.debug  → nil               — no cask is touched
com.dragonapp.yahoo-keykey (legacy, v1.7.1…2.0.0) → nil           — no cask is touched
```

## Verification

```
tools/build-app.sh (release identity)  → Done, clean
Packages/KeyKeyEngine  swift test      → 194 tests, 0 failures
Packages/KeyKeyApp     swift test      → 66 tests, 0 failures
dragon-conformance.py --app . --kit …  → PASS — no violations
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)