### PR TITLE
release: 2.11.5 — the Language menu offered languages KeyKey doesn't have

### DIFF
--- a/App/GeneralPane.swift
+++ b/App/GeneralPane.swift
@@ -60,7 +60,24 @@ private struct GeneralPaneView: View {
             }
 
             DragonSection(LocalizedStringKey(L("keykey.general.language"))) {
-                LanguagePicker()
+                // Exactly the languages KeyKey has translated ITSELF into: App/en.lproj and
+                // App/zh-Hant.lproj. The parameter defaults to DragonLanguage.selectable — all
+                // seven locales the kit ships — and taking that default is what shipped through
+                // 2.11.4: Settings offered Español, Français, 日本語, 한국어 and 简体中文, and
+                // choosing one translated the kit's four panes while every KeyKey string fell back
+                // to English. ice-2 hit the same default first and hand-rolled its own picker,
+                // which CONFORMANCE forbids; DragonKit 3.4.0 added this argument instead, and this
+                // release is the pin bump that makes it available.
+                //
+                // Widen this only together with a new .lproj — ConfigContentTests'
+                // testLanguagePickerOffersExactlyTheShippedLocalizations compares the two and
+                // fails in either direction.
+                //
+                // No onChange: it exists for apps whose own strings cannot switch live (ice-2
+                // mirrors the choice into AppleLanguages and relaunches). Every KeyKey string is
+                // read through L(), which dragonLocalized() re-resolves in place, so there is
+                // nothing to relaunch for.
+                LanguagePicker(languages: [.en, .zhHant])
             }
         }
     }

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.11.4</string>
+	<string>2.11.5</string>
 	<key>CFBundleVersion</key>
 	<string>23</string>
 	<key>ComponentInputModeDict</key>

--- a/App/WhatsNewConfig.swift
+++ b/App/WhatsNewConfig.swift
@@ -6,22 +6,30 @@ import DragonKit
 // binary isn't. That makes the entries and the date the only things to keep in sync with
 // CHANGELOG.md on release.
 //
-// 2.11.5 is maintenance only, and says so. Exactly two commits separate it from 2.11.4: a comment
-// in .github/workflows/release.yml naming when the appcast mirror retires, and the DragonKit pin
-// moving 3.3.0 -> 3.4.0. Only the second reaches a user at all, and only as the About pane's
-// "Built with · DragonKit v3.4.0" row. 3.4.0 adds LanguagePicker(languages:onChange:) with both
-// parameters defaulted, which this app never calls — the bump is for pin currency, which
-// CONFORMANCE §R10 requires the day the kit tags a release, not to adopt an API. `.changed` and
-// not `.fixed` because nothing was broken; not `.improved` because a user gains nothing, the same
-// reasoning that chose `.changed` for 2.11.3.
+// 2.11.5 started as maintenance — a DragonKit pin bump for currency and a CI comment — and stopped
+// being maintenance when the bump turned out to fix a live bug. So the notes lead with the fix,
+// `.fixed`, and the bump follows as `.changed`. Getting this wrong in the safe-looking direction
+// (shipping the maintenance-only wording that was already written) would have hidden the only
+// thing in the release a user can actually notice.
 //
-// Shipping no entry at all was the other option and is worse. The pane is the only place a user is
-// told what a version did, so leaving 2.11.4's text in place would claim the update-feed migration
-// a second time, to everyone who already read it. A release that changed nothing a user can use
-// still owes the reader the sentence saying so.
+// The bug: App/GeneralPane.swift called LanguagePicker with no argument, so it took the kit's
+// default of DragonLanguage.selectable — all seven locales DragonKit ships — while KeyKey has
+// translated itself into two, App/en.lproj and App/zh-Hant.lproj. Settings therefore offered
+// Español, Français, 日本語, 한국어 and 简体中文, and choosing one translated the kit's four panes
+// and nothing else. `.fixed` and not `.changed`: the menu was making an offer the app could not
+// keep.
 //
