### PR TITLE
docs(about): cite the right conformance rule for the single-holder copyright

### DIFF
--- a/App/AboutConfig.swift
+++ b/App/AboutConfig.swift
@@ -32,8 +32,11 @@ enum AboutConfig {
             // (docs/THIRD-PARTY-NOTICES.md) and disclaims affiliation (README.md) — so claiming a
             // Yahoo copyright over this binary would contradict both. That was this app's own
             // reading until DragonKit 4.0.0 adopted it kit-wide: copyright(original:years:holder:)
-            // is gone and CONFORMANCE §R13 enforces the single holder, so this is no longer a
-            // local decision KeyKey could drift back out of. The lineage is carried by
+            // is gone and CONFORMANCE §R14 enforces the single holder, so this is no longer a
+            // local decision KeyKey could drift back out of. §R14 and not §R13 — this cited R13
+            // for one day, the number the rule was written as before dragon-kit renumbered it to
+            // free R13 for a rule about the language picker. Both are live, so "correcting" this
+            // back points at the wrong rule entirely. The lineage is carried by
             // originalWork below, and the New BSD notice for the Yahoo-derived Cangjie tables
             // lives on the licences page.
             copyright: DragonAbout.copyright(years: "2026", holder: "Teddy Chan"),


### PR DESCRIPTION
## What

One-word comment fix in `App/AboutConfig.swift`: the About copyright's rule is **§R14**, not §R13.

```diff
-            // is gone and CONFORMANCE §R13 enforces the single holder, so this is no longer a
+            // is gone and CONFORMANCE §R14 enforces the single holder, so this is no longer a
```

## Why

The number was correct when 2.11.6 was written and stopped being correct while that release was
in flight:

- dragon-kit **#62** renumbered the About-copyright rule from R13 to **R14**, because R13 had
  collided with a then-open PR.
- dragon-kit **#60** has since merged and now owns **R13** for an unrelated rule — *the language
  picker offers exactly the languages the app ships*.

Both rules are live on the kit's `main`, so the stale citation does not merely point at nothing;
it points a future reader at a completely different rule.

The comment now says *why* it is R14, not just R14 — the obvious "correction" from memory is to
put R13 back, and that is precisely the wrong edit.

## Scope

- **Comment-only.** No code, no behaviour, no strings.
- **No version bump and no tag.** v2.11.6 is already published and its binary is correct; nothing
  a user can see is affected.
- Only one such reference existed in the whole repo. A sweep for any `R1x` rule citation across
  Swift, Markdown, JSON, shell, YAML and plist — excluding `vendor/`, `.build/` and the two
  untracked worktrees — found `App/AboutConfig.swift:35` and nothing else.
  `.dragon-conformance.json` cites no rule numbers.

## Verification

- `python3 Scripts/dragon-conformance.py --app . --kit ~/git/dragon-kit` — **PASS, no violations**,
  run against the renumbered rule set (kit `main` at `f86e72a`, which carries both the renumber and
  the new R13). Worth noting: KeyKey passes the *new* R13 as well, because 2.11.5 narrowed the
  picker to `[.en, .zhHant]`.
- `swift test --package-path Packages/KeyKeyApp -Xswiftc -warnings-as-errors` — 67 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)