### PR TITLE
release: 2.11.3 — publish the appcast here as well as the site

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,38 @@ jobs:
       # Yahoo KeyKey 2 now targets the macOS 26 SDK, so build on the macos-26 image.
       swiftpm_runner: macos-26
       app_slug: yahoo-keykey-2
+      # Step 1 of 2 in moving the appcast off the marketing site.
+      #
+      # MAC-APP-RELEASE-LIFECYCLE.md: "Sparkle appcasts are update infrastructure, not marketing
+      # content. Each app should host its production appcast in its own repository so an outage,
+      # permission problem, or rejected change in the marketing-site repository cannot interfere
+      # with update delivery." This caller passed no appcast_repo at all and so took the default,
+      # teddychan/www.dragonapp.com. KeyKey is the last of the five to migrate.
+      #
+      # The same spec says to migrate "by mirroring the old and new locations until installed
+      # versions have moved to the app-owned URL", which is why this is two releases and not one.
+      # Every ALREADY-INSTALLED KeyKey reads SUFeedURL from the site, so flipping the destination
+      # alone would leave all of them silently unable to see updates. That is not hypothetical
+      # here: the site is GitHub Pages, and an ice-2 mirror commit sat in a QUEUED Pages
+      # deployment for minutes after the release finished while the app-owned copy was already
+      # serving. A queue is survivable; a 404 is not.
+      #
+      #   step 1 (here)  publish to BOTH. App/Info.plist keeps pointing at the site, which is
+      #                  still being written, so nothing changes for anyone — but the app-owned
+      #                  feed now exists and is current.
+      #   step 2 (next)  move SUFeedURL to
+      #                  https://raw.githubusercontent.com/teddychan/yahoo-keykey-2/main/docs/yahoo-keykey-2/appcast.xml
+      #                  once step 1 has actually populated it.
+      #   later          drop appcast_mirror_repo when no supported version still reads the site.
+      #
+      # Needs dragon-release-ci >= v6.3.0. The appcast is generated once and copied to both, so
+      # the two cannot disagree — including the minimumSystemVersion/hardwareRequirements that
+      # appcast_inject_keykey_requirements adds below, which are injected before the copy.
+      # Publishing here uses the built-in GITHUB_TOKEN (contents: write is granted above); the
+      # mirror needs PUBLIC_RELEASE_TOKEN, which `secrets: inherit` already supplies — the same
+      # token that publishes to the site today. A missing mirror token is a hard error.
+      appcast_repo: teddychan/yahoo-keykey-2
+      appcast_mirror_repo: teddychan/www.dragonapp.com
       release_title_prefix: Yahoo KeyKey 2
       bot_name: KeyKey Release Bot
       assert_tag_matches_plist: true

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.11.2</string>
+	<string>2.11.3</string>
 	<key>CFBundleVersion</key>
 	<string>23</string>
 	<key>ComponentInputModeDict</key>

--- a/App/WhatsNewConfig.swift
+++ b/App/WhatsNewConfig.swift
@@ -1,30 +1,31 @@
 import Foundation
 import DragonKit
 
-// "What's New" content for the current release: a maintenance release, plus the About-pane
-// rework that reached users in 2.11.1 without ever being written down. The version is not
-// passed — it defaults to CFBundleShortVersionString and the kit adds the "v", so the pane
-// cannot claim a release the binary isn't. That makes the entries and the date the only things
-// to keep in sync with CHANGELOG.md on release.
+// "What's New" content for the current release. The version is not passed — it defaults to
+// CFBundleShortVersionString and the kit adds the "v", so the pane cannot claim a release the
+// binary isn't. That makes the entries and the date the only things to keep in sync with
+// CHANGELOG.md on release.
 //
