### PR TITLE
fix(about): give the bundle a copyright notice, and unify the LICENSE holder name

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.12.0</string>
+	<string>2.12.1</string>
 	<key>CFBundleVersion</key>
 	<string>23</string>
 	<key>ComponentInputModeDict</key>
@@ -101,6 +101,8 @@
 	<string>26.0</string>
 	<key>LSUIElement</key>
 	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>© 2026 Teddy Chan</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>SUEnableAutomaticChecks</key>

--- a/App/WhatsNewConfig.swift
+++ b/App/WhatsNewConfig.swift
@@ -6,28 +6,27 @@ import DragonKit
 // binary isn't. That makes the entries and the date the only things to keep in sync with
 // CHANGELOG.md on release.
 //
-// 2.12.0 adds the five localizations KeyKey did not have: App/{es,fr,ja,ko,zh-Hans}.lproj, beside
-// the en and zh-Hant it shipped with. One `.added` entry, because that is the whole of what a user
-// can notice.
+// 2.12.1 claims one fix: `App/Info.plist` had no `NSHumanReadableCopyright`, so Finder's Get Info
+// panel showed no copyright line for Yahoo! KeyKey 2 at all. It now carries `© 2026 Teddy Chan` —
+// byte-for-byte the string the About pane's copyright row renders.
 //
-// This closes 2.11.5 from the other side. That release NARROWED the Language menu to [.en, .zhHant]
-// because the bare LanguagePicker() took the kit's default of all seven locales while KeyKey had
-// two, so choosing one of the other five translated the shared panes and left every KeyKey string
-// in English. Narrowing was the honest fix for a two-language app; translating the app is the fix
-// that lets the menu open back up. App/GeneralPane.swift is bare again as a result, and it is bare
-// rather than a literal list of seven on purpose — see the comment there.
+// Found by auditing the field across all five Dragon apps, where it was in four different states:
+// a tagline in clipmenu-2, two holders in ice-2, and absent here, in spectacle-2 and in the sample
+// app. KeyKey is the app whose About copyright slot once held `倉頡／簡易 輸入法` — the defect
+// DragonKit still cites in `DragonAbout.copyright(years:holder:)` — so having the bundle's own
+// notice missing entirely was the same failure one field over. The key is an optional Apple one
+// that no licence names, so it is presentation, and the rule for presentation is the one About
+// already follows: a single holder, the app's own.
 //
-// Deliberately NOT in the notes: this release also drops appcast_mirror_repo from
-// .github/workflows/release.yml, the step-3 retirement that file has been committed to since
-// 2.11.3 and that names the next MINOR release as its trigger — 2.11.6 was a patch and correctly
-// left it alone; this is the release the trigger meant. It is invisible either way, since
-// installed copies have read the app-owned feed since 2.11.4, and the notes describe what a user
-// can see. CHANGELOG.md carries it as an under-the-hood line.
+// `.fixed`, not `.added`. A bundle is expected to carry this field; the app shipped without it.
 //
