### PR TITLE
release: 2.12.0 — Yahoo! KeyKey 2 now speaks all seven languages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,15 +42,26 @@ jobs:
       #
       # These are the real files, not the symlinks under Packages/KeyKeyApp/Sources/KeyKeyApp/ —
       # the gate stats each path and diffs it, so it must name what git tracks.
+      #
+      # ALL SEVEN locales, not just en and zh-Hant. 2.12.0 added the other five, and a list naming
+      # only two would have let a release rewrite the notes in those two and ship the previous
+      # version's text to Spanish, French, Japanese, Korean and Simplified Chinese readers — the
+      # exact staleness this gate exists to catch, narrowed to the languages nobody on the release
+      # would be reading. Add a line here with every new .lproj.
       whats_new_path: >-
         App/WhatsNewConfig.swift
         App/en.lproj/Localizable.strings
+        App/es.lproj/Localizable.strings
+        App/fr.lproj/Localizable.strings
+        App/ja.lproj/Localizable.strings
+        App/ko.lproj/Localizable.strings
+        App/zh-Hans.lproj/Localizable.strings
         App/zh-Hant.lproj/Localizable.strings
       build_kind: script
       # Yahoo KeyKey 2 now targets the macOS 26 SDK, so build on the macos-26 image.
       swiftpm_runner: macos-26
       app_slug: yahoo-keykey-2
-      # Moving the appcast off the marketing site. Steps 1 and 2 are done; the mirror stays.
+      # Moving the appcast off the marketing site. DONE as of 2.12.0 — all three steps.
       #
       # MAC-APP-RELEASE-LIFECYCLE.md: "Sparkle appcasts are update infrastructure, not marketing
       # content. Each app should host its production appcast in its own repository so an outage,
@@ -71,31 +82,36 @@ jobs:
       #                    and was current. Both copies verified byte-identical after.
       #   step 2  v2.11.4  SUFeedURL moved to
       #                    https://raw.githubusercontent.com/teddychan/yahoo-keykey-2/main/docs/yahoo-keykey-2/appcast.xml
-      #   step 3  v2.12.0  drop appcast_mirror_repo. The NEXT MINOR RELEASE retires the mirror.
+      #   step 3  v2.12.0  appcast_mirror_repo dropped — THIS release. The trigger was "the next
+      #                    minor release retires the mirror", chosen on 2026-08-11, and 2.12.0 is
+      #                    it. Nothing publishes to teddychan/www.dragonapp.com from here now.
       #
-      # That trigger was chosen on 2026-08-11, replacing "when no supported version still reads
-      # the site" — which read like a rule but named no measurable condition, so it would have
-      # stayed "later" indefinitely. The site is GitHub Pages and exposes no per-path traffic, so
-      # there is no way to observe when the last reader stops reading. A minor release is instead a
-      # real, deliberate event that already opens a PR here, so the removal rides one rather than
-      # needing its own; and Sparkle checks daily by default, so anyone who launches Yahoo! KeyKey 2
-      # even once between 2.11.4 and that release has already moved to the app-owned feed.
+      # That trigger replaced "when no supported version still reads the site" — which read like a
+      # rule but named no measurable condition, so it would have stayed "later" indefinitely. The
+      # site is GitHub Pages and exposes no per-path traffic, so there is no way to observe when the
+      # last reader stops reading. A minor release is instead a real, deliberate event that already
+      # opens a PR here, so the removal rode one rather than needing its own; and Sparkle checks
+      # daily by default, so anyone who launched Yahoo! KeyKey 2 even once between 2.11.4 and this
+      # release has already moved to the app-owned feed.
       #
-      # Do not drop the mirror before then. Every copy still at 2.11.3 or older reads the site and
-      # only the site; the mirror is the whole reason flipping SUFeedURL did not strand them.
-      # The accepted cost is the other direction: shipping no minor for a long time keeps the
-      # mirror that long. That is the safe way to be wrong — an unnecessary mirror costs one extra
-      # publish per release, while a premature drop silently strands installs that cannot tell the
-      # difference between "no update" and "feed gone".
+      # The residual risk, stated plainly rather than left implied: a copy still at 2.11.3 or older
+      # reads the site and only the site, and the site's copy stops being updated after this
+      # release. Such a copy has not launched since 2.11.4 shipped, so it was already choosing not
+      # to update; it sees "no update available" rather than an error, and reinstalling from the
+      # GitHub release recovers it. The site's existing appcast.xml is deliberately NOT deleted —
+      # it goes stale, which is a silent no-op for those copies, where a 404 would be a visible
+      # Sparkle failure.
       #
-      # Needs dragon-release-ci >= v6.3.0. The appcast is generated once and copied to both, so
-      # the two cannot disagree — including the minimumSystemVersion/hardwareRequirements that
-      # appcast_inject_keykey_requirements adds below, which are injected before the copy.
-      # Publishing here uses the built-in GITHUB_TOKEN (contents: write is granted above); the
-      # mirror needs PUBLIC_RELEASE_TOKEN, which `secrets: inherit` already supplies — the same
-      # token that publishes to the site today. A missing mirror token is a hard error.
+      # Omitting appcast_mirror_repo is not a workaround — empty is its documented default, which
+      # release-macos.yml calls "every app's steady state". Keep the dragon-release-ci >= v6.3.0
+      # floor anyway: re-adding a mirror later must not silently do nothing on an older pin.
+      #
+      # appcast_repo is THIS repository, so the appcast publish can use the built-in GITHUB_TOKEN
+      # (contents: write is granted above) — the mirror was the only cross-repo appcast destination,
+      # and cross-repo is what needed PUBLIC_RELEASE_TOKEN. That secret is still required, just not
+      # for the appcast: dragon-release-ci uses it for the Homebrew cask bump and the site-changelog
+      # dispatch, and skips both with a warning when it is unset. So keep inheriting it.
       appcast_repo: teddychan/yahoo-keykey-2
-      appcast_mirror_repo: teddychan/www.dragonapp.com
       release_title_prefix: Yahoo KeyKey 2
       bot_name: KeyKey Release Bot
       assert_tag_matches_plist: true