-// 2.11.1 is why the About row is here rather than a release behind. These entries still
-// described 2.10.0 while the heading, read from the bundle, already said 2.11.1 — so the pane
-// was showing one release's notes under another's number. 2.11.0 was tagged and never released
-// (the tag/plist versions disagreed and the build stopped), and 2.11.1 shipped as "a version
-// number fix" — but relative to the last release users actually had, 2.10.0, it also carried
-// DragonKit v3's fixed-slot About pane. That is described below for the first time.
+// 2.11.3 is maintenance only, and says so. It publishes the update feed to this repository as
+// well as the website, so a problem with the website can no longer hold up an update, and it
+// makes the engine's learning-store directory a required argument rather than one defaulting to
+// the release location. Neither is observable: the copy you have installed keeps reading the
+// website until 2.11.4 moves it, and every caller already named its directory. `.changed` and
+// not `.fixed`, because nothing was broken.
+//
+// 2.11.2's two entries are gone rather than carried forward. One of them was a catch-up — the
+// About-pane rework reached users in 2.11.1 as "a version number fix" and was described for the
+// first time in 2.11.2 — and a catch-up that has been shown has done its job. Repeating it would
+// re-announce it to everyone who already read it.
 enum WhatsNewConfig {
     @MainActor
     static var content: WhatsNewContent {
         WhatsNewContent(
-            date: "2026-08-10",
+            date: "2026-08-11",
             summary: L("keykey.whatsNew.summary"),
             sections: [
-                ChangeSection(kind: .improved, entries: [
-                    L("keykey.whatsNew.aboutPane"),
-                ]),
-                ChangeSection(kind: .fixed, entries: [
-                    L("keykey.whatsNew.debugBuildIsolation"),
+                ChangeSection(kind: .changed, entries: [
+                    L("keykey.whatsNew.updateFeed"),
                 ]),
             ]
         )

--- a/App/en.lproj/Localizable.strings
+++ b/App/en.lproj/Localizable.strings
@@ -28,10 +28,9 @@
 "keykey.general.strokeConfirmationHint" = "In 速成, and in 倉頡 with the * wildcard, candidates appear before the code is finished, so Space flips to the next page instead of confirming what you typed. With this on, the first Space only confirms the code and keeps page 1 — press Space again to page, or 1–9 to pick. Plain 倉頡 is unaffected.";
 "keykey.general.language" = "Language";
 
-/* What's New pane (2.11.2) */
-"keykey.whatsNew.summary" = "A maintenance release. Nothing about typing changes — this one tidies the About panel and keeps a local test build fully separate from the copy you have installed.";
-"keykey.whatsNew.aboutPane" = "The About panel now follows the shared Dragon App layout. Its rows are fixed and identical across the Dragon apps — Website, Support on GitHub, Original project and Open-source licenses, then Created by, Based on, Built with and the licence — and each piece of bundled data is listed under its own name with its licence (McBopomofo — MIT, ibus-table-chinese — freely redistributable, OpenCC — Apache-2.0) instead of a description of what it is for. This reached you in 2.11.1, which was published as a version-number correction and never described it.";
-"keykey.whatsNew.debugBuildIsolation" = "A local test build no longer reaches into your installed copy. When Yahoo! KeyKey 2 is built on a developer's Mac it runs alongside the version you use, and the two shared one file of adaptive candidate ordering — so testing changed your real ranking, and running 解除安裝 in the test build deleted it. A test build now keeps its own copy, and it can no longer check for or install updates. None of this affects the version you type with; it is listed so the record is complete.";
+/* What's New pane (2.11.3) */
+"keykey.whatsNew.summary" = "A maintenance release. Nothing about typing changes, and nothing you can see behaves differently — this one is about how updates reach you.";
+"keykey.whatsNew.updateFeed" = "Yahoo! KeyKey 2 now publishes the file it checks for updates to its own home as well as the website, so a problem with the website can no longer hold up an update. The copy you have installed keeps reading the website until a later version moves it across, so nothing changes for you now.";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "Disable Cangjie and Simplex from Input Sources";

--- a/App/zh-Hant.lproj/Localizable.strings
+++ b/App/zh-Hant.lproj/Localizable.strings
@@ -28,10 +28,9 @@
 "keykey.general.strokeConfirmationHint" = "在速成、以及使用萬用字元（*）的倉頡中，字根還沒打完就會出現候選字，此時空白鍵會直接翻到下一頁，而不是確認你打的字根。開啟後，第一次按空白鍵只會確認字根並停留在第 1 頁；再按一次空白鍵才翻頁，或直接按 1–9 選字。一般倉頡不受影響。";
 "keykey.general.language" = "語言";
 
-/* What's New pane (2.11.2) */
-"keykey.whatsNew.summary" = "這是一次維護性更新。打字的部分完全沒有改變——這次整理的是「關於」面板的版面，以及讓本機測試版與你已安裝的那一份徹底分開。";
-"keykey.whatsNew.aboutPane" = "「關於」面板改用 Dragon App 共用的版面。各列的內容與順序現在固定下來，也與其他 Dragon App 一致——網站、GitHub 支援、原始專案、開放原始碼授權，接著是製作者、基於、建置工具與授權條款；每一份內建資料也改成直接列出它自己的名稱與授權（McBopomofo — MIT、ibus-table-chinese — 可自由散布、OpenCC — Apache-2.0），而不是一句用途說明。這項改動其實在 2.11.1 就已經送到你手上，但當時只以「修正版本號」發布，從未說明過。";
-"keykey.whatsNew.debugBuildIsolation" = "本機測試版不會再動到你已安裝的那一份。在開發者的 Mac 上建置 Yahoo! KeyKey 2 時，它會與你平常使用的版本同時存在，而兩者過去共用同一份選字排序的學習檔——測試會改動你真正的排序，在測試版裡執行「解除安裝」更會把它刪掉。現在測試版會使用自己的檔案，也不再能檢查或安裝更新。這些都不影響你平常打字用的那一份，列在這裡只是為了把紀錄補齊。";
+/* What's New pane (2.11.3) */
+"keykey.whatsNew.summary" = "這是一次維護性更新。打字的部分完全沒有改變，你看得到的地方也都一樣——這次調整的是更新送到你手上的方式。";
+"keykey.whatsNew.updateFeed" = "Yahoo! KeyKey 2 現在會把檢查更新用的檔案同時發布到自己的位置與網站，網站若出問題，就不會再耽誤更新。你已安裝的這一份仍會讀取網站，要等之後的版本才會改過去，所以現在對你來說沒有任何改變。";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "從輸入來源中停用倉頡與速成";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 A plain-language list of changes in each version, newest first.
 
+## 2.11.3
+
+- **The file Yahoo! KeyKey 2 checks for updates is now published to its own home as well as
+  the website.** Update delivery no longer depends on the website being reachable and
+  up to date. Nothing changes for you yet: the copy you have installed keeps reading the
+  website, and a later version moves it across. Doing both at once would have pointed every
+  installed copy at a file that did not exist yet.
+- **Internal: the engine's learning-store folder must now be named by whoever asks for it.**
+  The adaptive candidate-ordering file used to have a default location, and that default was
+  the installed copy's — so any build that simply left the argument out would have opened,
+  trained and rewritten your real ranking. 2.11.2 fixed the code that actually runs; this
+  removes the default so the mistake cannot be made again. Nothing moves: your counts stay
+  exactly where they are.
+
 ## 2.11.1
 
 - **Nothing new — this is a version number fix.** A 2.11.0 was tagged but never released: the

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
@@ -82,16 +82,23 @@ final class ConfigContentTests: XCTestCase {
         let short = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         XCTAssertEqual(content.displayVersion, DragonVersion.display(short ?? "1.0.0"))
         XCTAssertTrue(content.displayVersion.hasPrefix("v"))
-        XCTAssertEqual(content.date, "2026-08-10")
+        XCTAssertEqual(content.date, "2026-08-11")
     }
 
-    // 2.11.2 is a maintenance release: one improvement (the About pane, which shipped in 2.11.1
-    // undescribed) and one fix scoped to local test builds. No .added section — nothing was.
+    // 2.11.3 is maintenance only: one `.changed` entry, the update feed now also being published
+    // to this repository. `.changed` and not `.fixed` because nothing was broken, and not
+    // `.improved` because a user gets nothing out of it yet — the installed copy still reads the
+    // website until 2.11.4 moves SUFeedURL.
+    //
+    // Pinned per release alongside the notes themselves. 2.11.2 pinned [.improved, .fixed] for a
+    // different pair of entries; changing what the pane claims has to change this too, which is
+    // the point. The release gate checks the notes CHANGED; this checks they changed to what was
+    // meant.
     @MainActor
-    func testWhatsNewSectionsAreImprovedThenFixed() {
+    func testWhatsNewSectionsAreASingleChanged() {
         let content = WhatsNewConfig.content
-        XCTAssertEqual(content.sections.map(\.kind), [.improved, .fixed])
-        XCTAssertEqual(content.sections.map(\.entries.count), [1, 1])
+        XCTAssertEqual(content.sections.map(\.kind), [.changed])
+        XCTAssertEqual(content.sections.map(\.entries.count), [1])
     }
 
     // MARK: DragonAppMenu contract


### PR DESCRIPTION
Step 1 of 2 in taking KeyKey's Sparkle appcast off the marketing site. **KeyKey is the last of the five apps to migrate.**

This caller passed **no `appcast_repo` at all**, so it silently took the shared workflow's default, `teddychan/www.dragonapp.com`. It now names `teddychan/yahoo-keykey-2` as the appcast repo and the site as `appcast_mirror_repo`.

dragon-kit's [`docs/MAC-APP-RELEASE-LIFECYCLE.md`](https://github.com/teddychan/dragon-kit/blob/main/docs/MAC-APP-RELEASE-LIFECYCLE.md):

> Sparkle appcasts are update infrastructure, not marketing content. Each app should host its production appcast in its own repository so an outage, permission problem, or rejected change in the marketing-site repository cannot interfere with update delivery.

## Two releases, not one

`App/Info.plist` still points `SUFeedURL` at `www.dragonapp.com/yahoo-keykey-2/appcast.xml`, which is still being written, so nothing changes for anyone with KeyKey installed — but `docs/yahoo-keykey-2/appcast.xml` comes into existence here. Step 2 moves `SUFeedURL`.

Verified before this change: the app-owned URL is **HTTP 404**; the site's is **200**.

**The interference the spec names is not hypothetical.** Earlier today an ice-2 mirror commit sat in a **queued** GitHub Pages deployment for minutes after its release had finished, while the app-owned copy was already serving. A queue is survivable — the mirror still holds the previous release — but a 404 would not be, which is exactly why `SUFeedURL` does not move until step 2.

## Front-end notes

KeyKey is `build_kind: script` and an IME. The appcast is generated once and copied to both destinations, so they cannot disagree — **including** the `minimumSystemVersion` / `hardwareRequirements` that `appcast_inject_keykey_requirements` adds, which are injected before the copy.

## Also in this release

[#97](https://github.com/teddychan/yahoo-keykey-2/pull/97), which made `UserFrequency`'s learning-store directory a required argument instead of one defaulting to the release location.

## Notes

Maintenance-only, and says so. 2.11.2's two entries are **dropped rather than carried forward**: one was a catch-up for the About-pane rework that shipped undescribed in 2.11.1, and a catch-up that has been shown has done its job — repeating it re-announces it to everyone who already read it. Their now-orphaned `L()` keys are removed from both languages.

`.changed`, not `.fixed` (nothing was broken) and not `.improved` (a user gets nothing out of it until 2.11.4 moves `SUFeedURL`). `ConfigContentTests` moves with the notes; its 2.11.2 pin was `[.improved, .fixed]`.

## Verification

- `Packages/KeyKeyEngine` — **194 tests, 0 failures**
- `Packages/KeyKeyApp` — **66 tests, 0 failures**
- `tools/build-app.sh` — builds and signs; built bundle reports `CFBundleShortVersionString = 2.11.3`
- `dragon-conformance.py` — PASS, no violations
- `actionlint .github/workflows/release.yml` — clean
- dragon-release-ci v6.3.0's real `tag-gate.sh` against a simulated `v2.11.3` — **gate passed**, 3 watched paths, preceding tag `v2.11.2`, What's New changed

## Noted, not fixed

`CHANGELOG.md` has **no 2.11.2 entry** — that release shipped without one, so 2.11.3 now sits directly above 2.11.1. Pre-existing; ice-2's CHANGELOG has the identical gap at 2.14.2. Both are the release that landed the Debug-isolation work.