### PR TITLE
docs(release): correct four facts RELEASE.md had drifted on

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -6,8 +6,12 @@ App Store distribution is **not** used for this version.
 
 The tagged release is published by CI: [`.github/workflows/release.yml`](../.github/workflows/release.yml)
 is a thin caller that delegates to the shared pipeline
-`teddychan/dragon-release-ci/.github/workflows/release-macos.yml@v5`, which builds,
-Developer ID-signs, notarizes, staples, and zips the app.
+`teddychan/dragon-release-ci/.github/workflows/release-macos.yml@v6`, which builds,
+Developer ID-signs, notarizes, staples, and zips the app. The `@v6` pin is not
+interchangeable with the older `@v5`: v6 gates the trigger on an exact `vX.Y.Z` tag (v5's
+version parse turned a `workflow_dispatch` on a branch into version `main`) and requires
+the `whats_new_path` input, so a release whose What's New text never changed is rejected —
+see the caller's comments for why that input names the `.strings` files too.
 
 **A release ships exactly one file: the `.zip`. No `.pkg`, no `.dmg`.** That `.zip`
 (`YahooKeyKey2-<version>.zip`) is the user download, the Sparkle update payload, and
@@ -122,30 +126,52 @@ The recommended path is CI: bump the version (step 1 below), commit, then push a
 `v<version>` tag to `teddychan/yahoo-keykey-2`. `.github/workflows/release.yml`
 (GitHub-hosted macOS runner) builds, Developer ID-signs, notarizes, staples, zips,
 uploads the `.zip` to the GitHub release, publishes the EdDSA-signed appcast to
-`docs/yahoo-keykey-2/appcast.xml` on the website repo, and bumps the Homebrew cask.
+`docs/yahoo-keykey-2/appcast.xml` **in this repo**, mirrors that same file to the website
+repo, and bumps the Homebrew cask.
 It requires these repository secrets: `DEVELOPER_ID_CERT_P12_BASE64`,
 `DEVELOPER_ID_CERT_PASSWORD`, `NOTARY_KEY_P8_BASE64`, `NOTARY_KEY_ID`,
 `NOTARY_ISSUER_ID`, `PUBLIC_RELEASE_TOKEN`, `SPARKLE_EDDSA_PRIVATE_KEY` (the same
 set used by clipmenu-2 / ice-2).
 