--- a/App/GeneralPane.swift
+++ b/App/GeneralPane.swift
@@ -60,24 +60,29 @@ private struct GeneralPaneView: View {
             }
 
             DragonSection(LocalizedStringKey(L("keykey.general.language"))) {
-                // Exactly the languages KeyKey has translated ITSELF into: App/en.lproj and
-                // App/zh-Hant.lproj. The parameter defaults to DragonLanguage.selectable — all
-                // seven locales the kit ships — and taking that default is what shipped through
-                // 2.11.4: Settings offered Español, Français, 日本語, 한국어 and 简体中文, and
-                // choosing one translated the kit's four panes while every KeyKey string fell back
-                // to English. ice-2 hit the same default first and hand-rolled its own picker,
-                // which CONFORMANCE forbids; DragonKit 3.4.0 added this argument instead, and this
-                // release is the pin bump that makes it available.
+                // No argument, which means DragonLanguage.selectable — all seven locales the kit
+                // ships. That is correct again as of 2.12.0, because KeyKey now ships all seven
+                // itself: App/{en,es,fr,ja,ko,zh-Hans,zh-Hant}.lproj.
                 //
-                // Widen this only together with a new .lproj — ConfigContentTests'
-                // testLanguagePickerOffersExactlyTheShippedLocalizations compares the two and
-                // fails in either direction.
+                // It was NOT correct through 2.11.4, when this same bare call shipped against two
+                // .lproj — Settings offered Español, Français, 日本語, 한국어 and 简体中文, and
+                // choosing one translated the shared panes while every KeyKey string fell back to
+                // English. 2.11.5 narrowed it to `languages: [.en, .zhHant]`, which was the honest
+                // list for a two-language app; this release closes the gap the other way instead,
+                // so the narrowing is no longer needed.
+                //
+                // Bare rather than a literal seven, so the day the kit adds an eighth locale the
+                // picker offers it and the checks below fail loudly, instead of a stale list
+                // quietly hiding a language KeyKey has not translated yet. What keeps that honest:
+                // ConfigContentTests' testLanguagePickerOffersExactlyTheShippedLocalizations, and
+                // DragonKit CONFORMANCE §R13, which compares this call site against App/*.lproj
+                // for every Dragon app rather than only this one.
                 //
                 // No onChange: it exists for apps whose own strings cannot switch live (ice-2
                 // mirrors the choice into AppleLanguages and relaunches). Every KeyKey string is
                 // read through L(), which dragonLocalized() re-resolves in place, so there is
                 // nothing to relaunch for.
-                LanguagePicker(languages: [.en, .zhHant])
+                LanguagePicker()
             }
         }
     }

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.11.6</string>
+	<string>2.12.0</string>
 	<key>CFBundleVersion</key>
 	<string>23</string>
 	<key>ComponentInputModeDict</key>

--- a/App/WhatsNewConfig.swift
+++ b/App/WhatsNewConfig.swift
@@ -6,26 +6,28 @@ import DragonKit
 // binary isn't. That makes the entries and the date the only things to keep in sync with
 // CHANGELOG.md on release.
 //
-// 2.11.6 is maintenance, and unlike 2.11.5 it stayed that way. It bumps the DragonKit pin to
-// 4.0.0, a BREAKING kit release that turns the About pane's rows from a convention into the
-// initializer's own signature: the licences page is a required argument, and the upstream
-// project's repository moved inside OriginalWork so the `Original project` link and the
-// `Based on` credit are one value that cannot be supplied by halves.
+// 2.12.0 adds the five localizations KeyKey did not have: App/{es,fr,ja,ko,zh-Hans}.lproj, beside
+// the en and zh-Hant it shipped with. One `.added` entry, because that is the whole of what a user
+// can notice.
 //
-// Nothing on screen moves here, which is the point worth stating rather than dressing up.
-// yahoo-keykey-2 was the app that already had all four link rows and the single-holder copyright
-// — its own AboutConfig comment is what settled the copyright canon for the other four — so the
-// migration was mechanical and the pane it produces is byte-for-byte the arrangement 2.11.2
-// shipped. The one visible difference is the DragonKit version the About pane reports.
+// This closes 2.11.5 from the other side. That release NARROWED the Language menu to [.en, .zhHant]
+// because the bare LanguagePicker() took the kit's default of all seven locales while KeyKey had
+// two, so choosing one of the other five translated the shared panes and left every KeyKey string
+// in English. Narrowing was the honest fix for a two-language app; translating the app is the fix
+// that lets the menu open back up. App/GeneralPane.swift is bare again as a result, and it is bare
+// rather than a literal list of seven on purpose — see the comment there.
 //
-// So: one `.changed` entry, no `.fixed`. Writing this up as a fix would claim a defect this app
-// never had, and the honest version of "the shared code now enforces what we were already doing"
-// is a single line about the bump. 2.11.3 and 2.11.4 were both a lone `.changed` for the same
-// reason.
+// Deliberately NOT in the notes: this release also drops appcast_mirror_repo from
+// .github/workflows/release.yml, the step-3 retirement that file has been committed to since
+// 2.11.3 and that names the next MINOR release as its trigger — 2.11.6 was a patch and correctly
+// left it alone; this is the release the trigger meant. It is invisible either way, since
+// installed copies have read the app-owned feed since 2.11.4, and the notes describe what a user
+// can see. CHANGELOG.md carries it as an under-the-hood line.
 //
