### PR TITLE
chore: bump the DragonKit pin to 3.4.0

### DIFF
--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -86,7 +86,7 @@ echo "==> Building DragonKit (SwiftPM, release) in pinned checkout"
 # tools/test-resolve-dragon-kit.sh can drive every one of them without a swiftc build.
 # DRAGONKIT_TAG stays HERE: the propagation SOP and .github/workflows/tests.yml both read the pin
 # out of this file.
-DRAGONKIT_TAG="v3.3.0"
+DRAGONKIT_TAG="v3.4.0"
 DRAGONKIT_URL="https://github.com/teddychan/dragon-kit"
 "$ROOT/tools/resolve-dragon-kit.sh" "$KIT_DIR" "$DRAGONKIT_TAG" "$DRAGONKIT_URL"
 ( cd "$KIT_DIR" && swift build -c release )


### PR DESCRIPTION
`CONFORMANCE` §R10 requires the declared pin to be `>=` the newest `vX.Y.Z` tag in dragon-kit, so publishing **v3.4.0** put this app in violation the moment it landed:

```
R10  pinned to DragonKit 3.3.0 but 3.4.0 is released — a stale pin silently misses shared fixes
```

That is a hard failure (`exit=1`), and the reusable conformance workflow runs the same checker on every PR here — so this repo's next PR would have red-X'd on a rule break it did not introduce. R10 exists because every app once sat on 1.3.0 while the kit was at 1.4.0 and none had the shared menu at all.

## This is pin currency, not API adoption

3.4.0 adds `LanguagePicker(languages:onChange:)` with **both parameters defaulted**, for an app translated into fewer languages than the kit ships. Nothing in this app uses it and no behaviour changes. The one user-visible difference is About's **Built with** row, which now reports `DragonKit v3.4.0`.

## Verification

```
KeyKeyEngine  ->  194 tests, 0 failures
KeyKeyApp     ->   66 tests, 0 failures
tools/build-app.sh  ->  app built and signed
conformance: PASS — no violations
```

`tools/build-app.sh` was run because `swift test` does not compile every `App/` file, and `DRAGONKIT_TAG` in that script *is* the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)