### PR TITLE
fix(debug): refresh the input-menu agents so the mode labels actually show

### DIFF
--- a/tools/run-debug.sh
+++ b/tools/run-debug.sh
@@ -35,10 +35,26 @@ echo "==> Registering + launching"
 # one. The release IME is a different id and was never reachable either way.
 open -n "$DST"
 
+# Make the menu bar re-read the input-source names. TextInputMenuAgent caches them per input
+# source id and does not notice a bundle whose InfoPlist.strings changed underneath it, so the
+# ⌃Space menu and the menu-bar item kept listing this build as a plain "倉頡" — pixel-identical to
+# the installed release's row — while System Settings ▸ Input Sources, which reads TIS live,
+# correctly showed "倉頡 (Debug)". The agent on the machine where this was found had been running
+# for five days, since before the debug bundle id first existed.
+#
+# That is the whole point of the labels: an IME's mode name is the only place its identity is ever
+# visible to a user, and the menu is where you pick between the two builds. lsregister above
+# refreshes Launch Services, which is a different cache and does not cover this.
+#
+# launchd respawns both agents immediately; the menu-bar item redraws within a second.
+killall TextInputMenuAgent 2>/dev/null || true
+killall TextInputSwitcher 2>/dev/null || true
+
 cat <<EOF
 
 Debug IME installed: $DST
 Add it in System Settings -> Keyboard -> Input Sources -> + -> Chinese, Traditional ->
-"Yahoo KeyKey 2 Debug". If it doesn't appear, log out/in once (it registers separately
-from the release IME).
+"倉頡 (Debug)" / "速成 (Debug)" / "拼音 (Debug)" — the suffix is how you tell this build's modes
+apart from the installed release's, which are named plainly. If they don't appear at all, log
+out/in once (this registers separately from the release IME).
 EOF


### PR DESCRIPTION
[#95](https://github.com/teddychan/yahoo-keykey-2/pull/95) gave the debug build's modes distinct names, and **System Settings ▸ Keyboard ▸ Input Sources showed them correctly** — but the menu-bar input menu and the ⌃Space switcher still listed a plain `倉頡`, pixel-identical to the installed release's row. That's the surface where you actually pick between the two builds, so the labels weren't doing their job.

## Cause

`TextInputMenuAgent` caches input-source names per source id and doesn't notice a bundle whose `InfoPlist.strings` changed underneath it. Settings reads TIS live, so the two disagreed:

```
kTISPropertyLocalizedName (live)  →  倉頡 (Debug)     ✅
menu-bar row (cached)             →  倉頡             ❌
```

The agent on the machine where this was found had been running for **five days** — since before the debug bundle id first existed — so it had cached the unlabelled name from an older build and never looked again. `lsregister -f` (already in this script) refreshes Launch Services, which is a *different* cache and doesn't cover this.

Confirmed by restarting the agents by hand and re-checking the menu: the labels appeared, **with no rebuild and no change to the bundle**. So the string was always right; only the cache was stale.

## Fix

`killall TextInputMenuAgent` + `TextInputSwitcher` after install. launchd respawns both immediately and the menu-bar item redraws within a second.

Doing it in the script rather than documenting it: "log out and back in" was already this script's advice for a related problem, and it's a poor answer to a cache that one signal clears.

Also fixes the closing hint, which told you to look for "Yahoo KeyKey 2 Debug" — a string that appears nowhere in that picker. The rows read `倉頡 (Debug)` / `速成 (Debug)` / `拼音 (Debug)`, which is what you're actually scanning for.

## Verification

`bash -n` clean. Verified end to end on a real machine: labels now appear in the menu bar, the installed release IME's rows stay plain, and its bundle, prefs and `user-frequency.json` were untouched throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)