### PR TITLE
release: 2.11.6 — adopt DragonKit 4.0.0's fixed About slots

### DIFF
--- a/App/AboutConfig.swift
+++ b/App/AboutConfig.swift
@@ -1,8 +1,11 @@
 import Foundation
 import DragonKit
 
-// About-pane content. DragonKit v3 owns every row title, SF Symbol and ordering — this file
+// About-pane content. DragonKit v4 owns every row title, SF Symbol and ordering — this file
 // supplies only URLs and proper nouns, so the pane cannot drift from the other Dragon apps.
+// As of 4.0.0 the slots are closed by the initializer itself: an omitted licences page or an
+// upstream project credited without a link is a compile error here rather than something found
+// by putting five screenshots side by side.
 // A local debug build is re-id'd to <release-id>.debug and stamped DragonBuildChannel = Debug
 // by tools/build-app.sh, so a test build still shows a distinct "Yahoo! KeyKey 2 Debug" name.
 enum AboutConfig {
@@ -23,24 +26,38 @@ enum AboutConfig {
         AboutContent(
             appName: appName,
             versionString: versionString,
-            // Single holder, deliberately. The dual-holder form would also name the upstream
-            // project's copyright, but this app is an independent reimplementation that uses no
-            // Yahoo! KeyKey source code (docs/THIRD-PARTY-NOTICES.md) and disclaims affiliation
-            // (README.md) — so claiming a Yahoo copyright over this binary would contradict both.
-            // The lineage is carried by originalProjectURL and originalWork instead, and the New
-            // BSD notice for the Yahoo-derived Cangjie tables lives on the licences page.
+            // Single holder — and now the only form the kit offers. The dual-holder form would
+            // also name the upstream project's copyright, but this app is an independent
+            // reimplementation that uses no Yahoo! KeyKey source code
+            // (docs/THIRD-PARTY-NOTICES.md) and disclaims affiliation (README.md) — so claiming a
+            // Yahoo copyright over this binary would contradict both. That was this app's own
+            // reading until DragonKit 4.0.0 adopted it kit-wide: copyright(original:years:holder:)
+            // is gone and CONFORMANCE §R13 enforces the single holder, so this is no longer a
+            // local decision KeyKey could drift back out of. The lineage is carried by
+            // originalWork below, and the New BSD notice for the Yahoo-derived Cangjie tables
+            // lives on the licences page.
             copyright: DragonAbout.copyright(years: "2026", holder: "Teddy Chan"),
             // The canonical marketing page is repo-named; /keykey/ is a <meta refresh> stub whose
             // rel=canonical points here. The kit checks this path against supportURL's repo name.
             websiteURL: URL(string: "https://www.dragonapp.com/yahoo-keykey-2/")!,
             supportURL: URL(string: "https://github.com/teddychan/yahoo-keykey-2/issues")!,
-            license: "MIT",
-            originalProjectURL: URL(string: "https://github.com/ninjapanda/YahooKeyKey")!,
             // Third-party notices, chiefly OpenCC's Apache-2.0 licence and NOTICE, which that
             // licence requires ship with the app. Trailing slash: it is the path Pages serves, so
-            // the row does not point at a redirect.
+            // the row does not point at a redirect. Required as of DragonKit 4.0.0; it moved ahead
+            // of `license:` with the signature, and the two are not interchangeable — this is the
+            // third-party notices page, `license:` is this app's own licence.
             licensesURL: URL(string: "https://www.dragonapp.com/yahoo-keykey-2/licenses/")!,
-            originalWork: OriginalWork(name: "Yahoo! KeyKey", author: "ninjapanda · zonble"),
+            license: "MIT",
+            // One value, both rows: the upstream repository used to be a separate
+            // `originalProjectURL:` argument beside this credit, and DragonKit 4.0.0 folded it in
+            // because two apps passed the credit without the URL and shipped a "Based on" row
+            // linking nowhere. It drives the Original project link and the Based on credit alike,
+            // so they cannot disagree or go missing one at a time.
+            originalWork: OriginalWork(
+                name: "Yahoo! KeyKey",
+                author: "ninjapanda · zonble",
+                url: URL(string: "https://github.com/ninjapanda/YahooKeyKey")!
+            ),
             // Attributions are name → licence, the kit's canon since 3.1.0: the thing's own name
             // as its authors spell it, then its licence. These were role labels paired with an
             // origin — L("keykey.about.cangjieTable") → "ibus-table-chinese" — on the reasoning

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.11.5</string>
+	<string>2.11.6</string>
 	<key>CFBundleVersion</key>
 	<string>23</string>
 	<key>ComponentInputModeDict</key>

--- a/App/WhatsNewConfig.swift
+++ b/App/WhatsNewConfig.swift
@@ -6,30 +6,26 @@ import DragonKit
 // binary isn't. That makes the entries and the date the only things to keep in sync with
 // CHANGELOG.md on release.
 //
-// 2.11.5 started as maintenance — a DragonKit pin bump for currency and a CI comment — and stopped
-// being maintenance when the bump turned out to fix a live bug. So the notes lead with the fix,
-// `.fixed`, and the bump follows as `.changed`. Getting this wrong in the safe-looking direction
-// (shipping the maintenance-only wording that was already written) would have hidden the only
-// thing in the release a user can actually notice.
+// 2.11.6 is maintenance, and unlike 2.11.5 it stayed that way. It bumps the DragonKit pin to
+// 4.0.0, a BREAKING kit release that turns the About pane's rows from a convention into the
+// initializer's own signature: the licences page is a required argument, and the upstream
+// project's repository moved inside OriginalWork so the `Original project` link and the
+// `Based on` credit are one value that cannot be supplied by halves.
 //
-// The bug: App/GeneralPane.swift called LanguagePicker with no argument, so it took the kit's
-// default of DragonLanguage.selectable — all seven locales DragonKit ships — while KeyKey has
-// translated itself into two, App/en.lproj and App/zh-Hant.lproj. Settings therefore offered
-// Español, Français, 日本語, 한국어 and 简体中文, and choosing one translated the kit's four panes
-// and nothing else. `.fixed` and not `.changed`: the menu was making an offer the app could not
-// keep.
+// Nothing on screen moves here, which is the point worth stating rather than dressing up.
+// yahoo-keykey-2 was the app that already had all four link rows and the single-holder copyright
+// — its own AboutConfig comment is what settled the copyright canon for the other four — so the
+// migration was mechanical and the pane it produces is byte-for-byte the arrangement 2.11.2
+// shipped. The one visible difference is the DragonKit version the About pane reports.
 //
-// The `languages:` argument that fixes it is new in DragonKit 3.4.0, which is what this release
-// bumps the pin to — so the two entries are one story, and the second earns its place by being the
-// reason the first is possible rather than by padding the list.
+// So: one `.changed` entry, no `.fixed`. Writing this up as a fix would claim a defect this app
+// never had, and the honest version of "the shared code now enforces what we were already doing"
+// is a single line about the bump. 2.11.3 and 2.11.4 were both a lone `.changed` for the same
+// reason.
 //
-// Worth saying in the notes and not only here: the kit appends an out-of-set selection to the
-// picker (LanguagePicker.offeredLanguages), so a user who had already chosen 日本語 still sees it
-// listed and can move off it. Narrowing the list would otherwise orphan their choice, and SwiftUI
-// draws a Picker whose selection matches no tag as blank.
-//
-// 2.11.4's entry is not carried forward. The feed moved once; the pane describes this version, not
-// the accumulated history — that is CHANGELOG.md's job.
+// 2.11.5's language-menu entry is not carried forward, and keykey.whatsNew.languagePicker is
+// deleted with it. The pane describes this version, not the accumulated history — that is
+// CHANGELOG.md's job.
 enum WhatsNewConfig {
     @MainActor
     static var content: WhatsNewContent {
@@ -37,9 +33,6 @@ enum WhatsNewConfig {
             date: "2026-08-11",
             summary: L("keykey.whatsNew.summary"),
             sections: [
-                ChangeSection(kind: .fixed, entries: [
-                    L("keykey.whatsNew.languagePicker"),
-                ]),
                 ChangeSection(kind: .changed, entries: [
                     L("keykey.whatsNew.sharedCode"),
                 ]),

--- a/App/en.lproj/Localizable.strings
+++ b/App/en.lproj/Localizable.strings
@@ -28,10 +28,9 @@
 "keykey.general.strokeConfirmationHint" = "In 速成, and in 倉頡 with the * wildcard, candidates appear before the code is finished, so Space flips to the next page instead of confirming what you typed. With this on, the first Space only confirms the code and keeps page 1 — press Space again to page, or 1–9 to pick. Plain 倉頡 is unaffected.";
 "keykey.general.language" = "Language";
 
-/* What's New pane (2.11.5) */
-"keykey.whatsNew.summary" = "This one fixes the Language menu in Settings, which offered languages Yahoo! KeyKey 2 has never been translated into. Nothing about typing changes.";
-"keykey.whatsNew.languagePicker" = "The Language menu in Settings no longer offers languages Yahoo! KeyKey 2 does not have. Beside English and 繁體中文 it listed Español, Français, 日本語, 한국어 and 简体中文, and choosing one of those translated only the About, What's New, Updates and Uninstall panes while every other word stayed in English. It now offers the two languages Yahoo! KeyKey 2 is actually translated into. If you had already picked one of the others, it stays in the menu and stays selected until you move off it, so you can still see where you are and change it.";
-"keykey.whatsNew.sharedCode" = "Yahoo! KeyKey 2 is now built with DragonKit 3.4.0, the shared code behind the Settings window's About, What's New, Backup & Restore, Updates and Uninstall panes — and the version that added the setting the fix above needed. The About pane reports the new number; nothing else about it is different.";
+/* What's New pane (2.11.6) */
+"keykey.whatsNew.summary" = "Housekeeping only. Yahoo! KeyKey 2 is built with a new version of the code it shares with the other Dragon apps. Nothing about typing changes, and nothing in the app moves.";
+"keykey.whatsNew.sharedCode" = "Yahoo! KeyKey 2 is now built with DragonKit 4.0.0, the shared code behind the Settings window's About, What's New, Backup & Restore, Updates and Uninstall panes. This version fixes the About pane's rows in place, so none of the Dragon apps can quietly grow, drop or rename one. Yahoo! KeyKey 2's About pane already looked exactly the way the shared code now requires — it was the app the others were brought in line with — so the only thing that changes on screen is the DragonKit version the About pane reports.";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "Disable Cangjie and Simplex from Input Sources";

--- a/App/zh-Hant.lproj/Localizable.strings
+++ b/App/zh-Hant.lproj/Localizable.strings
@@ -28,10 +28,9 @@
 "keykey.general.strokeConfirmationHint" = "在速成、以及使用萬用字元（*）的倉頡中，字根還沒打完就會出現候選字，此時空白鍵會直接翻到下一頁，而不是確認你打的字根。開啟後，第一次按空白鍵只會確認字根並停留在第 1 頁；再按一次空白鍵才翻頁，或直接按 1–9 選字。一般倉頡不受影響。";
 "keykey.general.language" = "語言";
 
-/* What's New pane (2.11.5) */
-"keykey.whatsNew.summary" = "這次修正了設定中的「語言」選單——它列出了 Yahoo! KeyKey 2 從未翻譯過的語言。打字的部分完全沒有改變。";
-"keykey.whatsNew.languagePicker" = "設定中的「語言」選單不再列出 Yahoo! KeyKey 2 沒有的語言。它原本除了 English 與繁體中文，還列出 Español、Français、日本語、한국어 與简体中文；選了其中任何一個，只有「關於」、「新功能」、「更新」與「解除安裝」四個面板會被翻譯，其餘文字全都退回英文。現在只會列出 Yahoo! KeyKey 2 實際翻譯過的這兩種語言。如果你先前已經選了其他語言，它仍會留在選單中並維持選取狀態，直到你切換離開，因此你依然看得到自己目前的設定，也改得回來。";
-"keykey.whatsNew.sharedCode" = "Yahoo! KeyKey 2 現在改用 DragonKit 3.4.0 建構，那是設定視窗中「關於」、「新功能」、「備份與還原」、「更新」與「解除安裝」各面板共用的程式碼，也正是這個版本才提供上述修正所需的設定。「關於」面板會顯示新的版本號，其他部分沒有任何不同。";
+/* What's New pane (2.11.6) */
+"keykey.whatsNew.summary" = "這一版只是例行維護。Yahoo! KeyKey 2 改用新版的共用程式碼建構，那是各個 Dragon App 共同使用的部分。打字的部分完全沒有改變，介面也沒有任何移動。";
+"keykey.whatsNew.sharedCode" = "Yahoo! KeyKey 2 現在改用 DragonKit 4.0.0 建構，那是設定視窗中「關於」、「新功能」、「備份與還原」、「更新」與「解除安裝」各面板共用的程式碼。這一版把「關於」面板的各列固定下來，讓任何一個 Dragon App 都無法再私自增加、刪除或改名其中一列。Yahoo! KeyKey 2 的「關於」面板原本就與共用程式碼現在要求的樣子完全一致——其他幾個 App 正是以它為準對齊的——所以畫面上唯一的變化，就是「關於」面板顯示的 DragonKit 版本號。";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "從輸入來源中停用倉頡與速成";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 A plain-language list of changes in each version, newest first.
 
+## 2.11.6
+
+- **Under the hood: updated to DragonKit 4.0.0** (from 3.4.0), the shared code behind the Settings
+  window's About, What's New, Backup & Restore, Updates and Uninstall panes. This version fixes the
+  About pane's rows in place — the licences page is now required, and the original project's
+  repository travels with the credit that names it, so no Dragon app can list an upstream project
+  it never links or name bundled data whose licences are published nowhere. Yahoo! KeyKey 2's About
+  pane already looked exactly the way the shared code now requires: it had all four link rows and
+  the single-holder copyright, and its own reasoning about that copyright — that an independent
+  reimplementation using no upstream source cannot assert the upstream author's copyright over this
+  binary — is what the shared code adopted for every app. So nothing here moves. The About pane
+  reports the new number; that is the whole of what you can see.
+
 ## 2.11.5
 
 - **Fixed: the Language menu in Settings offered languages Yahoo! KeyKey 2 does not have.** Beside

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
@@ -58,8 +58,14 @@ final class ConfigContentTests: XCTestCase {
     @MainActor
     func testAboutCreditRowsEndWithTheDataAttributions() {
         let content = AboutConfig.content
+        // The url is part of OriginalWork as of DragonKit 4.0.0, and it is the same value the
+        // `heart` link row above renders — one value feeding both rows is the point of folding it
+        // in, so asserting it here pins the credit and the link together.
         XCTAssertEqual(content.originalWork,
-                       OriginalWork(name: "Yahoo! KeyKey", author: "ninjapanda · zonble"))
+                       OriginalWork(name: "Yahoo! KeyKey",
+                                    author: "ninjapanda · zonble",
+                                    url: URL(string: "https://github.com/ninjapanda/YahooKeyKey")!))
+        XCTAssertEqual(content.originalProjectURL, content.originalWork?.url)
         XCTAssertEqual(content.creditRows.count, 7)
         // Pinned as name → licence pairs, not values alone. The kit renders an Attribution as
         // label: name, value: licence, so checking one half would let a role label ("Cangjie
@@ -85,30 +91,28 @@ final class ConfigContentTests: XCTestCase {
         XCTAssertEqual(content.date, "2026-08-11")
     }
 
-    // 2.11.5 leads with a fix and follows with the pin bump that made it possible: the Language
-    // menu offered all seven locales DragonKit ships while KeyKey has two, and `languages:` — the
-    // argument that fixes it — is new in 3.4.0. `.fixed` first because the menu was making an
-    // offer the app could not keep, then `.changed` for the bump itself.
-    //
-    // The release was drafted as maintenance-only, a single `.changed` about the bump, before the
-    // bug behind it was found; that draft would have shipped notes silent on the only thing in the
-    // release a user can notice. 2.11.2 pinned [.improved, .fixed] for a different pair.
+    // 2.11.6 is a lone `.changed`: the DragonKit pin moves to 4.0.0, which makes the About pane's
+    // rows the initializer's own signature rather than a convention five apps followed by hand.
+    // No `.fixed`, deliberately — this app's About pane was the correct one, so the migration
+    // changed no behaviour and claiming a fix would invent a defect KeyKey never had. 2.11.5 was
+    // [.fixed, .changed] for a real bug the bump exposed; 2.11.2 was [.improved, .fixed].
     //
     // Entry KEYS are pinned, not just kinds and counts, because kinds and counts had stopped
     // catching anything: 2.11.3, 2.11.4 and the 2.11.5 draft were all [.changed] with one entry —
     // three in a row — so a release that forgot to touch the notes would have passed unchanged
-    // while shipping its predecessor's text. Compared against the same L() keys WhatsNewConfig
-    // builds the entries from, so this holds in whatever language the test bundle resolves,
-    // exactly as the DragonAppMenu test below compares titles against the kit's keys. What the
-    // text SAYS is the release gate's job — it diffs both .strings files — so between them a
-    // stale pane cannot ship.
+    // while shipping its predecessor's text. That is live again here, 2.11.6 being a single
+    // `.changed` reusing the sharedCode key, and the keys alone would not have caught it either:
+    // what makes this assertion bite is that keykey.whatsNew.languagePicker is gone from the list.
+    // Compared against the same L() keys WhatsNewConfig builds the entries from, so this holds in
+    // whatever language the test bundle resolves, exactly as the DragonAppMenu test below compares
+    // titles against the kit's keys. What the text SAYS is the release gate's job — it diffs both
+    // .strings files — so between them a stale pane cannot ship.
     @MainActor
-    func testWhatsNewLeadsWithTheLanguageMenuFix() {
+    func testWhatsNewIsTheSharedCodeBumpAlone() {
         let content = WhatsNewConfig.content
-        XCTAssertEqual(content.sections.map(\.kind), [.fixed, .changed])
-        XCTAssertEqual(content.sections.map(\.entries.count), [1, 1])
+        XCTAssertEqual(content.sections.map(\.kind), [.changed])
+        XCTAssertEqual(content.sections.map(\.entries.count), [1])
         XCTAssertEqual(content.sections.flatMap(\.entries), [
-            L("keykey.whatsNew.languagePicker"),
             L("keykey.whatsNew.sharedCode"),
         ])
     }

--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -86,7 +86,7 @@ echo "==> Building DragonKit (SwiftPM, release) in pinned checkout"
 # tools/test-resolve-dragon-kit.sh can drive every one of them without a swiftc build.
 # DRAGONKIT_TAG stays HERE: the propagation SOP and .github/workflows/tests.yml both read the pin
 # out of this file.
-DRAGONKIT_TAG="v3.4.0"
+DRAGONKIT_TAG="v4.0.0"
 DRAGONKIT_URL="https://github.com/teddychan/dragon-kit"
 "$ROOT/tools/resolve-dragon-kit.sh" "$KIT_DIR" "$DRAGONKIT_TAG" "$DRAGONKIT_URL"
 ( cd "$KIT_DIR" && swift build -c release )


### PR DESCRIPTION
## What

Bumps the DragonKit pin to **4.0.0** and migrates `App/AboutConfig.swift` to its new
`AboutContent` signature, then releases **2.11.6**.

DragonKit 4.0.0 is a breaking release that closes the last gaps in the About pane using the
initializer itself rather than a convention five apps followed by hand:

- `licensesURL` is now **required** — spectacle-2 and the sample app both left it nil while
  listing `Sparkle → MIT` in Credits, naming a bundled component and linking its notices
  nowhere. It also moved ahead of `license:` in the parameter list.
- The upstream project's repository moved **inside** `OriginalWork`, so the `Original project`
  link row and the `Based on` credit row are one value. They were separate optionals, and
  clipmenu-2 and ice-2 both credited an upstream project the pane never linked.
- `DragonAbout.copyright(original:years:holder:)` is gone; only `copyright(years:holder:)` remains.

## Why this is mechanical, not a fix

**Yahoo! KeyKey 2's About pane was already the correct one of the five.** It is the only app that
had all four link rows and the single-holder copyright, and its own `AboutConfig` comment is what
settled the copyright canon for the others — CONFORMANCE §R13 now enforces that reasoning
kit-wide. So the pane this produces is the arrangement 2.11.2 shipped, and **the only visible
difference is the DragonKit version the About pane reports**.

That is why the What's New is a lone `.changed` and no `.fixed`: writing it up as a fix would
claim a defect this app never had.

## Changes

| File | Change |
|---|---|
| `App/AboutConfig.swift` | Fold the upstream URL into `OriginalWork(name:author:url:)`; move `licensesURL` ahead of `license`; record that the single-holder copyright is now the kit's rule, not a local decision |
| `tools/build-app.sh` | `DRAGONKIT_TAG` `v3.4.0` → `v4.0.0` |
| `App/Info.plist` | `CFBundleShortVersionString` → `2.11.6` |
| `App/WhatsNewConfig.swift` + both `.lproj` | One `.changed` entry for the bump; the now-unused `keykey.whatsNew.languagePicker` deleted with 2.11.5's entry |
| `ConfigContentTests.swift` | `OriginalWork`'s required `url`, asserted equal to what the `Original project` row renders; new single-section What's New shape |
| `CHANGELOG.md` | 2.11.6 entry |

**Deliberately untouched:** the copyright value itself, and the three `attributions`. In
particular `ibus-table-chinese → Freely redistributable without restriction` stays quoted in full
from `docs/THIRD-PARTY-NOTICES.md` — it is not GPL-3.0 (that covers the surrounding repository
packaging, not the one table bundled) and not the narrower "Freely redistributable" a past
correction shortened it to. `CFBundleVersion` stays the inert placeholder; the real build number
is stamped from the commit count.

## Verification

All run locally before pushing:

- `./tools/build-app.sh` — builds against the v4.0.0 checkout; app reports `2.11.6`, build `199`,
  no `DragonBuildChannel` (release shape).
- `swift test --package-path Packages/KeyKeyEngine -Xswiftc -warnings-as-errors` — **194 XCTest
  cases, 0 failures**, plus the empty swift-testing harness.
- `swift test --package-path Packages/KeyKeyApp -Xswiftc -warnings-as-errors` — **67 XCTest cases,
  0 failures**, plus the empty swift-testing harness. All 9 `ConfigContentTests` pass, including
  the `© 2026 Teddy Chan` copyright assertion.
- `./tools/test-resolve-dragon-kit.sh` — PASS, 34 cases.
- `python3 Scripts/dragon-conformance.py --app . --kit ~/git/dragon-kit` — **PASS, no violations.**
  It failed R10 on the stale pin before this change.
- Both `.strings` files lint clean and have identical key sets.

Release notes: see the `## 2.11.6` section of `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)