-1. Bump `CFBundleShortVersionString` **and** `CFBundleVersion` in `App/Info.plist`.
-   `CFBundleVersion` must strictly increase — Sparkle compares it to decide what's
-   newer. (The CI build fails if the tag doesn't match `CFBundleShortVersionString`.)
+The appcast became app-owned across 2.11.3 and 2.11.4 — the caller passes `appcast_repo:
+teddychan/yahoo-keykey-2`, where it used to take the default of the marketing-site repo. A
+Sparkle appcast is update infrastructure, not marketing content, so it belongs in the app's
+own repository: an outage, a permission problem, or a rejected change on the marketing site
+then cannot interfere with update delivery. `appcast_mirror_repo:
+teddychan/www.dragonapp.com` keeps publishing the identical file to the old location for
+copies still at 2.11.3 or older, which read the site and only the site; the mirror is
+dropped at the next **minor** release. The three-step migration, and why the mirror cannot
+go sooner, is spelled out in the comments in `.github/workflows/release.yml`.
+
+1. Bump **only** `CFBundleShortVersionString` in `App/Info.plist`. (The CI build fails if
+   the tag doesn't match it.) Leave `CFBundleVersion` alone — the committed value is an
+   inert placeholder, `23` since v2.3.0. The real build number is stamped into the bundle
+   at build time from `git rev-list --count HEAD` (`tools/build-app.sh` locally, the same
+   number in CI), which is why 2.11.3 shipped build 190 and 2.11.4 build 192 while the
+   plist never moved. Sparkle does compare `CFBundleVersion` to decide what's newer — the
+   commit count is what keeps it increasing, so hand-bumping the placeholder changes
+   nothing, and "fixing" a number that is deliberately inert only wastes the next
+   releaser's time.
 
 ### Per release (manual fallback)
 
 If running locally instead of CI:
 
-1. Bump the versions as above.
+1. Bump the version as above.
 2. Run `tools/package-release.sh` with `DEVELOPER_ID_APP` (and `NOTARY_PROFILE`)
    set. In addition to the `.zip`, it writes **`build/appcast.xml`**
    (EdDSA-signed; enclosure URL → the GitHub release zip).
 3. Create the GitHub release at tag `v<version>` and upload the `.zip` — that single
    file is the entire release (first-time users download it; Sparkle updates from it).
    It must be named `YahooKeyKey2-<version>.zip` so the appcast URL matches.
-4. **Publish the appcast:** copy `build/appcast.xml` into the website repo at
-   `docs/yahoo-keykey-2/appcast.xml`, commit, and push. GitHub Pages serves it at
-   `https://www.dragonapp.com/yahoo-keykey-2/appcast.xml` — the `SUFeedURL` the app reads.
+4. **Publish the appcast:** copy `build/appcast.xml` over `docs/yahoo-keykey-2/appcast.xml`
+   **in this repo**, commit, and push. That is the file the app reads — `App/Info.plist`'s
+   `SUFeedURL` is
+   `https://raw.githubusercontent.com/teddychan/yahoo-keykey-2/main/docs/yahoo-keykey-2/appcast.xml`.
+   While the mirror is still in place ([above](#per-release-automated)), copy the same file
+   into the website repo at `docs/yahoo-keykey-2/appcast.xml` as well: GitHub Pages serves
+   it at `https://www.dragonapp.com/yahoo-keykey-2/appcast.xml`, which is the only feed
+   2.11.3 and older know about.
 5. Bump the Homebrew cask `Casks/yahoo-keykey-2.rb` in `teddychan/homebrew-tap`
    (version + the `.zip` sha256; the cask installs the app from the `.zip`).
 


### PR DESCRIPTION
`docs/RELEASE.md` described how the release used to work in four places. Each claim was verified against the current source before editing. **Docs-only** — no workflow, script, or plist changes, no restructuring, and the legacy `.pkg` section is untouched.

| Doc said | Source says |
|---|---|
| pipeline pinned `@v5` | [`release.yml:27`](.github/workflows/release.yml#L27) pins `@v6` |
| bump `CFBundleShortVersionString` **and** `CFBundleVersion` | [`tools/build-app.sh:121-125`](tools/build-app.sh#L121-L125) calls the plist value "an inert placeholder" and stamps `git rev-list --count HEAD` |
| appcast published to the website repo | `appcast_repo: teddychan/yahoo-keykey-2`, with `appcast_mirror_repo` as a temporary mirror |
| `SUFeedURL` = `www.dragonapp.com/yahoo-keykey-2/appcast.xml` | `App/Info.plist` reads the `raw.githubusercontent.com` URL in this repo |

### What changed, and why it says why

**1. `@v5` → `@v6`.** The pin is not a cosmetic bump, so the doc now says what the difference buys: v6 gates the trigger on an exact `vX.Y.Z` tag — v5's `VERSION=${TAG##*v}` left a value containing no `v` untouched, so a `workflow_dispatch` on a branch built as version `main` — and v6 requires the `whats_new_path` input, which rejects a release whose What's New text never changed. It points at the caller's comments rather than restating the reasoning there.

**2. `CFBundleVersion` is not hand-bumped.** Step 1 now says to bump **only** `CFBundleShortVersionString`. The committed `CFBundleVersion` is an inert placeholder — `23` since v2.3.0 (`9fafdec`), verified with `git show v2.4.0:App/Info.plist` and `v2.11.3` — while the real monotonic number is stamped into the bundle from `git rev-list --count HEAD`, locally by `tools/build-app.sh` and the same way in CI. That is why the published appcast advertises `sparkle:version` 190 for 2.11.3 and 192 for 2.11.4 with the plist never moving. Sparkle *does* still compare `CFBundleVersion`, so the doc keeps that fact and names the commit count as what keeps it increasing; the old phrasing was the trap — it read as an instruction to fix a number that is deliberately inert.

**3. The appcast is app-owned.** CI publishes to `docs/yahoo-keykey-2/appcast.xml` in **this** repo and mirrors the identical file to the site. The doc gives the lifecycle spec's reason — a Sparkle appcast is update infrastructure, not marketing content, so it lives in the app's own repository where an outage or a rejected change on the marketing site cannot interfere with update delivery — notes that the mirror exists for copies at 2.11.3 or older, and states that it retires at the next **minor** release. The three-step migration stays where it already is, in `release.yml`.

**4. Manual-fallback publish step.** Now copies `build/appcast.xml` over `docs/yahoo-keykey-2/appcast.xml` in this repo and quotes the actual `SUFeedURL`. It still says to copy into the website repo while the mirror is in place, because 2.11.3 and older know no other feed.

Also made "Bump the versions as above" singular in the manual fallback, since it refers to the step that no longer bumps two.

### Verification

```
python3 ~/git/dragon-kit/Scripts/dragon-conformance.py --app ~/git/yahoo-keykey-2 --kit ~/git/dragon-kit
DragonKit conformance — Yahoo! KeyKey 2 (62 Swift files, 45 kit types)
PASS — no violations.
```

No tag pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)