### PR TITLE
docs(release): give the appcast mirror a retirement trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,10 +71,22 @@ jobs:
       #                    and was current. Both copies verified byte-identical after.
       #   step 2  v2.11.4  SUFeedURL moved to
       #                    https://raw.githubusercontent.com/teddychan/yahoo-keykey-2/main/docs/yahoo-keykey-2/appcast.xml
-      #   later            drop appcast_mirror_repo when no supported version still reads the site.
+      #   step 3  v2.12.0  drop appcast_mirror_repo. The NEXT MINOR RELEASE retires the mirror.
       #
-      # Do not drop the mirror early. Every copy still at 2.11.3 or older reads the site and only
-      # the site; the mirror is the whole reason flipping SUFeedURL did not strand them.
+      # That trigger was chosen on 2026-08-11, replacing "when no supported version still reads
+      # the site" — which read like a rule but named no measurable condition, so it would have
+      # stayed "later" indefinitely. The site is GitHub Pages and exposes no per-path traffic, so
+      # there is no way to observe when the last reader stops reading. A minor release is instead a
+      # real, deliberate event that already opens a PR here, so the removal rides one rather than
+      # needing its own; and Sparkle checks daily by default, so anyone who launches Yahoo! KeyKey 2
+      # even once between 2.11.4 and that release has already moved to the app-owned feed.
+      #
+      # Do not drop the mirror before then. Every copy still at 2.11.3 or older reads the site and
+      # only the site; the mirror is the whole reason flipping SUFeedURL did not strand them.
+      # The accepted cost is the other direction: shipping no minor for a long time keeps the
+      # mirror that long. That is the safe way to be wrong — an unnecessary mirror costs one extra
+      # publish per release, while a premature drop silently strands installs that cannot tell the
+      # difference between "no update" and "feed gone".
       #
       # Needs dragon-release-ci >= v6.3.0. The appcast is generated once and copied to both, so
       # the two cannot disagree — including the minimumSystemVersion/hardwareRequirements that


### PR DESCRIPTION
The appcast migration comment ended with:

> `later  drop appcast_mirror_repo when no supported version still reads the site.`

That reads like a rule but names no **measurable** condition. The site is GitHub Pages, which exposes no per-path traffic, so there is no way to observe when the last reader stops reading — the step would have stayed `later` indefinitely.

## The trigger

`step 3  v2.12.0  drop appcast_mirror_repo. The NEXT MINOR RELEASE retires the mirror.`

A minor release is a real, deliberate event that already opens a PR here, so the removal rides one instead of needing its own. Sparkle checks daily by default, so anyone who launches Yahoo! KeyKey 2 even once between 2.11.4 and that release has already moved to the app-owned feed.

The accepted cost is recorded in the comment too: shipping no minor for a long time keeps the mirror that long. That is the safe direction to be wrong in — an unnecessary mirror costs one extra publish per release, while a premature drop silently strands installs that cannot tell "no update" from "feed gone".

## Scope

**Comment-only.** Verified mechanically, not by eye:

```
parsed workflow identical to main: True
non-comment changed lines:         0
```

No mirror is dropped in this PR — it only writes down when to drop it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)