-// 2.11.5's language-menu entry is not carried forward, and keykey.whatsNew.languagePicker is
-// deleted with it. The pane describes this version, not the accumulated history — that is
-// CHANGELOG.md's job.
+// The DragonKit pin does not move here — 2.11.6 already took it to 4.0.0 — so there is no
+// `.changed` for it, and `keykey.whatsNew.sharedCode` is deleted with that release's entry. 2.11.5
+// and 2.11.6 both carried a pin entry because the bump was the substance of those releases;
+// repeating it every time is the padding those entries avoided.
 enum WhatsNewConfig {
     @MainActor
     static var content: WhatsNewContent {
@@ -33,8 +35,8 @@ enum WhatsNewConfig {
             date: "2026-08-11",
             summary: L("keykey.whatsNew.summary"),
             sections: [
-                ChangeSection(kind: .changed, entries: [
-                    L("keykey.whatsNew.sharedCode"),
+                ChangeSection(kind: .added, entries: [
+                    L("keykey.whatsNew.allLanguages"),
                 ]),
             ]
         )

--- a/App/en.lproj/Localizable.strings
+++ b/App/en.lproj/Localizable.strings
@@ -28,9 +28,9 @@
 "keykey.general.strokeConfirmationHint" = "In 速成, and in 倉頡 with the * wildcard, candidates appear before the code is finished, so Space flips to the next page instead of confirming what you typed. With this on, the first Space only confirms the code and keeps page 1 — press Space again to page, or 1–9 to pick. Plain 倉頡 is unaffected.";
 "keykey.general.language" = "Language";
 
-/* What's New pane (2.11.6) */
-"keykey.whatsNew.summary" = "Housekeeping only. Yahoo! KeyKey 2 is built with a new version of the code it shares with the other Dragon apps. Nothing about typing changes, and nothing in the app moves.";
-"keykey.whatsNew.sharedCode" = "Yahoo! KeyKey 2 is now built with DragonKit 4.0.0, the shared code behind the Settings window's About, What's New, Backup & Restore, Updates and Uninstall panes. This version fixes the About pane's rows in place, so none of the Dragon apps can quietly grow, drop or rename one. Yahoo! KeyKey 2's About pane already looked exactly the way the shared code now requires — it was the app the others were brought in line with — so the only thing that changes on screen is the DragonKit version the About pane reports.";
+/* What's New pane (2.12.0) */
+"keykey.whatsNew.summary" = "Yahoo! KeyKey 2 is now translated into all seven languages the Language menu offers. Nothing about typing changes.";
+"keykey.whatsNew.allLanguages" = "Yahoo! KeyKey 2 now speaks Español, Français, 日本語, 한국어 and 简体中文, alongside English and 繁體中文. Version 2.11.5 took those five out of the Language menu because they were the shared Dragon App code's languages and not Yahoo! KeyKey 2's — choosing one translated the shared Settings panes and left every other word in English. They are back, and this time every word behind them is translated too.";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "Disable Cangjie and Simplex from Input Sources";

--- a/App/es.lproj/InfoPlist.strings
+++ b/App/es.lproj/InfoPlist.strings
@@ -1,0 +1,5 @@
+CFBundleName = "Yahoo KeyKey 2";
+CFBundleDisplayName = "Yahoo KeyKey 2";
+"com.dragonapp.inputmethod.yahoo-keykey.Cangjie" = "倉頡";
+"com.dragonapp.inputmethod.yahoo-keykey.Simplex" = "速成";
+"com.dragonapp.inputmethod.yahoo-keykey.Pinyin" = "拼音";

--- a/App/es.lproj/Localizable.strings
+++ b/App/es.lproj/Localizable.strings
@@ -1,0 +1,38 @@
+/* App-specific strings for Yahoo! KeyKey 2. DragonKit's own UI strings live in its own
+   bundle (7 languages) and are not duplicated here. */
+
+/* Sidebar pane title (General). Other panes use DragonKit's built-in titles. */
+"keykey.pane.general" = "General";
+
+/* General pane */
+"keykey.general.input" = "Entrada";
+"keykey.general.outputSimplified" = "Escribir en chino simplificado";
+"keykey.general.fullWidthPunctuation" = "Puntuación de ancho completo";
+"keykey.general.associatedPhrases" = "Frases asociadas (聯想)";
+"keykey.general.associationContinuationOnly" = "Mostrar solo la continuación en las frases asociadas";
+"keykey.general.associationContinuationOnlyHint" = "Muestra 係／心／於 en lugar de 關係, como el Yahoo! KeyKey original. Lo que se confirma no cambia.";
+"keykey.general.associationTrigger" = "Tecla de selección de frases asociadas";
+"keykey.general.associationTriggerNumber" = "Tecla numérica";
+"keykey.general.associationTriggerShift" = "Mayús + número";
+"keykey.general.associationTriggerHint" = "Con «Mayús + número», una tecla numérica sola escribe el dígito en lugar de elegir una frase asociada, lo que resulta práctico para escribir números justo después de un carácter (por ejemplo, 這周有7天).";
+"keykey.general.codeHint" = "Mostrar el código Cangjie";
+"keykey.general.codeHintHint" = "Muestra el código Cangjie de cada carácter junto al candidato (por ejemplo, 倉 → 人口竹口) para ayudarte a aprender y comprobar su descomposición.";
+"keykey.general.appearance" = "Apariencia";
+"keykey.general.candidateFontSize" = "Tamaño del texto de los candidatos";
+"keykey.general.inputMethod" = "Método de entrada";
+"keykey.general.cangjieVersion" = "Versión de Cangjie";
+"keykey.general.cangjieV5" = "Cangjie de 5.ª generación";
+"keykey.general.cangjieV3" = "Cangjie de 3.ª generación (compatible con Yahoo KeyKey)";
+"keykey.general.cangjieVersionHint" = "El «Cangjie de 3.ª generación» usa la tabla de códigos y el orden de candidatos del Yahoo! KeyKey original (se aplica tanto a 倉頡 como a 速成) y surte efecto de inmediato.";
+"keykey.general.strokeConfirmation" = "Pulsar Espacio para confirmar el código";
+"keykey.general.strokeConfirmationHint" = "En 速成, y en 倉頡 con el comodín *, los candidatos aparecen antes de que el código esté terminado, así que Espacio pasa a la página siguiente en lugar de confirmar lo que has escrito. Con esta opción activada, el primer Espacio solo confirma el código y se queda en la página 1: vuelve a pulsar Espacio para cambiar de página, o 1–9 para elegir. El 倉頡 normal no se ve afectado.";
+"keykey.general.language" = "Idioma";
+
+/* What's New pane (2.12.0) */
+"keykey.whatsNew.summary" = "Yahoo! KeyKey 2 ya está traducido a los siete idiomas que ofrece el menú Idioma. Nada cambia al escribir.";
+"keykey.whatsNew.allLanguages" = "Yahoo! KeyKey 2 ahora habla Español, Français, 日本語, 한국어 y 简体中文, además de English y 繁體中文. La versión 2.11.5 retiró esos cinco del menú Idioma porque eran los idiomas del código compartido de Dragon App y no los de Yahoo! KeyKey 2: al elegir uno se traducían los paneles compartidos de Ajustes y todo lo demás se quedaba en inglés. Han vuelto, y esta vez también está traducida cada palabra que hay detrás de ellos.";
+
+/* Uninstall pane checklist */
+"keykey.uninstall.item.inputSources" = "Desactivar 倉頡 y 速成 en Fuentes de entrada";
+"keykey.uninstall.item.learningAndSettings" = "Eliminar los datos de aprendizaje y las preferencias";
+"keykey.uninstall.item.trash" = "Mover Yahoo! KeyKey 2 a la Papelera";

--- a/App/fr.lproj/InfoPlist.strings
+++ b/App/fr.lproj/InfoPlist.strings
@@ -1,0 +1,5 @@
+CFBundleName = "Yahoo KeyKey 2";
+CFBundleDisplayName = "Yahoo KeyKey 2";
+"com.dragonapp.inputmethod.yahoo-keykey.Cangjie" = "倉頡";
+"com.dragonapp.inputmethod.yahoo-keykey.Simplex" = "速成";
+"com.dragonapp.inputmethod.yahoo-keykey.Pinyin" = "拼音";

--- a/App/fr.lproj/Localizable.strings
+++ b/App/fr.lproj/Localizable.strings
@@ -1,0 +1,38 @@
+/* App-specific strings for Yahoo! KeyKey 2. DragonKit's own UI strings live in its own
+   bundle (7 languages) and are not duplicated here. */
+
+/* Sidebar pane title (General). Other panes use DragonKit's built-in titles. */
+"keykey.pane.general" = "Général";
+
+/* General pane */
+"keykey.general.input" = "Saisie";
+"keykey.general.outputSimplified" = "Écrire en chinois simplifié";
+"keykey.general.fullWidthPunctuation" = "Ponctuation pleine largeur";
+"keykey.general.associatedPhrases" = "Expressions associées (聯想)";
+"keykey.general.associationContinuationOnly" = "N’afficher que la suite dans les expressions associées";
+"keykey.general.associationContinuationOnlyHint" = "Affiche 係／心／於 au lieu de 關係, comme le Yahoo! KeyKey d’origine. Ce qui est validé ne change pas.";
+"keykey.general.associationTrigger" = "Touche de sélection des expressions associées";
+"keykey.general.associationTriggerNumber" = "Touche numérique";
+"keykey.general.associationTriggerShift" = "Maj + chiffre";
+"keykey.general.associationTriggerHint" = "Avec « Maj + chiffre », une touche numérique seule saisit le chiffre au lieu de choisir une expression associée — pratique pour taper des chiffres juste après un caractère (par exemple 這周有7天).";
+"keykey.general.codeHint" = "Afficher le code Cangjie";
+"keykey.general.codeHintHint" = "Affiche le code Cangjie de chaque caractère à côté du candidat (par exemple 倉 → 人口竹口) pour vous aider à apprendre et à vérifier sa décomposition.";
+"keykey.general.appearance" = "Apparence";
+"keykey.general.candidateFontSize" = "Taille du texte des candidats";
+"keykey.general.inputMethod" = "Méthode de saisie";
+"keykey.general.cangjieVersion" = "Version de Cangjie";
+"keykey.general.cangjieV5" = "Cangjie de 5e génération";
+"keykey.general.cangjieV3" = "Cangjie de 3e génération (compatible Yahoo KeyKey)";
+"keykey.general.cangjieVersionHint" = "Le « Cangjie de 3e génération » utilise la table de codes et l’ordre des candidats du Yahoo! KeyKey d’origine (appliqué à 倉頡 comme à 速成), avec effet immédiat.";
+"keykey.general.strokeConfirmation" = "Appuyer sur Espace pour valider le code";
+"keykey.general.strokeConfirmationHint" = "En 速成, et en 倉頡 avec le joker *, les candidats apparaissent avant que le code soit terminé : Espace passe donc à la page suivante au lieu de valider ce que vous avez tapé. Avec cette option, le premier Espace ne fait que valider le code et reste sur la page 1 — appuyez de nouveau sur Espace pour changer de page, ou sur 1–9 pour choisir. Le 倉頡 normal n’est pas affecté.";
+"keykey.general.language" = "Langue";
+
+/* What's New pane (2.12.0) */
+"keykey.whatsNew.summary" = "Yahoo! KeyKey 2 est désormais traduit dans les sept langues que propose le menu Langue. Rien ne change à la saisie.";
+"keykey.whatsNew.allLanguages" = "Yahoo! KeyKey 2 parle maintenant Español, Français, 日本語, 한국어 et 简体中文, en plus de English et 繁體中文. La version 2.11.5 avait retiré ces cinq langues du menu Langue parce qu’il s’agissait des langues du code partagé de Dragon App et non de celles de Yahoo! KeyKey 2 : en choisir une traduisait les panneaux partagés des Réglages et laissait tout le reste en anglais. Elles sont de retour, et cette fois chaque mot qui se trouve derrière elles est traduit aussi.";
+
+/* Uninstall pane checklist */
+"keykey.uninstall.item.inputSources" = "Désactiver 倉頡 et 速成 dans les sources de saisie";
+"keykey.uninstall.item.learningAndSettings" = "Supprimer les données d’apprentissage et les préférences";
+"keykey.uninstall.item.trash" = "Placer Yahoo! KeyKey 2 dans la corbeille";

--- a/App/ja.lproj/InfoPlist.strings
+++ b/App/ja.lproj/InfoPlist.strings
@@ -1,0 +1,5 @@
+CFBundleName = "Yahoo KeyKey 2";
+CFBundleDisplayName = "Yahoo KeyKey 2";
+"com.dragonapp.inputmethod.yahoo-keykey.Cangjie" = "倉頡";
+"com.dragonapp.inputmethod.yahoo-keykey.Simplex" = "速成";
+"com.dragonapp.inputmethod.yahoo-keykey.Pinyin" = "拼音";

--- a/App/ja.lproj/Localizable.strings
+++ b/App/ja.lproj/Localizable.strings
@@ -1,0 +1,38 @@
+/* App-specific strings for Yahoo! KeyKey 2. DragonKit's own UI strings live in its own
+   bundle (7 languages) and are not duplicated here. */
+
+/* Sidebar pane title (General). Other panes use DragonKit's built-in titles. */
+"keykey.pane.general" = "一般";
+
+/* General pane */
+"keykey.general.input" = "入力";
+"keykey.general.outputSimplified" = "簡体字で出力";
+"keykey.general.fullWidthPunctuation" = "全角の句読点";
+"keykey.general.associatedPhrases" = "連想入力（聯想）";
+"keykey.general.associationContinuationOnly" = "連想候補に続きの文字だけを表示";
+"keykey.general.associationContinuationOnlyHint" = "「關係」ではなく「係／心／於」を表示します（オリジナルの Yahoo! KeyKey と同じ）。確定される文字は変わりません。";
+"keykey.general.associationTrigger" = "連想候補の選択キー";
+"keykey.general.associationTriggerNumber" = "数字キー";
+"keykey.general.associationTriggerShift" = "Shift + 数字";
+"keykey.general.associationTriggerHint" = "「Shift + 数字」を選ぶと、数字キーだけを押したときは連想候補を選ばずにその数字を入力します。文字のすぐ後に数字を打つとき（例：「這周有7天」）に便利です。";
+"keykey.general.codeHint" = "倉頡コードのヒントを表示";
+"keykey.general.codeHintHint" = "候補の横にその文字の倉頡コード（例：倉 → 人口竹口）を表示し、分解の学習と確認に役立てます。";
+"keykey.general.appearance" = "外観";
+"keykey.general.candidateFontSize" = "候補の文字サイズ";
+"keykey.general.inputMethod" = "入力方式";
+"keykey.general.cangjieVersion" = "倉頡のバージョン";
+"keykey.general.cangjieV5" = "第5世代倉頡";
+"keykey.general.cangjieV3" = "第3世代倉頡（Yahoo KeyKey 互換）";
+"keykey.general.cangjieVersionHint" = "「第3世代倉頡」はオリジナルの Yahoo! KeyKey のコード表と候補順を使います（倉頡と速成の両方に適用）。すぐに反映されます。";
+"keykey.general.strokeConfirmation" = "スペースキーでコードを確定";
+"keykey.general.strokeConfirmationHint" = "速成、および * ワイルドカードを使う倉頡では、コードを打ち終わる前に候補が出るため、スペースキーは打ったコードを確定せずに次のページへ送ってしまいます。オンにすると、最初のスペースキーはコードの確定だけを行い 1 ページ目に留まります。もう一度スペースキーを押すとページが進み、1〜9 で直接選べます。通常の倉頡は影響を受けません。";
+"keykey.general.language" = "言語";
+
+/* What's New pane (2.12.0) */
+"keykey.whatsNew.summary" = "Yahoo! KeyKey 2 が「言語」メニューに並ぶ 7 言語すべてに翻訳されました。入力の動作は何も変わりません。";
+"keykey.whatsNew.allLanguages" = "Yahoo! KeyKey 2 は English と繁體中文 に加えて、Español、Français、日本語、한국어、简体中文 を話すようになりました。2.11.5 ではこの 5 言語を「言語」メニューから外しました。それらは Dragon App 共通コードの言語であって Yahoo! KeyKey 2 の言語ではなく、選んでも共通の設定パネルだけが翻訳され、ほかの文字はすべて英語のままだったからです。今回それらが戻り、しかも今度はメニューの向こう側にある言葉もすべて翻訳されています。";
+
+/* Uninstall pane checklist */
+"keykey.uninstall.item.inputSources" = "入力ソースから倉頡と速成を無効にする";
+"keykey.uninstall.item.learningAndSettings" = "学習データと環境設定を削除する";
+"keykey.uninstall.item.trash" = "Yahoo! KeyKey 2 をゴミ箱に入れる";

--- a/App/ko.lproj/InfoPlist.strings
+++ b/App/ko.lproj/InfoPlist.strings
@@ -1,0 +1,5 @@
+CFBundleName = "Yahoo KeyKey 2";
+CFBundleDisplayName = "Yahoo KeyKey 2";
+"com.dragonapp.inputmethod.yahoo-keykey.Cangjie" = "倉頡";
+"com.dragonapp.inputmethod.yahoo-keykey.Simplex" = "速成";
+"com.dragonapp.inputmethod.yahoo-keykey.Pinyin" = "拼音";

--- a/App/ko.lproj/Localizable.strings
+++ b/App/ko.lproj/Localizable.strings
@@ -1,0 +1,38 @@
+/* App-specific strings for Yahoo! KeyKey 2. DragonKit's own UI strings live in its own
+   bundle (7 languages) and are not duplicated here. */
+
+/* Sidebar pane title (General). Other panes use DragonKit's built-in titles. */
+"keykey.pane.general" = "일반";
+
+/* General pane */
+"keykey.general.input" = "입력";
+"keykey.general.outputSimplified" = "간체자로 출력";
+"keykey.general.fullWidthPunctuation" = "전각 문장 부호";
+"keykey.general.associatedPhrases" = "연상 입력(聯想)";
+"keykey.general.associationContinuationOnly" = "연상 후보에 이어지는 글자만 표시";
+"keykey.general.associationContinuationOnlyHint" = "「關係」 대신 「係／心／於」를 표시합니다(원래 Yahoo! KeyKey와 같음). 실제로 입력되는 글자는 바뀌지 않습니다.";
+"keykey.general.associationTrigger" = "연상 후보 선택 키";
+"keykey.general.associationTriggerNumber" = "숫자 키";
+"keykey.general.associationTriggerShift" = "Shift + 숫자";
+"keykey.general.associationTriggerHint" = "「Shift + 숫자」를 선택하면 숫자 키만 눌렀을 때 연상 후보를 고르지 않고 그 숫자를 입력합니다. 글자 바로 뒤에 숫자를 입력할 때(예: 「這周有7天」) 편리합니다.";
+"keykey.general.codeHint" = "창힐 코드 힌트 표시";
+"keykey.general.codeHintHint" = "후보 옆에 그 글자의 창힐 코드(예: 倉 → 人口竹口)를 표시해 분해를 익히고 확인하는 데 도움이 됩니다.";
+"keykey.general.appearance" = "모양";
+"keykey.general.candidateFontSize" = "후보 글자 크기";
+"keykey.general.inputMethod" = "입력 방식";
+"keykey.general.cangjieVersion" = "창힐 버전";
+"keykey.general.cangjieV5" = "5세대 창힐";
+"keykey.general.cangjieV3" = "3세대 창힐(Yahoo KeyKey 호환)";
+"keykey.general.cangjieVersionHint" = "「3세대 창힐」은 원래 Yahoo! KeyKey의 코드표와 후보 순서를 사용합니다(창힐과 속성 모두에 적용). 즉시 적용됩니다.";
+"keykey.general.strokeConfirmation" = "스페이스로 코드 확정";
+"keykey.general.strokeConfirmationHint" = "속성, 그리고 * 와일드카드를 사용하는 창힐에서는 코드를 다 입력하기 전에 후보가 나타나므로, 스페이스가 입력한 코드를 확정하지 않고 다음 페이지로 넘어갑니다. 이 옵션을 켜면 첫 번째 스페이스는 코드만 확정하고 1페이지에 머무릅니다. 페이지를 넘기려면 스페이스를 한 번 더 누르거나 1~9로 바로 선택하세요. 일반 창힐은 영향을 받지 않습니다.";
+"keykey.general.language" = "언어";
+
+/* What's New pane (2.12.0) */
+"keykey.whatsNew.summary" = "Yahoo! KeyKey 2가 「언어」 메뉴에 있는 7개 언어 모두로 번역되었습니다. 입력 동작은 전혀 바뀌지 않습니다.";
+"keykey.whatsNew.allLanguages" = "Yahoo! KeyKey 2는 English와 繁體中文에 더해 Español, Français, 日本語, 한국어, 简体中文를 말합니다. 2.11.5에서는 이 다섯 언어를 「언어」 메뉴에서 빼냈습니다. 그것은 Dragon App 공용 코드의 언어이지 Yahoo! KeyKey 2의 언어가 아니어서, 하나를 고르면 공용 설정 패널만 번역되고 나머지 모든 단어는 영어로 남았기 때문입니다. 이제 그 언어들이 돌아왔고, 이번에는 메뉴 뒤에 있는 모든 단어까지 번역되어 있습니다.";
+
+/* Uninstall pane checklist */
+"keykey.uninstall.item.inputSources" = "입력 소스에서 창힐과 속성 사용 중지";
+"keykey.uninstall.item.learningAndSettings" = "사용자 학습 데이터와 환경설정 삭제";
+"keykey.uninstall.item.trash" = "Yahoo! KeyKey 2를 휴지통으로 이동";

--- a/App/zh-Hans.lproj/InfoPlist.strings
+++ b/App/zh-Hans.lproj/InfoPlist.strings
@@ -1,0 +1,5 @@
+CFBundleName = "Yahoo KeyKey 2";
+CFBundleDisplayName = "Yahoo KeyKey 2";
+"com.dragonapp.inputmethod.yahoo-keykey.Cangjie" = "仓颉";
+"com.dragonapp.inputmethod.yahoo-keykey.Simplex" = "速成";
+"com.dragonapp.inputmethod.yahoo-keykey.Pinyin" = "拼音";

--- a/App/zh-Hans.lproj/Localizable.strings
+++ b/App/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,38 @@
+/* App-specific strings for Yahoo! KeyKey 2. DragonKit's own UI strings live in its own
+   bundle (7 languages) and are not duplicated here. */
+
+/* Sidebar pane title (General). Other panes use DragonKit's built-in titles. */
+"keykey.pane.general" = "通用";
+
+/* General pane */
+"keykey.general.input" = "输入";
+"keykey.general.outputSimplified" = "输出简体字";
+"keykey.general.fullWidthPunctuation" = "全角标点";
+"keykey.general.associatedPhrases" = "联想词（聯想）";
+"keykey.general.associationContinuationOnly" = "联想只显示后续字";
+"keykey.general.associationContinuationOnlyHint" = "显示「系／心／于」而非「关系」，与原版 Yahoo! KeyKey 一致。实际输入的字不变。";
+"keykey.general.associationTrigger" = "联想选字键";
+"keykey.general.associationTriggerNumber" = "数字键";
+"keykey.general.associationTriggerShift" = "Shift + 数字";
+"keykey.general.associationTriggerHint" = "选「Shift + 数字」时，单独按数字键会输入该数字，而不会选取联想词，方便在字后紧接着输入数字（例如「这周有7天」）。";
+"keykey.general.codeHint" = "反查提示";
+"keykey.general.codeHintHint" = "在候选字旁显示该字的仓颉拆码（例：仓 → 人口竹口），方便学习与核对。";
+"keykey.general.appearance" = "外观";
+"keykey.general.candidateFontSize" = "候选字大小";
+"keykey.general.inputMethod" = "输入方式";
+"keykey.general.cangjieVersion" = "仓颉版本";
+"keykey.general.cangjieV5" = "五代仓颉";
+"keykey.general.cangjieV3" = "三代仓颉（兼容 Yahoo KeyKey）";
+"keykey.general.cangjieVersionHint" = "「三代仓颉」使用 Yahoo! KeyKey 原版的拆码与候选字顺序（同时应用于仓颉与速成），立即生效。";
+"keykey.general.strokeConfirmation" = "以空格键确认字根";
+"keykey.general.strokeConfirmationHint" = "在速成、以及使用通配符（*）的仓颉中，字根还没输完就会出现候选字，此时空格键会直接翻到下一页，而不是确认你输入的字根。开启后，第一次按空格键只确认字根并停留在第 1 页；再按一次空格键才翻页，或直接按 1–9 选字。普通仓颉不受影响。";
+"keykey.general.language" = "语言";
+
+/* What's New pane (2.12.0) */
+"keykey.whatsNew.summary" = "Yahoo! KeyKey 2 现已翻译成「语言」菜单所列出的全部七种语言。打字的部分完全没有改变。";
+"keykey.whatsNew.allLanguages" = "除了 English 与繁體中文，Yahoo! KeyKey 2 现在也会说 Español、Français、日本語、한국어 与简体中文。2.11.5 曾把这五种语言从「语言」菜单中移除，因为那是 Dragon App 共用代码的语言，而不是 Yahoo! KeyKey 2 的——选了其中任何一个，只有共用的设置面板会被翻译，其余文字全都退回英文。现在它们回来了，而且这一次，菜单背后的每一个字也都翻译好了。";
+
+/* Uninstall pane checklist */
+"keykey.uninstall.item.inputSources" = "从输入源中停用仓颉与速成";
+"keykey.uninstall.item.learningAndSettings" = "删除用户学习数据与偏好设置";
+"keykey.uninstall.item.trash" = "将 Yahoo! KeyKey 2 移到废纸篓";

--- a/App/zh-Hant.lproj/Localizable.strings
+++ b/App/zh-Hant.lproj/Localizable.strings
@@ -28,9 +28,9 @@
 "keykey.general.strokeConfirmationHint" = "在速成、以及使用萬用字元（*）的倉頡中，字根還沒打完就會出現候選字，此時空白鍵會直接翻到下一頁，而不是確認你打的字根。開啟後，第一次按空白鍵只會確認字根並停留在第 1 頁；再按一次空白鍵才翻頁，或直接按 1–9 選字。一般倉頡不受影響。";
 "keykey.general.language" = "語言";
 
-/* What's New pane (2.11.6) */
-"keykey.whatsNew.summary" = "這一版只是例行維護。Yahoo! KeyKey 2 改用新版的共用程式碼建構，那是各個 Dragon App 共同使用的部分。打字的部分完全沒有改變，介面也沒有任何移動。";
-"keykey.whatsNew.sharedCode" = "Yahoo! KeyKey 2 現在改用 DragonKit 4.0.0 建構，那是設定視窗中「關於」、「新功能」、「備份與還原」、「更新」與「解除安裝」各面板共用的程式碼。這一版把「關於」面板的各列固定下來，讓任何一個 Dragon App 都無法再私自增加、刪除或改名其中一列。Yahoo! KeyKey 2 的「關於」面板原本就與共用程式碼現在要求的樣子完全一致——其他幾個 App 正是以它為準對齊的——所以畫面上唯一的變化，就是「關於」面板顯示的 DragonKit 版本號。";
+/* What's New pane (2.12.0) */
+"keykey.whatsNew.summary" = "Yahoo! KeyKey 2 現在已翻譯成「語言」選單所列出的全部七種語言。打字的部分完全沒有改變。";
+"keykey.whatsNew.allLanguages" = "除了 English 與繁體中文，Yahoo! KeyKey 2 現在也會說 Español、Français、日本語、한국어 與简体中文。2.11.5 把這五種語言從「語言」選單移除，因為那是 Dragon App 共用程式碼的語言，而不是 Yahoo! KeyKey 2 的——選了其中任何一個，只有共用的設定面板會被翻譯，其餘文字全都退回英文。現在它們回來了，而且這一次，選單背後的每一個字也都翻譯好了。";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "從輸入來源中停用倉頡與速成";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 A plain-language list of changes in each version, newest first.
 
+## 2.12.0
+
+- **Added: Yahoo! KeyKey 2 now speaks all seven languages the Language menu offers.** Español,
+  Français, 日本語, 한국어 and 简体中文 join English and 繁體中文, and every word of Yahoo! KeyKey 2's
+  own interface is translated into each — the General pane and its explanations, the uninstall
+  checklist, and these release notes. 2.11.5 took those five languages out of the menu because they
+  were the shared Dragon App code's languages and not Yahoo! KeyKey 2's, so choosing one translated
+  the shared Settings panes and left everything else in English. This release closes that gap from
+  the other side, so the menu offers them again and means it. In System Settings ▸ Keyboard ▸ Input
+  Sources, a Simplified Chinese system now sees 仓颉 and 速成 written in simplified characters.
+- **Under the hood: the update feed no longer publishes a copy to the website.** Yahoo! KeyKey 2 has
+  read its updates from this repository since 2.11.4, and the website copy existed only so that
+  copies still on 2.11.3 or older — which read the website and nothing else — were not cut off
+  while everyone moved across. Since Sparkle checks daily, anyone who has launched the app even
+  once since 2.11.4 moved long ago. Nothing changes for them. A copy that has not been launched in
+  all that time will report no updates available rather than an error; reinstalling from the
+  releases page brings it back. The website's old file is left in place, stale, rather than
+  deleted, because a stale file is a quiet no-op where a missing one would be a visible failure.
+
 ## 2.11.6
 
 - **Under the hood: updated to DragonKit 4.0.0** (from 3.4.0), the shared code behind the Settings

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
@@ -91,29 +91,31 @@ final class ConfigContentTests: XCTestCase {
         XCTAssertEqual(content.date, "2026-08-11")
     }
 
-    // 2.11.6 is a lone `.changed`: the DragonKit pin moves to 4.0.0, which makes the About pane's
-    // rows the initializer's own signature rather than a convention five apps followed by hand.
-    // No `.fixed`, deliberately — this app's About pane was the correct one, so the migration
-    // changed no behaviour and claiming a fix would invent a defect KeyKey never had. 2.11.5 was
-    // [.fixed, .changed] for a real bug the bump exposed; 2.11.2 was [.improved, .fixed].
+    // 2.12.0 is a single `.added`: the five localizations KeyKey did not have. It closes 2.11.5
+    // from the other side — that release narrowed the Language menu to the two languages KeyKey
+    // actually had, and this one translates the app so the menu can open back up.
+    //
+    // Only one entry, and deliberately no `.changed`. The DragonKit pin does not move — 2.11.6
+    // already took it to 4.0.0 — and the appcast mirror this release retires is invisible, since
+    // installed copies have read the app-owned feed since 2.11.4. 2.11.5 and 2.11.6 each carried a
+    // pin entry because the bump was the substance of those releases; repeating it every time is
+    // the padding those entries avoided. 2.11.2 pinned [.improved, .fixed] for a different pair.
     //
     // Entry KEYS are pinned, not just kinds and counts, because kinds and counts had stopped
     // catching anything: 2.11.3, 2.11.4 and the 2.11.5 draft were all [.changed] with one entry —
     // three in a row — so a release that forgot to touch the notes would have passed unchanged
-    // while shipping its predecessor's text. That is live again here, 2.11.6 being a single
-    // `.changed` reusing the sharedCode key, and the keys alone would not have caught it either:
-    // what makes this assertion bite is that keykey.whatsNew.languagePicker is gone from the list.
-    // Compared against the same L() keys WhatsNewConfig builds the entries from, so this holds in
-    // whatever language the test bundle resolves, exactly as the DragonAppMenu test below compares
-    // titles against the kit's keys. What the text SAYS is the release gate's job — it diffs both
-    // .strings files — so between them a stale pane cannot ship.
+    // while shipping its predecessor's text. Compared against the same L() keys WhatsNewConfig
+    // builds the entries from, so this holds in whatever language the test bundle resolves,
+    // exactly as the DragonAppMenu test below compares titles against the kit's keys. What the
+    // text SAYS is the release gate's job — it diffs every locale's .strings file — so between
+    // them a stale pane cannot ship.
     @MainActor
-    func testWhatsNewIsTheSharedCodeBumpAlone() {
+    func testWhatsNewAnnouncesTheNewLocalizations() {
         let content = WhatsNewConfig.content
-        XCTAssertEqual(content.sections.map(\.kind), [.changed])
+        XCTAssertEqual(content.sections.map(\.kind), [.added])
         XCTAssertEqual(content.sections.map(\.entries.count), [1])
         XCTAssertEqual(content.sections.flatMap(\.entries), [
-            L("keykey.whatsNew.sharedCode"),
+            L("keykey.whatsNew.allLanguages"),
         ])
     }
 
@@ -133,8 +135,16 @@ final class ConfigContentTests: XCTestCase {
     // those from disk is how the sibling engine suites reach Resources/, and comparing source text
     // against the repo is what Scripts/dragon-conformance.py does with these same files.
     //
-    // Fails in every direction that matters: a new App/ja.lproj without widening the picker,
-    // widening the picker without shipping the .lproj, and reverting to a bare LanguagePicker().
+    // A bare call is not itself the bug, and asserting that an explicit `languages:` exists was
+    // the wrong shape of test: as of 2.12.0 KeyKey ships all seven .lproj, so the kit's default IS
+    // the correct list and App/GeneralPane.swift is bare again. What matters is only whether the
+    // two sets agree, so this resolves a bare call to DragonLanguage.selectable and compares that,
+    // exactly as DragonKit CONFORMANCE §R13 now does for all five Dragon apps.
+    //
+    // Fails in every direction that matters: dropping a locale without narrowing the picker,
+    // narrowing the picker while the .lproj is still shipped, a hand-written list that disagrees
+    // with disk, and deleting the picker altogether. The one thing it can no longer fail on is the
+    // shape of the call — which is right, because both shapes are correct for some app.
     @MainActor
     func testLanguagePickerOffersExactlyTheShippedLocalizations() throws {
         var dir = URL(fileURLWithPath: #filePath)
@@ -154,31 +164,75 @@ final class ConfigContentTests: XCTestCase {
             .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
             .joined(separator: "\n")
 
-        guard let call = code.range(of: "LanguagePicker(languages:"),
-              let open = code.range(of: "[", range: call.upperBound..<code.endIndex),
-              let close = code.range(of: "]", range: open.upperBound..<code.endIndex) else {
-            return XCTFail("""
-                App/GeneralPane.swift passes no explicit `languages:` to LanguagePicker, so it takes \
-                the kit's default of DragonLanguage.selectable — all seven locales DragonKit ships, \
-                against the \(shippedLocalizations(in: appDir).count) KeyKey is translated into.
-                """)
+        // Deleting the picker would otherwise leave nothing to compare, and a comparison with no
+        // subject passes.
+        guard code.range(of: "LanguagePicker(") != nil else {
+            return XCTFail("App/GeneralPane.swift no longer constructs a LanguagePicker")
         }
 
-        let tokens = code[open.upperBound..<close.lowerBound]
-            .split(separator: ",")
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).trimmingCharacters(in: CharacterSet(charactersIn: ".")) }
-            .filter { !$0.isEmpty }
-        // Case names in source ("zhHant") to locale codes ("zh-Hant"), which is what an .lproj is
-        // named. Asserting the count survives the mapping stops an unrecognized token from being
-        // dropped and letting both sides agree by being equally short.
-        let offered = Set(tokens.compactMap { token in
-            DragonLanguage.allCases.first { String(describing: $0) == token }?.rawValue
-        })
-        XCTAssertEqual(offered.count, tokens.count,
-                       "a language in the picker's list matches no DragonLanguage case: \(tokens)")
+        let offered: Set<String>
+        if let call = code.range(of: "LanguagePicker(languages:"),
+           let open = code.range(of: "[", range: call.upperBound..<code.endIndex),
+           let close = code.range(of: "]", range: open.upperBound..<code.endIndex) {
+            let tokens = code[open.upperBound..<close.lowerBound]
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).trimmingCharacters(in: CharacterSet(charactersIn: ".")) }
+                .filter { !$0.isEmpty }
+            // Case names in source ("zhHant") to locale codes ("zh-Hant"), which is what an .lproj
+            // is named. Asserting the count survives the mapping stops an unrecognized token from
+            // being dropped and letting both sides agree by being equally short.
+            offered = Set(tokens.compactMap { token in
+                DragonLanguage.allCases.first { String(describing: $0) == token }?.rawValue
+            })
+            XCTAssertEqual(offered.count, tokens.count,
+                           "a language in the picker's list matches no DragonLanguage case: \(tokens)")
+        } else {
+            // No argument means the kit's default. Read from DragonLanguage rather than written out
+            // as seven codes, so the day the kit adds an eighth this fails against App/*.lproj
+            // instead of comparing against a list that stopped describing the picker.
+            offered = Set(DragonLanguage.selectable.map(\.rawValue))
+        }
 
         XCTAssertEqual(offered, shippedLocalizations(in: appDir),
                        "the Language picker and App/*.lproj disagree")
+    }
+
+    // Every locale must define the same keys. A key present in en.lproj and missing from ko.lproj
+    // falls back to English silently — no crash, no warning, just one English row in an otherwise
+    // Korean pane — and going from two locales to seven multiplies the places that can happen.
+    // DragonKit pins its own seven the same way (LocalizationTests.allLanguagesDefineTheSameKeys);
+    // nothing pinned KeyKey's until now, which was survivable at two files and is not at seven.
+    func testEveryLocalizationDefinesTheSameKeys() throws {
+        var dir = URL(fileURLWithPath: #filePath)
+        var found: URL?
+        for _ in 0..<8 {
+            dir = dir.deletingLastPathComponent()
+            if FileManager.default.fileExists(atPath: dir.appendingPathComponent("App/GeneralPane.swift").path) {
+                found = dir.appendingPathComponent("App")
+                break
+            }
+        }
+        guard let appDir = found else { throw XCTSkip("App/ not present above this package") }
+
+        let locales = shippedLocalizations(in: appDir).sorted()
+        XCTAssertTrue(locales.contains("en"), "no en.lproj to compare the others against")
+
+        func keys(_ locale: String) throws -> Set<String> {
+            let url = appDir.appendingPathComponent("\(locale).lproj/Localizable.strings")
+            let table = try XCTUnwrap(NSDictionary(contentsOf: url) as? [String: String],
+                                      "\(locale).lproj/Localizable.strings is missing or malformed")
+            // An empty value resolves to "" and renders as a blank row, which reads as a layout bug
+            // rather than a missing translation, so it is caught here and not left to a screenshot.
+            XCTAssertEqual(table.filter { $0.value.isEmpty }.map(\.key), [],
+                           "\(locale) has empty values")
+            return Set(table.keys)
+        }
+
+        let english = try keys("en")
+        XCTAssertFalse(english.isEmpty)
+        for locale in locales where locale != "en" {
+            XCTAssertEqual(try keys(locale), english, "\(locale) key set differs from en")
+        }
     }
 
     /// The locale codes KeyKey ships its own strings in, read from the `.lproj` directories.


### PR DESCRIPTION
Adds `App/{es,fr,ja,ko,zh-Hans}.lproj` beside the `en` and `zh-Hant` KeyKey shipped with, so its own 28 strings are translated into every language the Language menu offers.

## Why

This closes 2.11.5 from the other side. That release **narrowed** the menu to `languages: [.en, .zhHant]`, because the bare `LanguagePicker()` took DragonKit's default of all seven locales while KeyKey had two — so choosing one of the other five translated the shared panes and left every KeyKey string in English. Narrowing was the honest fix for a two-language app; translating the app is what lets the menu open back up.

`App/GeneralPane.swift` is therefore **bare again** — and bare rather than a literal list of seven on purpose, so the day the kit adds an eighth locale the checks fail loudly instead of a stale list quietly hiding an untranslated language.

## ⚠️ The translations are mine, not a native speaker's

Worth a review pass before the tag. What I held fixed:

- **Proper nouns intact** — 倉頡 / 速成 / 拼音, Yahoo! KeyKey, DragonKit.
- **Illustrative Chinese examples intact** — 倉 → 人口竹口, 這周有7天, 係／心／於.
- **zh-Hans is the one that also changes `InfoPlist.strings`.** System Settings ▸ Keyboard ▸ Input Sources lists the mode names, so a Simplified system now reads 仓颉 rather than 倉頡. The other four keep the Chinese names, matching what `en.lproj` already did.
- Terminology follows Apple's per-locale conventions where they differ: 通用/全角/废纸篓 for zh-Hans, 창힐/속성 for the Cangjie and Simplex names in Korean.

## Also in this release

**The appcast mirror is retired.** `release.yml` has carried `step 3 v2.12.0 — drop appcast_mirror_repo. The NEXT MINOR RELEASE retires the mirror.` since 2.11.3, and this is that release. Verified upstream that the input is optional — empty is its documented default, *"every app's steady state"*. `PUBLIC_RELEASE_TOKEN` is still inherited: it is no longer needed for the appcast (`appcast_repo` is this repository, so `GITHUB_TOKEN` suffices) but dragon-release-ci still uses it for the Homebrew cask bump and the site-changelog dispatch. The site's stale `appcast.xml` is deliberately left in place — for a copy that has not launched since 2.11.4, a stale feed is a silent no-op where a 404 would be a visible Sparkle failure.

**The release gate's `whats_new_path` now covers all seven locale files.** Naming only `en` and `zh-Hant` would have let a release rewrite the notes in those two and ship the previous version's text to the five nobody on the release reads.

## Tests

`testLanguagePickerOffersExactlyTheShippedLocalizations` no longer asserts that an explicit `languages:` exists — that was the wrong shape of test, since the kit's default is now the correct list. It resolves a bare call to `DragonLanguage.selectable` and compares the sets, exactly as DragonKit CONFORMANCE §R13 does, and additionally fails if the picker is deleted outright.

New `testEveryLocalizationDefinesTheSameKeys` pins key parity across all seven and rejects empty values. Going from two locale files to seven multiplies the places a silent English fallback can hide, and nothing pinned it before.

## Verification

| Check | Result |
|---|---|
| `swift test` KeyKeyApp `-warnings-as-errors` | 68 tests, 0 failures |
| `swift test` KeyKeyEngine `-warnings-as-errors` | 194 tests, 0 failures |
| `tools/test-resolve-dragon-kit.sh` | 34 cases, 0 failures |
| `plutil -lint` on all 14 `.strings` + `Info.plist` | OK |
| DragonKit conformance checker (incl. §R13) | PASS |

Each new check proven to bite, not just pass:

- narrow the picker to `[.en, .zhHant]` while seven ship → **fails**
- delete the picker entirely → **fails** (`no longer constructs a LanguagePicker`)
- drop one key from `ko.lproj` → **fails**
- blank one value in `fr.lproj` → **fails**

All four restore to green.

Related: teddychan/dragon-kit#60 adds §R13, which machine-checks this same picker/`.lproj` agreement for all five Dragon apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)