### PR TITLE
release: 2.11.4 — the update feed moves to this repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,29 +50,31 @@ jobs:
       # Yahoo KeyKey 2 now targets the macOS 26 SDK, so build on the macos-26 image.
       swiftpm_runner: macos-26
       app_slug: yahoo-keykey-2
-      # Step 1 of 2 in moving the appcast off the marketing site.
+      # Moving the appcast off the marketing site. Steps 1 and 2 are done; the mirror stays.
       #
       # MAC-APP-RELEASE-LIFECYCLE.md: "Sparkle appcasts are update infrastructure, not marketing
       # content. Each app should host its production appcast in its own repository so an outage,
       # permission problem, or rejected change in the marketing-site repository cannot interfere
-      # with update delivery." This caller passed no appcast_repo at all and so took the default,
-      # teddychan/www.dragonapp.com. KeyKey is the last of the five to migrate.
+      # with update delivery." This caller used to pass no appcast_repo at all and so took the default,
+      # teddychan/www.dragonapp.com. KeyKey was the last of the five to migrate.
       #
       # The same spec says to migrate "by mirroring the old and new locations until installed
       # versions have moved to the app-owned URL", which is why this is two releases and not one.
-      # Every ALREADY-INSTALLED KeyKey reads SUFeedURL from the site, so flipping the destination
-      # alone would leave all of them silently unable to see updates. That is not hypothetical
+      # Every KeyKey installed at the time read SUFeedURL from the site, so flipping the destination
+      # alone would have left all of them silently unable to see updates. That is not hypothetical
       # here: the site is GitHub Pages, and an ice-2 mirror commit sat in a QUEUED Pages
       # deployment for minutes after the release finished while the app-owned copy was already
       # serving. A queue is survivable; a 404 is not.
       #
-      #   step 1 (here)  publish to BOTH. App/Info.plist keeps pointing at the site, which is
-      #                  still being written, so nothing changes for anyone — but the app-owned
-      #                  feed now exists and is current.
-      #   step 2 (next)  move SUFeedURL to
-      #                  https://raw.githubusercontent.com/teddychan/yahoo-keykey-2/main/docs/yahoo-keykey-2/appcast.xml
-      #                  once step 1 has actually populated it.
-      #   later          drop appcast_mirror_repo when no supported version still reads the site.
+      #   step 1  v2.11.3  published to BOTH, with App/Info.plist still pointing at the site, so
+      #                    nothing changed for anyone — but the app-owned feed came into existence
+      #                    and was current. Both copies verified byte-identical after.
+      #   step 2  v2.11.4  SUFeedURL moved to
+      #                    https://raw.githubusercontent.com/teddychan/yahoo-keykey-2/main/docs/yahoo-keykey-2/appcast.xml
+      #   later            drop appcast_mirror_repo when no supported version still reads the site.
+      #
+      # Do not drop the mirror early. Every copy still at 2.11.3 or older reads the site and only
+      # the site; the mirror is the whole reason flipping SUFeedURL did not strand them.
       #
       # Needs dragon-release-ci >= v6.3.0. The appcast is generated once and copied to both, so
       # the two cannot disagree — including the minimumSystemVersion/hardwareRequirements that

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.11.3</string>
+	<string>2.11.4</string>
 	<key>CFBundleVersion</key>
 	<string>23</string>
 	<key>ComponentInputModeDict</key>
@@ -106,7 +106,7 @@
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUFeedURL</key>
-	<string>https://www.dragonapp.com/yahoo-keykey-2/appcast.xml</string>
+	<string>https://raw.githubusercontent.com/teddychan/yahoo-keykey-2/main/docs/yahoo-keykey-2/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>p+F/ivF5bAYcmuNuCMNHcRv123A6LHFpCBagFm7Adu8=</string>
 	<key>SUScheduledCheckInterval</key>

--- a/App/WhatsNewConfig.swift
+++ b/App/WhatsNewConfig.swift
@@ -6,17 +6,18 @@ import DragonKit
 // binary isn't. That makes the entries and the date the only things to keep in sync with
 // CHANGELOG.md on release.
 //
