### PR TITLE
fix(debug): mark the debug IME's input-mode names, not just its bundle name

### DIFF
--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -251,6 +251,26 @@ if [[ "${KEYKEY_DEBUG_ID:-}" == "1" ]]; then
     [ -f "$sf" ] || continue
     sed -i '' "s|${RELEASE_BUNDLE_ID}|${DEBUG_BUNDLE_ID}|g" "$sf"
     sed -i '' 's|"Yahoo KeyKey 2"|"Yahoo KeyKey 2 Debug"|g' "$sf"
+    # And mark the mode names themselves. Re-keying moved the KEYS to the .debug mode ids but left
+    # their VALUES reading exactly "倉頡" / "速成" / "拼音" — character for character the release
+    # IME's. These are the strings System Settings ▸ Keyboard ▸ Input Sources actually lists, so the
+    # picker showed two identical entries per mode with no way to tell which build you were adding,
+    # and the ⌃Space switcher and the menu-bar item were equally ambiguous once both were enabled.
+    #
+    # That defeated the point of the whole .debug identity: MAC-APP-RELEASE-LIFECYCLE.md requires
+    # every hands-on build to say "Debug" visibly, and for an IME the mode name is the only place a
+    # user ever sees it — the bundle name suffixed above never appears in the picker's list rows.
+    # Reported from a screenshot of two indistinguishable 倉頡 entries.
+    #
+    # Runs after the re-key so it matches the .debug ids, and only rewrites lines whose key is a
+    # .debug mode id, so CFBundleName/CFBundleDisplayName above are untouched. `rm -rf "$APP"` at
+    # the top of this script recreates the bundle every build, so this always starts from the
+    # pristine source file — the substitution is never applied twice.
+    sed -i '' -E "s|^(\"${DEBUG_BUNDLE_ID}\.[A-Za-z]+\" = \"[^\"]*)(\";)$|\1 (Debug)\2|" "$sf"
+    # These files are now regex-edited rather than merely re-keyed, so prove each one still parses.
+    # A malformed .strings does not fail the build or the launch: macOS silently falls back to
+    # showing the raw KEY as the mode name, which would read as a much stranger bug than this one.
+    plutil -lint "$sf" >/dev/null
   done
   plutil -lint "$PLIST"
 fi


### PR DESCRIPTION
System Settings ▸ Keyboard ▸ Input Sources listed **two identical 倉頡 entries**, two identical 速成 and two identical 拼音, with no way to tell which build you were adding — or, once both were enabled, which one you were typing with.

The debug identity re-keyed the localized mode strings to the `.debug` mode ids but left their **values** untouched:

```
# before — keys moved, values didn't
"com.dragonapp.inputmethod.yahoo-keykey.debug.Cangjie" = "倉頡";
"com.dragonapp.inputmethod.yahoo-keykey.debug.Simplex" = "速成";
"com.dragonapp.inputmethod.yahoo-keykey.debug.Pinyin"  = "拼音";

# after
"com.dragonapp.inputmethod.yahoo-keykey.debug.Cangjie" = "倉頡 (Debug)";
"com.dragonapp.inputmethod.yahoo-keykey.debug.Simplex" = "速成 (Debug)";
"com.dragonapp.inputmethod.yahoo-keykey.debug.Pinyin"  = "拼音 (Debug)";
```

Those values are the strings the picker actually lists, and they're the **only** place a user ever sees an IME's identity — the `Yahoo KeyKey 2 Debug` bundle name this script already sets never appears in a list row. So the app was correctly isolated and completely unlabelled where it counted, which defeats the point: `MAC-APP-RELEASE-LIFECYCLE.md` requires every hands-on build to say `Debug` visibly.

## Blast radius

- Only lines whose key is a `.debug` mode id are rewritten, so `CFBundleName` / `CFBundleDisplayName` are untouched.
- **The release build is byte-identical to before** — verified: no `(Debug)` anywhere in its `.lproj`, release ids intact.
- Runs after the re-key so it matches the `.debug` ids, and `rm -rf "$APP"` at the top of the script recreates the bundle every build, so it always starts from the pristine source file and is never applied twice.

Also lints each `.strings` file now that they're regex-edited rather than merely re-keyed. A malformed `.strings` fails neither the build nor the launch — macOS silently shows the raw **key** as the mode name, which would read as a far stranger bug than the one this fixes.

## Verification

Installed it and asked macOS (`TISCreateInputSourceList`) what it would show:

```
com.dragonapp.inputmethod.yahoo-keykey…Cangjie         → 倉頡
com.dragonapp.inputmethod.yahoo-keykey…Simplex         → 速成
com.dragonapp.inputmethod.yahoo-keykey…Pinyin          → 拼音
com.dragonapp.inputmethod.yahoo-keykey.debug…Cangjie   → 倉頡 (Debug)
com.dragonapp.inputmethod.yahoo-keykey.debug…Simplex   → 速成 (Debug)
com.dragonapp.inputmethod.yahoo-keykey.debug…Pinyin    → 拼音 (Debug)
```

The installed release IME's bundle, prefs and `user-frequency.json` were byte-identical across the reinstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)