-// The DragonKit pin does not move here — 2.11.6 already took it to 4.0.0 — so there is no
-// `.changed` for it, and `keykey.whatsNew.sharedCode` is deleted with that release's entry. 2.11.5
-// and 2.11.6 both carried a pin entry because the bump was the substance of those releases;
-// repeating it every time is the padding those entries avoided.
+// Deliberately NOT in the notes: LICENSE's holder changes from "Lung Sang Chan (teddychan)" to
+// "Teddy Chan", so all five apps name the holder one way. That is the same person either way and
+// nothing a user can observe from inside the app — CHANGELOG.md carries it.
+//
+// `keykey.whatsNew.allLanguages` is gone, replaced in place by `keykey.whatsNew.copyrightNotice`
+// in all seven .strings files. 2.12.0's `.added` entry has nothing to say here, and leaving the
+// key behind would strand that release's sentence in seven files waiting to be shown again.
 enum WhatsNewConfig {
     @MainActor
     static var content: WhatsNewContent {
@@ -35,8 +34,8 @@ enum WhatsNewConfig {
             date: "2026-08-11",
             summary: L("keykey.whatsNew.summary"),
             sections: [
-                ChangeSection(kind: .added, entries: [
-                    L("keykey.whatsNew.allLanguages"),
+                ChangeSection(kind: .fixed, entries: [
+                    L("keykey.whatsNew.copyrightNotice"),
                 ]),
             ]
         )

--- a/App/en.lproj/Localizable.strings
+++ b/App/en.lproj/Localizable.strings
@@ -29,8 +29,8 @@
 "keykey.general.language" = "Language";
 
 /* What's New pane (2.12.0) */
-"keykey.whatsNew.summary" = "Yahoo! KeyKey 2 is now translated into all seven languages the Language menu offers. Nothing about typing changes.";
-"keykey.whatsNew.allLanguages" = "Yahoo! KeyKey 2 now speaks Español, Français, 日本語, 한국어 and 简体中文, alongside English and 繁體中文. Version 2.11.5 took those five out of the Language menu because they were the shared Dragon App code's languages and not Yahoo! KeyKey 2's — choosing one translated the shared Settings panes and left every other word in English. They are back, and this time every word behind them is translated too.";
+"keykey.whatsNew.summary" = "A small fix: Yahoo! KeyKey 2 now carries a copyright notice, the same one shown in About. Nothing about typing changes.";
+"keykey.whatsNew.copyrightNotice" = "Finder's Get Info panel now shows Yahoo! KeyKey 2's copyright notice. The app carried none at all, so that line was simply blank.";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "Disable Cangjie and Simplex from Input Sources";

--- a/App/es.lproj/Localizable.strings
+++ b/App/es.lproj/Localizable.strings
@@ -29,8 +29,8 @@
 "keykey.general.language" = "Idioma";
 
 /* What's New pane (2.12.0) */
-"keykey.whatsNew.summary" = "Yahoo! KeyKey 2 ya está traducido a los siete idiomas que ofrece el menú Idioma. Nada cambia al escribir.";
-"keykey.whatsNew.allLanguages" = "Yahoo! KeyKey 2 ahora habla Español, Français, 日本語, 한국어 y 简体中文, además de English y 繁體中文. La versión 2.11.5 retiró esos cinco del menú Idioma porque eran los idiomas del código compartido de Dragon App y no los de Yahoo! KeyKey 2: al elegir uno se traducían los paneles compartidos de Ajustes y todo lo demás se quedaba en inglés. Han vuelto, y esta vez también está traducida cada palabra que hay detrás de ellos.";
+"keykey.whatsNew.summary" = "Una pequeña corrección: Yahoo! KeyKey 2 ya incluye un aviso de copyright, el mismo que muestra Acerca de. Nada cambia al escribir.";
+"keykey.whatsNew.copyrightNotice" = "El panel «Obtener información» del Finder ahora muestra el aviso de copyright de Yahoo! KeyKey 2. La app no incluía ninguno, así que esa línea aparecía vacía.";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "Desactivar 倉頡 y 速成 en Fuentes de entrada";

--- a/App/fr.lproj/Localizable.strings
+++ b/App/fr.lproj/Localizable.strings
@@ -29,8 +29,8 @@
 "keykey.general.language" = "Langue";
 
 /* What's New pane (2.12.0) */
-"keykey.whatsNew.summary" = "Yahoo! KeyKey 2 est désormais traduit dans les sept langues que propose le menu Langue. Rien ne change à la saisie.";
-"keykey.whatsNew.allLanguages" = "Yahoo! KeyKey 2 parle maintenant Español, Français, 日本語, 한국어 et 简体中文, en plus de English et 繁體中文. La version 2.11.5 avait retiré ces cinq langues du menu Langue parce qu’il s’agissait des langues du code partagé de Dragon App et non de celles de Yahoo! KeyKey 2 : en choisir une traduisait les panneaux partagés des Réglages et laissait tout le reste en anglais. Elles sont de retour, et cette fois chaque mot qui se trouve derrière elles est traduit aussi.";
+"keykey.whatsNew.summary" = "Une petite correction : Yahoo! KeyKey 2 comporte désormais une mention de copyright, la même que celle affichée dans À propos. Rien ne change à la saisie.";
+"keykey.whatsNew.copyrightNotice" = "La fenêtre « Lire les informations » du Finder affiche désormais la mention de copyright de Yahoo! KeyKey 2. L’app n’en comportait aucune, la ligne restait donc vide.";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "Désactiver 倉頡 et 速成 dans les sources de saisie";

--- a/App/ja.lproj/Localizable.strings
+++ b/App/ja.lproj/Localizable.strings
@@ -29,8 +29,8 @@
 "keykey.general.language" = "言語";
 
 /* What's New pane (2.12.0) */
-"keykey.whatsNew.summary" = "Yahoo! KeyKey 2 が「言語」メニューに並ぶ 7 言語すべてに翻訳されました。入力の動作は何も変わりません。";
-"keykey.whatsNew.allLanguages" = "Yahoo! KeyKey 2 は English と繁體中文 に加えて、Español、Français、日本語、한국어、简体中文 を話すようになりました。2.11.5 ではこの 5 言語を「言語」メニューから外しました。それらは Dragon App 共通コードの言語であって Yahoo! KeyKey 2 の言語ではなく、選んでも共通の設定パネルだけが翻訳され、ほかの文字はすべて英語のままだったからです。今回それらが戻り、しかも今度はメニューの向こう側にある言葉もすべて翻訳されています。";
+"keykey.whatsNew.summary" = "小さな修正です。Yahoo! KeyKey 2 に著作権表示が追加され、「情報」に表示されるものと同じになりました。入力の動作は何も変わりません。";
+"keykey.whatsNew.copyrightNotice" = "Finder の「情報を見る」に Yahoo! KeyKey 2 の著作権表示が表示されるようになりました。これまではアプリが著作権表示を持っておらず、その欄は空のままでした。";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "入力ソースから倉頡と速成を無効にする";

--- a/App/ko.lproj/Localizable.strings
+++ b/App/ko.lproj/Localizable.strings
@@ -29,8 +29,8 @@
 "keykey.general.language" = "언어";
 
 /* What's New pane (2.12.0) */
-"keykey.whatsNew.summary" = "Yahoo! KeyKey 2가 「언어」 메뉴에 있는 7개 언어 모두로 번역되었습니다. 입력 동작은 전혀 바뀌지 않습니다.";
-"keykey.whatsNew.allLanguages" = "Yahoo! KeyKey 2는 English와 繁體中文에 더해 Español, Français, 日本語, 한국어, 简体中文를 말합니다. 2.11.5에서는 이 다섯 언어를 「언어」 메뉴에서 빼냈습니다. 그것은 Dragon App 공용 코드의 언어이지 Yahoo! KeyKey 2의 언어가 아니어서, 하나를 고르면 공용 설정 패널만 번역되고 나머지 모든 단어는 영어로 남았기 때문입니다. 이제 그 언어들이 돌아왔고, 이번에는 메뉴 뒤에 있는 모든 단어까지 번역되어 있습니다.";
+"keykey.whatsNew.summary" = "작은 수정입니다. Yahoo! KeyKey 2에 저작권 표시가 추가되어 정보 화면에 표시되는 것과 같아졌습니다. 입력 동작은 전혀 바뀌지 않습니다.";
+"keykey.whatsNew.copyrightNotice" = "Finder의 ‘정보 가져오기’ 창에 Yahoo! KeyKey 2의 저작권 표시가 나옵니다. 앱에 저작권 표시가 전혀 없어 해당 줄이 비어 있었습니다.";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "입력 소스에서 창힐과 속성 사용 중지";

--- a/App/zh-Hans.lproj/Localizable.strings
+++ b/App/zh-Hans.lproj/Localizable.strings
@@ -29,8 +29,8 @@
 "keykey.general.language" = "语言";
 
 /* What's New pane (2.12.0) */
-"keykey.whatsNew.summary" = "Yahoo! KeyKey 2 现已翻译成「语言」菜单所列出的全部七种语言。打字的部分完全没有改变。";
-"keykey.whatsNew.allLanguages" = "除了 English 与繁體中文，Yahoo! KeyKey 2 现在也会说 Español、Français、日本語、한국어 与简体中文。2.11.5 曾把这五种语言从「语言」菜单中移除，因为那是 Dragon App 共用代码的语言，而不是 Yahoo! KeyKey 2 的——选了其中任何一个，只有共用的设置面板会被翻译，其余文字全都退回英文。现在它们回来了，而且这一次，菜单背后的每一个字也都翻译好了。";
+"keykey.whatsNew.summary" = "一处小修复：Yahoo! KeyKey 2 现在带有版权声明，与「关于」中显示的一致。打字的部分完全没有改变。";
+"keykey.whatsNew.copyrightNotice" = "访达的「显示简介」现在会显示 Yahoo! KeyKey 2 的版权声明。此前应用完全没有版权声明，该行一直是空的。";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "从输入源中停用仓颉与速成";

--- a/App/zh-Hant.lproj/Localizable.strings
+++ b/App/zh-Hant.lproj/Localizable.strings
@@ -29,8 +29,8 @@
 "keykey.general.language" = "語言";
 
 /* What's New pane (2.12.0) */
-"keykey.whatsNew.summary" = "Yahoo! KeyKey 2 現在已翻譯成「語言」選單所列出的全部七種語言。打字的部分完全沒有改變。";
-"keykey.whatsNew.allLanguages" = "除了 English 與繁體中文，Yahoo! KeyKey 2 現在也會說 Español、Français、日本語、한국어 與简体中文。2.11.5 把這五種語言從「語言」選單移除，因為那是 Dragon App 共用程式碼的語言，而不是 Yahoo! KeyKey 2 的——選了其中任何一個，只有共用的設定面板會被翻譯，其餘文字全都退回英文。現在它們回來了，而且這一次，選單背後的每一個字也都翻譯好了。";
+"keykey.whatsNew.summary" = "一處小修正：Yahoo! KeyKey 2 現在帶有版權聲明，與「關於」中顯示的一致。打字的部分完全沒有改變。";
+"keykey.whatsNew.copyrightNotice" = "Finder 的「顯示簡介」現在會顯示 Yahoo! KeyKey 2 的版權聲明。先前應用程式完全沒有版權聲明，該行一直是空的。";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "從輸入來源中停用倉頡與速成";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 A plain-language list of changes in each version, newest first.
 
+## 2.12.1
+
+- **Fixed: Yahoo! KeyKey 2 now carries a copyright notice.** `App/Info.plist` had no
+  `NSHumanReadableCopyright`, so Finder's Get Info panel showed no copyright line for the app at
+  all. It now reads `© 2026 Teddy Chan` — byte-for-byte the string the About pane's copyright row
+  renders. Nothing about typing changes.
+
+  Found by auditing the field across all five Dragon apps, where it sat in four different states:
+  a tagline in ClipMenu 2 (`ClipMenu modern rewrite.`), two holders in Ice 2, and absent here, in
+  Spectacle 2 and in Dragon Sample App. Yahoo! KeyKey 2 is the app whose *About* copyright slot
+  once held `倉頡／簡易 輸入法` — the defect DragonKit still cites in
+  `DragonAbout.copyright(years:holder:)` — so the bundle's own notice being missing entirely was
+  the same failure one field over.
+
+  The key is an optional Apple one that no licence names, so it is presentation rather than a
+  legal notice, and the rule for presentation is the one About already follows: a single holder,
+  the app's own. `LICENSE` is where the MIT grant lives and is untouched apart from the name form
+  below.
+
+- **Under the hood: `LICENSE` names the holder "Teddy Chan".** It read
+  `Copyright (c) 2026 Lung Sang Chan (teddychan)`, the only one of the five apps to use that form —
+  the other four say `Teddy Chan`, and so does every About pane. Same person, same grant, same
+  year; only the spelling is unified. Not in the release notes, because there is nothing a user
+  can observe from inside the app.
+
 ## 2.12.0
 
 - **Added: Yahoo! KeyKey 2 now speaks all seven languages the Language menu offers.** Español,

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Lung Sang Chan (teddychan)
+Copyright (c) 2026 Teddy Chan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
@@ -91,15 +91,22 @@ final class ConfigContentTests: XCTestCase {
         XCTAssertEqual(content.date, "2026-08-11")
     }
 
-    // 2.12.0 is a single `.added`: the five localizations KeyKey did not have. It closes 2.11.5
-    // from the other side — that release narrowed the Language menu to the two languages KeyKey
-    // actually had, and this one translates the app so the menu can open back up.
+    // 2.12.1 is a single `.fixed`: `App/Info.plist` had no `NSHumanReadableCopyright`, so Finder's
+    // Get Info panel showed no copyright line for the app at all. It now carries
+    // `© 2026 Teddy Chan`, byte-for-byte what About's copyright row renders.
     //
-    // Only one entry, and deliberately no `.changed`. The DragonKit pin does not move — 2.11.6
-    // already took it to 4.0.0 — and the appcast mirror this release retires is invisible, since
-    // installed copies have read the app-owned feed since 2.11.4. 2.11.5 and 2.11.6 each carried a
-    // pin entry because the bump was the substance of those releases; repeating it every time is
-    // the padding those entries avoided. 2.11.2 pinned [.improved, .fixed] for a different pair.
+    // `.fixed`, not `.added` — a bundle is expected to carry that field, and this one shipped
+    // without it. KeyKey is the app whose About copyright slot once held `倉頡／簡易 輸入法`, the
+    // defect DragonKit still cites in `DragonAbout.copyright(years:holder:)`; the bundle's own
+    // notice being absent was the same failure one field over.
+    //
+    // One entry, and no second section. LICENSE's holder also changes here, from "Lung Sang Chan
+    // (teddychan)" to "Teddy Chan" so all five apps name it one way — but that is the same person
+    // either way and nothing observable from inside the app, so claiming it would be padding.
+    //
+    // 2.12.0 pinned a single `.added` for the five localizations KeyKey did not have. 2.11.5 and
+    // 2.11.6 each carried a DragonKit pin entry because the bump was the substance of those
+    // releases; 2.11.2 pinned [.improved, .fixed] for a different pair.
     //
     // Entry KEYS are pinned, not just kinds and counts, because kinds and counts had stopped
     // catching anything: 2.11.3, 2.11.4 and the 2.11.5 draft were all [.changed] with one entry —
@@ -110,12 +117,12 @@ final class ConfigContentTests: XCTestCase {
     // text SAYS is the release gate's job — it diffs every locale's .strings file — so between
     // them a stale pane cannot ship.
     @MainActor
-    func testWhatsNewAnnouncesTheNewLocalizations() {
+    func testWhatsNewAnnouncesTheCopyrightNoticeFix() {
         let content = WhatsNewConfig.content
-        XCTAssertEqual(content.sections.map(\.kind), [.added])
+        XCTAssertEqual(content.sections.map(\.kind), [.fixed])
         XCTAssertEqual(content.sections.map(\.entries.count), [1])
         XCTAssertEqual(content.sections.flatMap(\.entries), [
-            L("keykey.whatsNew.allLanguages"),
+            L("keykey.whatsNew.copyrightNotice"),
         ])
     }
 


### PR DESCRIPTION
`App/Info.plist` had no `NSHumanReadableCopyright`, so Finder's Get Info panel showed no copyright line for Yahoo! KeyKey 2 at all. It now reads `© 2026 Teddy Chan` — byte-for-byte the string the About pane's copyright row renders.

## Why here, why now

Found by auditing the field across all five Dragon apps, where it sat in four different states: a tagline in clipmenu-2 (`ClipMenu modern rewrite.`), two holders in ice-2, and absent here, in spectacle-2 and in dragon-sample-app.

This is the app whose **About** copyright slot once held `倉頡／簡易 輸入法` — the defect DragonKit still cites in the doc comment on `DragonAbout.copyright(years:holder:)`. The bundle's own notice being missing entirely was the same failure one field over.

The key is an optional Apple one that no licence names, so it is presentation rather than a legal notice, and the rule for presentation is the one About already follows: a single holder, the app's own. `.fixed` rather than `.added`, because a bundle is expected to carry the field.

## LICENSE holder name

`Copyright (c) 2026 Lung Sang Chan (teddychan)` → `Copyright (c) 2026 Teddy Chan`.

This was the only one of the five apps using that form; the other four say `Teddy Chan`, as does every About pane. Same person, same MIT grant, same year — only the spelling is unified. It stays out of the release notes because no user can observe it from inside the app; `CHANGELOG.md` carries it as an under-the-hood line.

## Release notes

`keykey.whatsNew.allLanguages` is replaced in place by `keykey.whatsNew.copyrightNotice` in all seven `.strings` files. 2.12.0's `.added` entry has nothing to say here, and leaving the key behind would strand that release's sentence waiting to be shown again.

`testWhatsNewAnnouncesTheNewLocalizations` is renamed and repinned. Worth noting it did its job: it pins entry **keys**, not just kinds and counts, and it is what caught this edit locally.

## Verified

| Check | Result |
|---|---|
| `swift test --package-path Packages/KeyKeyApp` | 68 tests, 0 failures |
| `swift test --package-path Packages/KeyKeyEngine -Xswiftc -warnings-as-errors` | 194 tests, 0 failures |
| `plutil -lint` | `App/Info.plist` + all 7 `.strings` OK |
| `PlistBuddy -c "Print :NSHumanReadableCopyright"` | `© 2026 Teddy Chan` |
| `PlistBuddy -c "Print :CFBundleShortVersionString"` | `2.12.1` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)