-// 2.11.3 is maintenance only, and says so. It publishes the update feed to this repository as
-// well as the website, so a problem with the website can no longer hold up an update, and it
-// makes the engine's learning-store directory a required argument rather than one defaulting to
-// the release location. Neither is observable: the copy you have installed keeps reading the
-// website until 2.11.4 moves it, and every caller already named its directory. `.changed` and
-// not `.fixed`, because nothing was broken.
+// 2.11.4 is maintenance only, and says so. It completes what 2.11.3 began: SUFeedURL now points
+// at this repository's copy of the appcast rather than the website's, so update delivery no
+// longer depends on the marketing site being deployed and current. Not observable — updates keep
+// arriving, from the same signing key, at the same cadence — so `.changed` and not `.fixed`.
 //
-// 2.11.2's two entries are gone rather than carried forward. One of them was a catch-up — the
-// About-pane rework reached users in 2.11.1 as "a version number fix" and was described for the
-// first time in 2.11.2 — and a catch-up that has been shown has done its job. Repeating it would
-// re-announce it to everyone who already read it.
+// The order was load-bearing. 2.11.3 published to BOTH while every installed copy still read the
+// website; only once that had actually run did the app-owned feed exist to be pointed at. Doing
+// both in one release would have sent every install to a 404.
+//
+// 2.11.2's entries are not carried forward. One was a catch-up — the About-pane rework reached
+// users in 2.11.1 as "a version number fix" and was described for the first time in 2.11.2 — and
+// a catch-up that has been shown has done its job.
 enum WhatsNewConfig {
     @MainActor
     static var content: WhatsNewContent {

--- a/App/en.lproj/Localizable.strings
+++ b/App/en.lproj/Localizable.strings
@@ -28,9 +28,9 @@
 "keykey.general.strokeConfirmationHint" = "In 速成, and in 倉頡 with the * wildcard, candidates appear before the code is finished, so Space flips to the next page instead of confirming what you typed. With this on, the first Space only confirms the code and keeps page 1 — press Space again to page, or 1–9 to pick. Plain 倉頡 is unaffected.";
 "keykey.general.language" = "Language";
 
-/* What's New pane (2.11.3) */
-"keykey.whatsNew.summary" = "A maintenance release. Nothing about typing changes, and nothing you can see behaves differently — this one is about how updates reach you.";
-"keykey.whatsNew.updateFeed" = "Yahoo! KeyKey 2 now publishes the file it checks for updates to its own home as well as the website, so a problem with the website can no longer hold up an update. The copy you have installed keeps reading the website until a later version moves it across, so nothing changes for you now.";
+/* What's New pane (2.11.4) */
+"keykey.whatsNew.summary" = "A maintenance release. Nothing about typing changes, and nothing you can see behaves differently — this one finishes the change to how updates reach you.";
+"keykey.whatsNew.updateFeed" = "Yahoo! KeyKey 2 now checks for updates at its own home rather than the website, so a problem with the website can no longer hold one up. Updates keep arriving exactly as before.";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "Disable Cangjie and Simplex from Input Sources";

--- a/App/zh-Hant.lproj/Localizable.strings
+++ b/App/zh-Hant.lproj/Localizable.strings
@@ -28,9 +28,9 @@
 "keykey.general.strokeConfirmationHint" = "在速成、以及使用萬用字元（*）的倉頡中，字根還沒打完就會出現候選字，此時空白鍵會直接翻到下一頁，而不是確認你打的字根。開啟後，第一次按空白鍵只會確認字根並停留在第 1 頁；再按一次空白鍵才翻頁，或直接按 1–9 選字。一般倉頡不受影響。";
 "keykey.general.language" = "語言";
 
-/* What's New pane (2.11.3) */
-"keykey.whatsNew.summary" = "這是一次維護性更新。打字的部分完全沒有改變，你看得到的地方也都一樣——這次調整的是更新送到你手上的方式。";
-"keykey.whatsNew.updateFeed" = "Yahoo! KeyKey 2 現在會把檢查更新用的檔案同時發布到自己的位置與網站，網站若出問題，就不會再耽誤更新。你已安裝的這一份仍會讀取網站，要等之後的版本才會改過去，所以現在對你來說沒有任何改變。";
+/* What's New pane (2.11.4) */
+"keykey.whatsNew.summary" = "這是一次維護性更新。打字的部分完全沒有改變，你看得到的地方也都一樣——這次是把更新送達方式的調整收尾。";
+"keykey.whatsNew.updateFeed" = "Yahoo! KeyKey 2 現在改成到自己的位置檢查更新，不再經過網站，網站若出問題也不會再耽誤更新。更新仍會照原本的方式送達。";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "從輸入來源中停用倉頡與速成";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 A plain-language list of changes in each version, newest first.
 
+## 2.11.4
+
+- **Yahoo! KeyKey 2 now checks for updates at its own home rather than the website.** Update
+  delivery no longer depends on the website being reachable, deployed and up to date. Updates
+  keep arriving exactly as before, signed by the same key. This finishes what 2.11.3 started:
+  that release began publishing the file to both places, and only once it had actually done so
+  was there anything here to point the app at. Doing both at once would have sent every
+  installed copy to a file that did not exist.
+
 ## 2.11.3
 
 - **The file Yahoo! KeyKey 2 checks for updates is now published to its own home as well as

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
@@ -85,15 +85,14 @@ final class ConfigContentTests: XCTestCase {
         XCTAssertEqual(content.date, "2026-08-11")
     }
 
-    // 2.11.3 is maintenance only: one `.changed` entry, the update feed now also being published
-    // to this repository. `.changed` and not `.fixed` because nothing was broken, and not
-    // `.improved` because a user gets nothing out of it yet — the installed copy still reads the
-    // website until 2.11.4 moves SUFeedURL.
+    // 2.11.4 is maintenance only: one `.changed` entry, SUFeedURL moving to this repository's
+    // copy of the appcast. `.changed` and not `.fixed` because nothing was broken.
     //
-    // Pinned per release alongside the notes themselves. 2.11.2 pinned [.improved, .fixed] for a
-    // different pair of entries; changing what the pane claims has to change this too, which is
-    // the point. The release gate checks the notes CHANGED; this checks they changed to what was
-    // meant.
+    // Same shape as 2.11.3 by coincidence, not by drift — that release was the other half of the
+    // same migration (publish to both, then point the app at the new one), so both are one
+    // `.changed` entry about update delivery. The entry TEXT differs, which is what the release
+    // gate checks; this pins the shape. 2.11.2 pinned [.improved, .fixed] for a different pair.
+    // Changing what the pane claims has to change this too, which is the point.
     @MainActor
     func testWhatsNewSectionsAreASingleChanged() {
         let content = WhatsNewConfig.content


### PR DESCRIPTION
Step 2 of 2, completing what `v2.11.3` began — and finishing the appcast migration for **the last of the five apps**. `SUFeedURL` now reads

```
https://raw.githubusercontent.com/teddychan/yahoo-keykey-2/main/docs/yahoo-keykey-2/appcast.xml
```

instead of `https://www.dragonapp.com/yahoo-keykey-2/appcast.xml`.

## Step 1 actually ran first

Verified on the released `v2.11.3` before making this change:

| Check | Result |
|---|---|
| `docs/yahoo-keykey-2/appcast.xml` in yahoo-keykey-2 | present, 895 bytes |
| same path in www.dragonapp.com | present, 895 bytes |
| byte-identical | ✅ sha256 `a4d7f17a518aa41296ac65fe4fc6b29e5359b05d6ece2c69813941b27809961d` |
| `sparkle:version` monotonic | 184 (2.11.2) → 190 (2.11.3) |
| **injected requirements in BOTH copies** | ✅ `minimumSystemVersion 26.0`, `hardwareRequirements arm64` |

That last row is the one specific to this app. KeyKey declares its minimum system version and hardware requirement **only in the appcast** (`appcast_inject_keykey_requirements`), so a migration that dropped them on one destination would offer the update to machines that cannot run it. The workflow generates once and copies, and the injection happens before the copy — confirmed rather than assumed.

## The mirror deliberately stays

Every copy at 2.11.3 or earlier still reads the site, and only a release after which no supported version does may drop it. The `release.yml` comment is rewritten from "step 2 (next)" accordingly.

## Notes

Maintenance-only. Same one-`.changed`-entry shape as 2.11.3 — not drift, but because both releases are halves of one migration. The entry *text* differs, which is what the release gate checks; `ConfigContentTests` pins the shape and its comment moves with it.

## Verification

- `Packages/KeyKeyEngine` — **194 tests, 0 failures**
- `Packages/KeyKeyApp` — **66 tests, 0 failures**
- `tools/build-app.sh` — builds and signs; the built bundle reports `2.11.4` and carries the app-owned `SUFeedURL`
- `dragon-conformance.py` — PASS, no violations
- `actionlint .github/workflows/release.yml` — clean
- dragon-release-ci v6.3.0's real `tag-gate.sh` against a simulated `v2.11.4` — **gate passed**, 3 watched paths, preceding tag `v2.11.3`, What's New changed