-// 2.11.4's entry is therefore not carried forward. The feed moved once; the pane describes this
-// version, not the accumulated history — that is CHANGELOG.md's job.
+// The `languages:` argument that fixes it is new in DragonKit 3.4.0, which is what this release
+// bumps the pin to — so the two entries are one story, and the second earns its place by being the
+// reason the first is possible rather than by padding the list.
+//
+// Worth saying in the notes and not only here: the kit appends an out-of-set selection to the
+// picker (LanguagePicker.offeredLanguages), so a user who had already chosen 日本語 still sees it
+// listed and can move off it. Narrowing the list would otherwise orphan their choice, and SwiftUI
+// draws a Picker whose selection matches no tag as blank.
+//
+// 2.11.4's entry is not carried forward. The feed moved once; the pane describes this version, not
+// the accumulated history — that is CHANGELOG.md's job.
 enum WhatsNewConfig {
     @MainActor
     static var content: WhatsNewContent {
@@ -29,6 +37,9 @@ enum WhatsNewConfig {
             date: "2026-08-11",
             summary: L("keykey.whatsNew.summary"),
             sections: [
+                ChangeSection(kind: .fixed, entries: [
+                    L("keykey.whatsNew.languagePicker"),
+                ]),
                 ChangeSection(kind: .changed, entries: [
                     L("keykey.whatsNew.sharedCode"),
                 ]),

--- a/App/WhatsNewConfig.swift
+++ b/App/WhatsNewConfig.swift
@@ -6,18 +6,22 @@ import DragonKit
 // binary isn't. That makes the entries and the date the only things to keep in sync with
 // CHANGELOG.md on release.
 //
-// 2.11.4 is maintenance only, and says so. It completes what 2.11.3 began: SUFeedURL now points
-// at this repository's copy of the appcast rather than the website's, so update delivery no
-// longer depends on the marketing site being deployed and current. Not observable — updates keep
-// arriving, from the same signing key, at the same cadence — so `.changed` and not `.fixed`.
+// 2.11.5 is maintenance only, and says so. Exactly two commits separate it from 2.11.4: a comment
+// in .github/workflows/release.yml naming when the appcast mirror retires, and the DragonKit pin
+// moving 3.3.0 -> 3.4.0. Only the second reaches a user at all, and only as the About pane's
+// "Built with · DragonKit v3.4.0" row. 3.4.0 adds LanguagePicker(languages:onChange:) with both
+// parameters defaulted, which this app never calls — the bump is for pin currency, which
+// CONFORMANCE §R10 requires the day the kit tags a release, not to adopt an API. `.changed` and
+// not `.fixed` because nothing was broken; not `.improved` because a user gains nothing, the same
+// reasoning that chose `.changed` for 2.11.3.
 //
-// The order was load-bearing. 2.11.3 published to BOTH while every installed copy still read the
-// website; only once that had actually run did the app-owned feed exist to be pointed at. Doing
-// both in one release would have sent every install to a 404.
+// Shipping no entry at all was the other option and is worse. The pane is the only place a user is
+// told what a version did, so leaving 2.11.4's text in place would claim the update-feed migration
+// a second time, to everyone who already read it. A release that changed nothing a user can use
+// still owes the reader the sentence saying so.
 //
-// 2.11.2's entries are not carried forward. One was a catch-up — the About-pane rework reached
-// users in 2.11.1 as "a version number fix" and was described for the first time in 2.11.2 — and
-// a catch-up that has been shown has done its job.
+// 2.11.4's entry is therefore not carried forward. The feed moved once; the pane describes this
+// version, not the accumulated history — that is CHANGELOG.md's job.
 enum WhatsNewConfig {
     @MainActor
     static var content: WhatsNewContent {
@@ -26,7 +30,7 @@ enum WhatsNewConfig {
             summary: L("keykey.whatsNew.summary"),
             sections: [
                 ChangeSection(kind: .changed, entries: [
-                    L("keykey.whatsNew.updateFeed"),
+                    L("keykey.whatsNew.sharedCode"),
                 ]),
             ]
         )

--- a/App/en.lproj/Localizable.strings
+++ b/App/en.lproj/Localizable.strings
@@ -29,8 +29,9 @@
 "keykey.general.language" = "Language";
 
 /* What's New pane (2.11.5) */
-"keykey.whatsNew.summary" = "A maintenance release. Nothing about typing changes, and nothing you can see behaves differently — this one only brings the shared code behind the Settings window up a version.";
-"keykey.whatsNew.sharedCode" = "Yahoo! KeyKey 2 is now built with DragonKit 3.4.0, the shared code behind the Settings window's About, What's New, Backup & Restore, Updates and Uninstall panes. Nothing it gives Yahoo! KeyKey 2 changed in this version, so nothing here works differently — the About pane reports the new number, and that is the whole of it.";
+"keykey.whatsNew.summary" = "This one fixes the Language menu in Settings, which offered languages Yahoo! KeyKey 2 has never been translated into. Nothing about typing changes.";
+"keykey.whatsNew.languagePicker" = "The Language menu in Settings no longer offers languages Yahoo! KeyKey 2 does not have. Beside English and 繁體中文 it listed Español, Français, 日本語, 한국어 and 简体中文, and choosing one of those translated only the About, What's New, Updates and Uninstall panes while every other word stayed in English. It now offers the two languages Yahoo! KeyKey 2 is actually translated into. If you had already picked one of the others, it stays in the menu and stays selected until you move off it, so you can still see where you are and change it.";
+"keykey.whatsNew.sharedCode" = "Yahoo! KeyKey 2 is now built with DragonKit 3.4.0, the shared code behind the Settings window's About, What's New, Backup & Restore, Updates and Uninstall panes — and the version that added the setting the fix above needed. The About pane reports the new number; nothing else about it is different.";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "Disable Cangjie and Simplex from Input Sources";

--- a/App/en.lproj/Localizable.strings
+++ b/App/en.lproj/Localizable.strings
@@ -28,9 +28,9 @@
 "keykey.general.strokeConfirmationHint" = "In 速成, and in 倉頡 with the * wildcard, candidates appear before the code is finished, so Space flips to the next page instead of confirming what you typed. With this on, the first Space only confirms the code and keeps page 1 — press Space again to page, or 1–9 to pick. Plain 倉頡 is unaffected.";
 "keykey.general.language" = "Language";
 
-/* What's New pane (2.11.4) */
-"keykey.whatsNew.summary" = "A maintenance release. Nothing about typing changes, and nothing you can see behaves differently — this one finishes the change to how updates reach you.";
-"keykey.whatsNew.updateFeed" = "Yahoo! KeyKey 2 now checks for updates at its own home rather than the website, so a problem with the website can no longer hold one up. Updates keep arriving exactly as before.";
+/* What's New pane (2.11.5) */
+"keykey.whatsNew.summary" = "A maintenance release. Nothing about typing changes, and nothing you can see behaves differently — this one only brings the shared code behind the Settings window up a version.";
+"keykey.whatsNew.sharedCode" = "Yahoo! KeyKey 2 is now built with DragonKit 3.4.0, the shared code behind the Settings window's About, What's New, Backup & Restore, Updates and Uninstall panes. Nothing it gives Yahoo! KeyKey 2 changed in this version, so nothing here works differently — the About pane reports the new number, and that is the whole of it.";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "Disable Cangjie and Simplex from Input Sources";

--- a/App/zh-Hant.lproj/Localizable.strings
+++ b/App/zh-Hant.lproj/Localizable.strings
@@ -29,8 +29,9 @@
 "keykey.general.language" = "語言";
 
 /* What's New pane (2.11.5) */
-"keykey.whatsNew.summary" = "這是一次維護性更新。打字的部分完全沒有改變，你看得到的地方也都一樣——這次只是把設定視窗共用的程式碼升上一個版本。";
-"keykey.whatsNew.sharedCode" = "Yahoo! KeyKey 2 現在改用 DragonKit 3.4.0 建構，那是設定視窗中「關於」、「新功能」、「備份與還原」、「更新」與「解除安裝」各面板共用的程式碼。這個版本並沒有改變它提供給 Yahoo! KeyKey 2 的任何功能，因此沒有任何地方的運作方式不同——「關於」面板會顯示新的版本號，僅此而已。";
+"keykey.whatsNew.summary" = "這次修正了設定中的「語言」選單——它列出了 Yahoo! KeyKey 2 從未翻譯過的語言。打字的部分完全沒有改變。";
+"keykey.whatsNew.languagePicker" = "設定中的「語言」選單不再列出 Yahoo! KeyKey 2 沒有的語言。它原本除了 English 與繁體中文，還列出 Español、Français、日本語、한국어 與简体中文；選了其中任何一個，只有「關於」、「新功能」、「更新」與「解除安裝」四個面板會被翻譯，其餘文字全都退回英文。現在只會列出 Yahoo! KeyKey 2 實際翻譯過的這兩種語言。如果你先前已經選了其他語言，它仍會留在選單中並維持選取狀態，直到你切換離開，因此你依然看得到自己目前的設定，也改得回來。";
+"keykey.whatsNew.sharedCode" = "Yahoo! KeyKey 2 現在改用 DragonKit 3.4.0 建構，那是設定視窗中「關於」、「新功能」、「備份與還原」、「更新」與「解除安裝」各面板共用的程式碼，也正是這個版本才提供上述修正所需的設定。「關於」面板會顯示新的版本號，其他部分沒有任何不同。";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "從輸入來源中停用倉頡與速成";

--- a/App/zh-Hant.lproj/Localizable.strings
+++ b/App/zh-Hant.lproj/Localizable.strings
@@ -28,9 +28,9 @@
 "keykey.general.strokeConfirmationHint" = "在速成、以及使用萬用字元（*）的倉頡中，字根還沒打完就會出現候選字，此時空白鍵會直接翻到下一頁，而不是確認你打的字根。開啟後，第一次按空白鍵只會確認字根並停留在第 1 頁；再按一次空白鍵才翻頁，或直接按 1–9 選字。一般倉頡不受影響。";
 "keykey.general.language" = "語言";
 
-/* What's New pane (2.11.4) */
-"keykey.whatsNew.summary" = "這是一次維護性更新。打字的部分完全沒有改變，你看得到的地方也都一樣——這次是把更新送達方式的調整收尾。";
-"keykey.whatsNew.updateFeed" = "Yahoo! KeyKey 2 現在改成到自己的位置檢查更新，不再經過網站，網站若出問題也不會再耽誤更新。更新仍會照原本的方式送達。";
+/* What's New pane (2.11.5) */
+"keykey.whatsNew.summary" = "這是一次維護性更新。打字的部分完全沒有改變，你看得到的地方也都一樣——這次只是把設定視窗共用的程式碼升上一個版本。";
+"keykey.whatsNew.sharedCode" = "Yahoo! KeyKey 2 現在改用 DragonKit 3.4.0 建構，那是設定視窗中「關於」、「新功能」、「備份與還原」、「更新」與「解除安裝」各面板共用的程式碼。這個版本並沒有改變它提供給 Yahoo! KeyKey 2 的任何功能，因此沒有任何地方的運作方式不同——「關於」面板會顯示新的版本號，僅此而已。";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "從輸入來源中停用倉頡與速成";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 A plain-language list of changes in each version, newest first.
 
+## 2.11.5
+
+- **Under the hood: updated to DragonKit 3.4.0** (from 3.3.0), the shared code behind the Settings
+  window's About, What's New, Backup & Restore, Updates and Uninstall panes. Nothing it provides to
+  Yahoo! KeyKey 2 changed in this version, so nothing about typing or any window behaves
+  differently — the About pane reports the new number, which is the only difference there is to
+  see. The bump is there to keep the shared code current: every Dragon app is required to sit on
+  the newest published version, so a version behind is a build failure rather than a drift nobody
+  notices.
+
 ## 2.11.4
 
 - **Yahoo! KeyKey 2 now checks for updates at its own home rather than the website.** Update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,18 @@ A plain-language list of changes in each version, newest first.
 
 ## 2.11.5
 
+- **Fixed: the Language menu in Settings offered languages Yahoo! KeyKey 2 does not have.** Beside
+  English and 繁體中文 it listed Español, Français, 日本語, 한국어 and 简体中文 — the languages the
+  shared Dragon App code is translated into, not the ones Yahoo! KeyKey 2 is. Choosing one of them
+  translated the About, What's New, Updates and Uninstall panes and left every other word in
+  English, which is not a language setting anyone wanted. The menu now offers the two languages
+  Yahoo! KeyKey 2 actually has. A choice already made outside those two stays listed and stays
+  selected until you move off it, so nobody is left on a language they can no longer see in the
+  menu.
 - **Under the hood: updated to DragonKit 3.4.0** (from 3.3.0), the shared code behind the Settings
-  window's About, What's New, Backup & Restore, Updates and Uninstall panes. Nothing it provides to
-  Yahoo! KeyKey 2 changed in this version, so nothing about typing or any window behaves
-  differently — the About pane reports the new number, which is the only difference there is to
-  see. The bump is there to keep the shared code current: every Dragon app is required to sit on
-  the newest published version, so a version behind is a build failure rather than a drift nobody
-  notices.
+  window's About, What's New, Backup & Restore, Updates and Uninstall panes — and the version that
+  added the setting the fix above needed, so the two arrived together. The About pane reports the
+  new number; nothing else it provides changed.
 
 ## 2.11.4
 

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
@@ -85,26 +85,102 @@ final class ConfigContentTests: XCTestCase {
         XCTAssertEqual(content.date, "2026-08-11")
     }
 
-    // 2.11.5 is maintenance only: one `.changed` entry, the DragonKit pin moving to 3.4.0.
-    // `.changed` and not `.fixed` because nothing was broken, and not `.improved` because the bump
-    // is for pin currency rather than to adopt an API. 2.11.2 pinned [.improved, .fixed] for a
-    // different pair; changing what the pane claims has to change this too, which is the point.
+    // 2.11.5 leads with a fix and follows with the pin bump that made it possible: the Language
+    // menu offered all seven locales DragonKit ships while KeyKey has two, and `languages:` — the
+    // argument that fixes it — is new in 3.4.0. `.fixed` first because the menu was making an
+    // offer the app could not keep, then `.changed` for the bump itself.
     //
-    // The entry's KEY is pinned as of 2.11.5, because kind and count alone had stopped catching
-    // anything. 2.11.3, 2.11.4 and this release are all [.changed] with one entry — three in a
-    // row — so a release that forgot to touch the notes at all would have passed this test
-    // unchanged while shipping its predecessor's text. The key names the subject, and this one
-    // moved from update delivery to the shared code, so it changes when the claim does. Compared
-    // against the same L() key WhatsNewConfig builds the entry from, so it holds in whatever
-    // language the test bundle resolves, exactly as the DragonAppMenu test below compares titles
-    // against the kit's keys. What the text SAYS is the release gate's job — it diffs the two
-    // .strings files — so between them a stale pane cannot ship.
+    // The release was drafted as maintenance-only, a single `.changed` about the bump, before the
+    // bug behind it was found; that draft would have shipped notes silent on the only thing in the
+    // release a user can notice. 2.11.2 pinned [.improved, .fixed] for a different pair.
+    //
+    // Entry KEYS are pinned, not just kinds and counts, because kinds and counts had stopped
+    // catching anything: 2.11.3, 2.11.4 and the 2.11.5 draft were all [.changed] with one entry —
+    // three in a row — so a release that forgot to touch the notes would have passed unchanged
+    // while shipping its predecessor's text. Compared against the same L() keys WhatsNewConfig
+    // builds the entries from, so this holds in whatever language the test bundle resolves,
+    // exactly as the DragonAppMenu test below compares titles against the kit's keys. What the
+    // text SAYS is the release gate's job — it diffs both .strings files — so between them a
+    // stale pane cannot ship.
     @MainActor
-    func testWhatsNewSectionsAreASingleChanged() {
+    func testWhatsNewLeadsWithTheLanguageMenuFix() {
         let content = WhatsNewConfig.content
-        XCTAssertEqual(content.sections.map(\.kind), [.changed])
-        XCTAssertEqual(content.sections.map(\.entries.count), [1])
-        XCTAssertEqual(content.sections.first?.entries.first, L("keykey.whatsNew.sharedCode"))
+        XCTAssertEqual(content.sections.map(\.kind), [.fixed, .changed])
+        XCTAssertEqual(content.sections.map(\.entries.count), [1, 1])
+        XCTAssertEqual(content.sections.flatMap(\.entries), [
+            L("keykey.whatsNew.languagePicker"),
+            L("keykey.whatsNew.sharedCode"),
+        ])
+    }
+
+    // MARK: LanguagePicker configuration
+
+    // The picker must offer exactly the languages KeyKey has translated ITSELF into, and nothing
+    // observable tied those two facts together until this test. That is how 2.11.4 shipped a menu
+    // offering Español, Français, 日本語, 한국어 and 简体中文 with no KeyKey strings behind them:
+    // App/GeneralPane.swift called LanguagePicker() bare and took the kit's default of
+    // DragonLanguage.selectable, all seven locales DragonKit ships.
+    //
+    // It cannot be asserted through the type. LanguagePicker keeps `languages` private and
+    // `offeredLanguages` internal, so a constructed picker reveals nothing to an app-side test —
+    // and App/GeneralPane.swift is not one of the files symlinked into this package, so the call
+    // site is not reachable as code either. What is reachable is the pair of artifacts that must
+    // agree: the argument written at the call site, and the .lproj directories that exist. Reading
+    // those from disk is how the sibling engine suites reach Resources/, and comparing source text
+    // against the repo is what Scripts/dragon-conformance.py does with these same files.
+    //
+    // Fails in every direction that matters: a new App/ja.lproj without widening the picker,
+    // widening the picker without shipping the .lproj, and reverting to a bare LanguagePicker().
+    @MainActor
+    func testLanguagePickerOffersExactlyTheShippedLocalizations() throws {
+        var dir = URL(fileURLWithPath: #filePath)
+        var found: URL?
+        for _ in 0..<8 {
+            dir = dir.deletingLastPathComponent()
+            if FileManager.default.fileExists(atPath: dir.appendingPathComponent("App/GeneralPane.swift").path) {
+                found = dir.appendingPathComponent("App")
+                break
+            }
+        }
+        guard let appDir = found else { throw XCTSkip("App/GeneralPane.swift not present above this package") }
+
+        // Comment lines go first, so prose naming the call cannot satisfy the search below.
+        let code = try String(contentsOf: appDir.appendingPathComponent("GeneralPane.swift"), encoding: .utf8)
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+
+        guard let call = code.range(of: "LanguagePicker(languages:"),
+              let open = code.range(of: "[", range: call.upperBound..<code.endIndex),
+              let close = code.range(of: "]", range: open.upperBound..<code.endIndex) else {
+            return XCTFail("""
+                App/GeneralPane.swift passes no explicit `languages:` to LanguagePicker, so it takes \
+                the kit's default of DragonLanguage.selectable — all seven locales DragonKit ships, \
+                against the \(shippedLocalizations(in: appDir).count) KeyKey is translated into.
+                """)
+        }
+
+        let tokens = code[open.upperBound..<close.lowerBound]
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).trimmingCharacters(in: CharacterSet(charactersIn: ".")) }
+            .filter { !$0.isEmpty }
+        // Case names in source ("zhHant") to locale codes ("zh-Hant"), which is what an .lproj is
+        // named. Asserting the count survives the mapping stops an unrecognized token from being
+        // dropped and letting both sides agree by being equally short.
+        let offered = Set(tokens.compactMap { token in
+            DragonLanguage.allCases.first { String(describing: $0) == token }?.rawValue
+        })
+        XCTAssertEqual(offered.count, tokens.count,
+                       "a language in the picker's list matches no DragonLanguage case: \(tokens)")
+
+        XCTAssertEqual(offered, shippedLocalizations(in: appDir),
+                       "the Language picker and App/*.lproj disagree")
+    }
+
+    /// The locale codes KeyKey ships its own strings in, read from the `.lproj` directories.
+    private func shippedLocalizations(in appDir: URL) -> Set<String> {
+        let names = (try? FileManager.default.contentsOfDirectory(atPath: appDir.path)) ?? []
+        return Set(names.filter { $0.hasSuffix(".lproj") }.map { String($0.dropLast(".lproj".count)) })
     }
 
     // MARK: DragonAppMenu contract

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
@@ -85,19 +85,26 @@ final class ConfigContentTests: XCTestCase {
         XCTAssertEqual(content.date, "2026-08-11")
     }
 
-    // 2.11.4 is maintenance only: one `.changed` entry, SUFeedURL moving to this repository's
-    // copy of the appcast. `.changed` and not `.fixed` because nothing was broken.
+    // 2.11.5 is maintenance only: one `.changed` entry, the DragonKit pin moving to 3.4.0.
+    // `.changed` and not `.fixed` because nothing was broken, and not `.improved` because the bump
+    // is for pin currency rather than to adopt an API. 2.11.2 pinned [.improved, .fixed] for a
+    // different pair; changing what the pane claims has to change this too, which is the point.
     //
-    // Same shape as 2.11.3 by coincidence, not by drift — that release was the other half of the
-    // same migration (publish to both, then point the app at the new one), so both are one
-    // `.changed` entry about update delivery. The entry TEXT differs, which is what the release
-    // gate checks; this pins the shape. 2.11.2 pinned [.improved, .fixed] for a different pair.
-    // Changing what the pane claims has to change this too, which is the point.
+    // The entry's KEY is pinned as of 2.11.5, because kind and count alone had stopped catching
+    // anything. 2.11.3, 2.11.4 and this release are all [.changed] with one entry — three in a
+    // row — so a release that forgot to touch the notes at all would have passed this test
+    // unchanged while shipping its predecessor's text. The key names the subject, and this one
+    // moved from update delivery to the shared code, so it changes when the claim does. Compared
+    // against the same L() key WhatsNewConfig builds the entry from, so it holds in whatever
+    // language the test bundle resolves, exactly as the DragonAppMenu test below compares titles
+    // against the kit's keys. What the text SAYS is the release gate's job — it diffs the two
+    // .strings files — so between them a stale pane cannot ship.
     @MainActor
     func testWhatsNewSectionsAreASingleChanged() {
         let content = WhatsNewConfig.content
         XCTAssertEqual(content.sections.map(\.kind), [.changed])
         XCTAssertEqual(content.sections.map(\.entries.count), [1])
+        XCTAssertEqual(content.sections.first?.entries.first, L("keykey.whatsNew.sharedCode"))
     }
 
     // MARK: DragonAppMenu contract


### PR DESCRIPTION
## What this is

The 2.11.5 release commit, plus the bug fix that changed what 2.11.5 *is*. `App/Info.plist`
goes 2.11.4 → 2.11.5. **No tag is pushed by this PR.**

It is two commits on purpose, because the second reverses the first's framing and the history
is worth keeping:

| commit | |
|---|---|
| 596e65f | `release: 2.11.5` — version bump, notes drafted as maintenance-only, `ConfigContentTests` key pin |
| 6895fb0 | `fix(settings):` — the Language-menu bug found while verifying the DragonKit bump, and the notes rewritten to lead with it |

## The bug

`App/GeneralPane.swift` called the kit's picker bare:

```swift
LanguagePicker()
```

`languages:` defaults to `DragonLanguage.selectable` — **all seven** locales DragonKit ships
(en, es, fr, ja, ko, zh-Hans, zh-Hant) — while Yahoo! KeyKey 2 has translated itself into
**two**, `App/en.lproj` and `App/zh-Hant.lproj`. So Settings offered Español, Français, 日本語,
한국어 and 简体中文, and choosing one translated the kit's About / What's New / Updates /
Uninstall panes while every KeyKey string fell back to English. This is live in the shipping
app, not hypothetical.

Confirmed in the built bundle rather than argued from the source:

```
$ ls build/YahooKeyKey2.app/Contents/Resources/ | grep lproj
en.lproj
zh-Hant.lproj
$ find build/YahooKeyKey2.app -name '*.lproj' -path '*DragonKit*'
en.lproj es.lproj fr.lproj ja.lproj ko.lproj zh-hans.lproj zh-hant.lproj
```

## The fix

```swift
LanguagePicker(languages: [.en, .zhHant])
```

No `onChange:`. The kit's own documentation reserves it for apps whose strings cannot switch
live — ice-2 mirrors the choice into `AppleLanguages` and relaunches — and states that an app
using `L()` "should leave this `nil`", because `dragonLocalized()` re-resolves in place. Every
KeyKey string goes through `L()`.

**Nobody is stranded on a language that just left the menu.** The kit's
`LanguagePicker.offeredLanguages(configured:selection:)` appends a persisted selection that
falls outside the configured set, precisely because narrowing the set otherwise orphans it and
SwiftUI draws a `Picker` whose selection matches no tag as blank. A user sitting on 日本語 still
sees 日本語 and can move off it. Verified in `vendor/dragon-kit`, not assumed.

The `languages:` argument is new in **DragonKit 3.4.0 — the pin this same release bumps** — so
the fix and the bump are one story. The notes say so.

## Release notes

`.fixed` leads, `.changed` follows. `.fixed` is the honest kind: the menu was making an offer
the app could not keep.

- `App/WhatsNewConfig.swift` — two sections, `[.fixed, .changed]`; new key
  `keykey.whatsNew.languagePicker` leads, `keykey.whatsNew.sharedCode` follows as the bump that
  made the fix possible. Still no explicit `version:`, so the heading keeps deriving from
  `CFBundleShortVersionString`.
- `App/en.lproj/` + `App/zh-Hant.lproj/Localizable.strings` — the new key in both, zh-Hant a
  real translation whose pane names match DragonKit's own zh-Hant strings. Key sets verified
  identical; those two are the only `.lproj` dirs under `App/`.
- `CHANGELOG.md` — leads with the fix, bump second.
- `App/Info.plist` — 2.11.4 → 2.11.5. `CFBundleVersion` left alone: it is an inert placeholder
  and `tools/build-app.sh` stamps the real monotonic number from the commit count (198 here,
  against 190 at 2.11.4), which is what Sparkle compares.

## ConfigContentTests

**Renamed** `testWhatsNewSectionsAreASingleChanged` → `testWhatsNewLeadsWithTheLanguageMenuFix`:
now `[.fixed, .changed]`, one entry each, and **both entry keys pinned**.

**Added** `testLanguagePickerOffersExactlyTheShippedLocalizations`, which compares the argument
written at the call site against the `.lproj` directories that exist on disk.

It is asserted that way because nothing else is reachable: `LanguagePicker` keeps `languages`
`private` and `offeredLanguages` internal, so a constructed picker reveals nothing to an
app-side test, and `App/GeneralPane.swift` is **not** among the files symlinked into
`Packages/KeyKeyApp`, so the call site is not visible as code either. Reading the file from disk
is how the sibling engine suites reach `Resources/`, and comparing source text against the repo
is what `Scripts/dragon-conformance.py` does with these same files. A test asserting
`[.en, .zhHant]` against a copy of itself would have been the tautology this same file just
stopped relying on.

Proven to bite in both directions before being kept:

```
# adding .ja to the picker without shipping App/ja.lproj
XCTAssertEqual failed: ("["ja", "en", "zh-Hant"]") is not equal to ("["en", "zh-Hant"]")
  - the Language picker and App/*.lproj disagree

# reverting to a bare LanguagePicker()
failed - App/GeneralPane.swift passes no explicit `languages:` to LanguagePicker, so it takes
the kit's default of DragonLanguage.selectable — all seven locales DragonKit ships, against
the 2 KeyKey is translated into.
```

The key-equality assertion added in 596e65f is kept, for the same reason: kinds and counts alone
had gone three releases without being able to fail.

## Verification

`Packages/KeyKeyEngine` — `swift test`:

```
Test Suite 'All tests' passed at 2026-08-11 16:06:02
	 Executed 194 tests, with 0 failures (0 unexpected) in 1.928 (1.942) seconds
```

`Packages/KeyKeyApp` — `swift test` (66 → **67**, the one added test):

```
Test Suite 'All tests' passed at 2026-08-11 16:05:54
	 Executed 67 tests, with 0 failures (0 unexpected) in 0.049 (0.057) seconds
```

`tools/build-app.sh` — the only check that compiles `App/GeneralPane.swift` at all, so it
matters more than usual here. Run against a removed `build/YahooKeyKey2.app`:

```
exit=0  # rebuilt from scratch against the final commit (6895fb0)
warnings/errors in build log: 0
Identifier=com.dragonapp.inputmethod.yahoo-keykey
Format=app bundle with Mach-O thin (arm64)
CodeDirectory v=20500 size=3143 flags=0x10002(adhoc,runtime) hashes=87+7 location=embedded
==> Done: build/YahooKeyKey2.app
```

```
$ plutil -extract CFBundleShortVersionString raw build/YahooKeyKey2.app/Contents/Info.plist
2.11.5
```

Conformance:

```
$ python3 ~/git/dragon-kit/Scripts/dragon-conformance.py --app . --kit ~/git/dragon-kit
DragonKit conformance — Yahoo! KeyKey 2 (62 Swift files, 45 kit types)
PASS — no violations.
```

`dragon-release-ci`'s `scripts/tag-gate.sh` What's New checks, simulated locally against
`v2.11.4`:

| check | result |
|---|---|
| all three `whats_new_path` files exist | pass |
| at least one changed since `v2.11.4` | pass — 3 files changed, 34 insertions(+), 17 deletions(-) |
| no explicit `version:` to `WhatsNewContent(` | pass — 0 matches |
| a `ChangeSection(` or maintenance wording | pass — 2 `ChangeSection(` |
| `assert_tag_matches_plist` vs `v2.11.5` | plist reads 2.11.5 |

## Not in this PR

No tag, and no merge. `v2.11.5` is pushed by hand after this merges.
