### PR TITLE
fix(engine): require the learning-store directory, don't default to release

### DIFF
--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/UserFrequency.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/UserFrequency.swift
@@ -24,23 +24,35 @@ import Foundation
 public final class UserFrequency: @unchecked Sendable {
     // The app's own Application Support directory: ~/Library/Application Support/<name>.
     //
-    // The name is a PARAMETER, and the app passes a distinct one for a local debug build,
-    // because this directory is the only piece of KeyKey's state that the `.debug` bundle id
-    // does not separate on its own: `UserDefaults.standard` is the bundle-id domain and the
+    // The name is a REQUIRED parameter, and the app passes a distinct one for a local debug
+    // build, because this directory is the only piece of KeyKey's state that the `.debug` bundle
+    // id does not separate on its own: `UserDefaults.standard` is the bundle-id domain and the
     // cache dir is `Caches/<bundle id>`, but this was a hardcoded literal shared by the
     // release IME and the debug one. Typing in the debug build therefore trained the installed
     // IME's candidate ranking, and — the reason it had to change — running Uninstall in the
     // debug build deleted it, which MAC-APP-RELEASE-LIFECYCLE.md forbids outright ("uninstall
-    // operations must never target the public bundle from Debug"). The default is the release
-    // name, unchanged, so an installed user's learning data stays exactly where it is.
-    public static func supportDirectory(named name: String = "YahooKeyKey2") -> URL {
+    // operations must never target the public bundle from Debug").
+    //
+    // 2.11.2 fixed that by threading an explicit name through from the app. It left `= "YahooKeyKey2"`
+    // here, and matching defaults on `defaultFileURL(directory:)` and `init(fileURL:)` below, so the
+    // chain still bottomed out on the RELEASE directory: a bare `UserFrequency()` from any build
+    // reopened the installed IME's learning data, and the safe value was one omitted argument away.
+    // The defaults are gone so the compiler asks the question instead. ice-2 keeps its equivalent
+    // default and makes it fail TOWARD the Debug folder (`SettingsBackup.defaultFolder`), which it
+    // can do because it may read `Bundle.main.bundleIdentifier`; the right answer here is different
+    // because KeyKeyEngine is a pure engine package with no app dependency — not DragonKit, so no
+    // `isDebugBuild()`, and teaching it the IME's bundle id would invert that layering. A required
+    // argument needs no runtime knowledge at all and cannot be got wrong at runtime.
+    public static func supportDirectory(named name: String) -> URL {
         let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Application Support")
         return base.appendingPathComponent(name)
     }
 
-    // Default on-disk location: ~/Library/Application Support/YahooKeyKey2/user-frequency.json
-    public static func defaultFileURL(directory: URL = UserFrequency.supportDirectory()) -> URL {
+    // On-disk location within a given directory: <directory>/user-frequency.json. `directory` is
+    // required for the reason on `supportDirectory(named:)` above — it used to default to the
+    // release directory, which is what let the whole chain bottom out there.
+    public static func defaultFileURL(directory: URL) -> URL {
         directory.appendingPathComponent("user-frequency.json")
     }
 
@@ -58,7 +70,9 @@ public final class UserFrequency: @unchecked Sendable {
     private var dirty = false           // a save is pending/coalescing
     private var saveScheduled = false   // a debounced save is already queued
 
-    public init(fileURL: URL = UserFrequency.defaultFileURL()) {
+    // `fileURL` is required: see `supportDirectory(named:)`. A defaulted one meant `UserFrequency()`
+    // opened the installed release IME's counts from whatever build called it.
+    public init(fileURL: URL) {
         self.fileURL = fileURL
         self.counts = UserFrequency.load(from: fileURL)
     }

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/UserFrequencyTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/UserFrequencyTests.swift
@@ -178,17 +178,20 @@ final class UserFrequencyTests: XCTestCase {
     }
 
     func testDefaultFileURLPointsAtAppSupport() {
-        let url = UserFrequency.defaultFileURL()
+        let url = UserFrequency.defaultFileURL(directory: UserFrequency.supportDirectory(named: "YahooKeyKey2"))
         XCTAssertEqual(url.lastPathComponent, "user-frequency.json")
         XCTAssertEqual(url.deletingLastPathComponent().lastPathComponent, "YahooKeyKey2")
     }
 
     // A local debug build passes its own directory name so it can't read, train, or (via the
     // Uninstall pane) delete the installed release IME's learning data — the one piece of
-    // KeyKey state the `.debug` bundle id does not separate on its own. The release default
-    // must stay put, or every existing install silently loses its counts.
+    // KeyKey state the `.debug` bundle id does not separate on its own. The release name must
+    // keep resolving where it always did, or every existing install silently loses its counts.
+    //
+    // Both names are spelled out here because neither is a default any more: the parameters were
+    // required in 2.11.3 so no build can reach the release directory by simply omitting one.
     func testNamedSupportDirectoryIsDistinctFromTheReleaseDefault() {
-        let release = UserFrequency.supportDirectory()
+        let release = UserFrequency.supportDirectory(named: "YahooKeyKey2")
         let debug = UserFrequency.supportDirectory(named: "YahooKeyKey2 Debug")
         XCTAssertEqual(release.lastPathComponent, "YahooKeyKey2")
         XCTAssertNotEqual(release, debug)


### PR DESCRIPTION
`UserFrequency` had a chain of three defaulted parameters that all bottomed out on the **release** directory:

```swift
init(fileURL: URL = UserFrequency.defaultFileURL())
  → defaultFileURL(directory: URL = UserFrequency.supportDirectory())
    → supportDirectory(named: String = "YahooKeyKey2")
```

So a bare `UserFrequency()` from **any** build opened, trained and rewrote the installed IME's learning data.

`~/Library/Application Support/YahooKeyKey2` is the one piece of KeyKey state the `.debug` bundle id does not separate on its own — `UserDefaults.standard` is the bundle-id domain and the cache dir is `Caches/<bundle id>`, but this path is spelled out in source.

## This was not a live defect

2.11.2 fixed the live path by threading an explicit name through from the app, and `App/SharedResources.swift:116` has passed explicit values ever since. What remained was the *safe value sitting one omitted argument away from the defect 2.11.2 had just fixed* — in a public initializer, with the compiler silently supplying the wrong answer.

## Why required arguments, not ice-2's approach

ice-2 solves the same shape differently: `SettingsBackup.defaultFolder` keeps its default and makes it fail **toward** the Debug folder, because it may read `Bundle.main.bundleIdentifier`.

That is the wrong answer here. `KeyKeyEngine` is a pure engine package with no app dependency — no DragonKit, so no `isDebugBuild()` — and teaching it the IME's bundle id would invert that layering. A required argument needs no runtime knowledge at all, and cannot be got wrong at runtime.

## Verification

Compiled the three previously-legal calls against the changed engine:

```
probe.swift:4:19: error: missing argument for parameter 'fileURL' in call
probe.swift:5:34: error: missing argument for parameter 'directory' in call
probe.swift:6:36: error: missing argument for parameter 'named' in call
```

All three compiled cleanly before this change, and each landed on the release directory.

- `KeyKeyEngine` — **194 tests, 0 failures**
- `KeyKeyApp` — **66 tests, 0 failures**
- `tools/build-app.sh` — **builds and signs**. This matters: `App/SharedResources.swift` (the one live call site) is **not** in the `KeyKeyApp` package, so `swift test` alone would not have compiled it.
- `dragon-conformance.py` — PASS, no violations

## No behaviour change

Every existing caller already passed explicit values, so an installed user's counts stay exactly where they are. Three test lines now name the release directory explicitly, since it is no longer a default.

No version bump here — this is internal and rides the next release.