### PR TITLE
docs(changelog): add the missing 2.11.2 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ A plain-language list of changes in each version, newest first.
   removes the default so the mistake cannot be made again. Nothing moves: your counts stay
   exactly where they are.
 
+## 2.11.2
+
+- **The About panel now follows the shared Dragon App layout.** Its rows are fixed and identical
+  across the Dragon apps — Website, Support on GitHub, Original project and Open-source licenses,
+  then Created by, Based on, Built with and the licence — and each piece of bundled data is listed
+  under its own name with its licence (McBopomofo — MIT, ibus-table-chinese — freely
+  redistributable, OpenCC — Apache-2.0) instead of a description of what it is for. This reached
+  you in 2.11.1, which was published as a version-number correction and never described it.
+- **Fixed: a local test build no longer reaches into your installed copy.** When Yahoo! KeyKey 2
+  is built on a developer's Mac it runs alongside the version you use, and the two shared one file
+  of adaptive candidate ordering — so testing changed your real ranking, and running 解除安裝 in
+  the test build deleted it. A test build now keeps its own copy, and it can no longer check for
+  or install updates. None of this affects the version you type with; it is listed so the record
+  is complete.
+
 ## 2.11.1
 
 - **Nothing new — this is a version number fix.** A 2.11.0 was tagged but never released: the


### PR DESCRIPTION
`CHANGELOG.md` jumped from 2.11.3 straight down to 2.11.1, so the release between them had no record at all.

## Where the content comes from

2.11.2 announced exactly two things to users, as `keykey.whatsNew.aboutPane` and `keykey.whatsNew.debugBuildIsolation`. Both were removed from the strings files in 2.11.3 — a catch-up that has been shown has done its job — so the pane no longer carries them and nothing else did either. They are recoverable at:

```
git show v2.11.2:App/en.lproj/Localizable.strings
```

The section is written from that shipped copy, cross-checked against the single commit in `v2.11.1..v2.11.2` (9f1daed, PR #92).

## Style

Matches the file rather than ice-2's: bold lead sentence, plain-language user-facing prose, flat bullet list with no headings under the version. Following 2.11.3's precedent, the pane's summary line ("A maintenance release. Nothing about typing changes…") is dropped — the bullets carry it, and the second one already ends by saying it does not affect the version you type with.

The release's remaining changes are developer-only plumbing (the DragonKit pin, a build-time version assert, `open -n` in `run-debug.sh`), so they get no bullet — the DragonKit bump is the mechanism behind bullet 2 rather than a separate user-facing item.

## Scope

Documentation only. One file, 15 lines added, nothing removed. No version bump, no `Info.plist` change, no tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)