### PR TITLE
docs(notices): carry the Yahoo! KeyKey tables' BSD-3 notice in full

### DIFF
--- a/Resources/CANGJIE-DATA-LICENSE.txt
+++ b/Resources/CANGJIE-DATA-LICENSE.txt
@@ -77,13 +77,29 @@ Upstream data origin / attribution
 -----------------------------------
 Both tables are the "large character set" builds based on opendesktop.org.tw's
 cj.cin / simplex.cin, merged/extended by yylin and b6s, and shipped inside the
-Yahoo! KeyKey source release (Copyright (c) 2007-2010 Yahoo! Taiwan / Lithoglyph;
-project licensed New BSD).
+Yahoo! KeyKey source release. cj-ext.cin's own header records exactly that:
+"tweaked by b6s for OVIMGeneric(SQLite)", "based on opendesktop.org.tw's cj.cin
+file and merged by yylin and b6s", extended for HKSCS and then CNS11643.
 
 License note / caveat
 ---------------------
-The Yahoo! KeyKey project is released under the New BSD license (see the project's
-COPYING). Unlike the ibus cangjie5 header, the cj-ext.cin / simplex-ext.cin table
-files carry no explicit per-file license line; reuse here relies on the project's
-BSD release and the OpenVanilla-community (opendesktop.org.tw) origin of the tables.
-Only the data tables are reused, with attribution as above.
+The Yahoo! KeyKey project is released under the New BSD (BSD-3-Clause) license.
+The operative notice is the one in the repository's LICENSE:
+
+    Copyright (c) 2012, Yahoo! Inc.  All rights reserved.
+
+It is reproduced IN FULL — notice, three conditions and disclaimer — in
+docs/THIRD-PARTY-NOTICES.md and on https://www.dragonapp.com/yahoo-keykey-2/licenses/,
+because BSD-3-Clause requires binary redistributions to reproduce all three.
+
+This file previously attributed the tables to "Copyright (c) 2007-2010 Yahoo!
+Taiwan / Lithoglyph". That line is real but SCOPED, and not to these files: the
+source release's COPYING says "Refer to individual source code header for
+copyright notices", then limits its Yahoo! Taiwan line to projects under
+PreferenceApplications/ and Utilities/. DataTables/ is neither. It is kept here as
+provenance and no longer presented as these tables' copyright notice.
+
+Unlike the ibus cangjie5 header, cj-ext.cin and simplex-ext.cin carry no explicit
+per-file license line at all; reuse relies on the project's BSD release and the
+OpenVanilla-community (opendesktop.org.tw) origin of the tables. Only the data
+tables are reused — no source code from the project is used.

--- a/docs/THIRD-PARTY-NOTICES.md
+++ b/docs/THIRD-PARTY-NOTICES.md
@@ -10,6 +10,7 @@ license — all of them permit redistribution, including commercial use:
 | libtabe / TaBE phrase data | BSD-style |
 | OpenCC conversion data | Apache-2.0 |
 | Cangjie-5 table | "Freely redistributable without restriction" (upstream table header; see `Resources/CANGJIE-DATA-LICENSE.txt`) |
+| Yahoo! KeyKey 三代 tables (倉頡第三代 / 速成) | New BSD (BSD-3-Clause) |
 
 Yahoo KeyKey 2 is an independent reimplementation and is not affiliated with, or
 endorsed by, Yahoo. See `CREDITS.md`.
@@ -43,7 +44,69 @@ own header declares: **"LICENSE = Freely redistributable without restriction"**
 ibus-table-chinese repository packaging is GPLv3; the table carries its own
 freely-redistributable declaration). See `Resources/CANGJIE-DATA-LICENSE.txt`.
 
+## Yahoo! KeyKey 三代 tables (倉頡第三代 / 速成)
+The bundled `Resources/cangjie-yahoo.txt` and `Resources/simplex-yahoo.txt` are
+extracted from the open-sourced Yahoo! KeyKey source release
+(`YahooKeyKey-Source-1.1.2528/DataTables/cj-ext.cin` and `simplex-ext.cin`),
+which is released under the New BSD (BSD-3-Clause) license.
+https://github.com/bency/YahooKeyKey
+
+Both tables are the "large character set" builds based on opendesktop.org.tw's
+`cj.cin` / `simplex.cin`, merged and extended by yylin and b6s — as the `cj.cin`
+header itself records. The `.cin` files carry no per-file copyright line, so the
+notice reproduced below is the project's, from the repository's `LICENSE`. The
+release's own `COPYING` says "Refer to individual source code header for copyright
+notices", and its `Copyright (c) 2007-2010 Yahoo! Taiwan` line is scoped to
+`PreferenceApplications/` and `Utilities/` — not to `DataTables/` — so it is
+recorded as provenance rather than presented as these tables' notice.
+
+Only the data tables are reused. Yahoo KeyKey 2 uses no source code from the
+original Yahoo! KeyKey. See `Resources/CANGJIE-DATA-LICENSE.txt` for the exact
+extraction and de-duplication steps.
+
+BSD-3-Clause requires binary redistributions to reproduce the copyright notice,
+the conditions and the disclaimer, so the license is reproduced here in full:
+
+```
+Copyright (c) 2012, Yahoo! Inc.  All rights reserved.
+
+Redistribution and use of this software in source and binary forms,
+with or without modification, are permitted provided that the following
+conditions are met:
+
+* Redistributions of source code must retain the above
+  copyright notice, this list of conditions and the
+  following disclaimer.
+
+* Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the
+  following disclaimer in the documentation and/or other
+  materials provided with the distribution.
+
+* Neither the name of Yahoo! Inc. nor the names of its
+  contributors may be used to endorse or promote products
+  derived from this software without specific prior
+  written permission of Yahoo! Inc.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+The third condition is why the summary at the top of this file states that
+Yahoo KeyKey 2 is not affiliated with, or endorsed by, Yahoo.
+
 ## Project source code
 The original Yahoo KeyKey 2 source code (Swift engine + macOS app) is released
 under the MIT License — see `LICENSE`. It is an independent reimplementation and
 uses no source code from the original Yahoo! KeyKey (credited in `CREDITS.md`).
+Its bundled **data** is another matter: the 三代 tables above come from that
+project's source release, under its New BSD license.


### PR DESCRIPTION
`docs/THIRD-PARTY-NOTICES.md` listed McBopomofo, libtabe, OpenCC and the Cangjie-5 table — but omitted the two bundled tables that come from the Yahoo! KeyKey source release:

```
Resources/cangjie-yahoo.txt    81,693 lines   ← DataTables/cj-ext.cin
Resources/simplex-yahoo.txt    63,163 lines   ← DataTables/simplex-ext.cin
```

Both are copied into the `.app` by `tools/build-app.sh`. They are now a row in the component table and a section of their own.

## The notice is reproduced in full

BSD-3-Clause requires a binary redistribution to reproduce the copyright notice, **the three conditions** and **the disclaimer**. Nothing carried them: this file didn't mention the tables at all, and the published licences page summarised the licence and pointed at the project's COPYING — while reproducing Sparkle's MIT and OpenCC's Apache-2.0 in full on the same page.

Now reproduced verbatim, and checked mechanically rather than by eye: every non-empty line of `bency/YahooKeyKey`'s `LICENSE` appears in the reproduction (0 missing).

## The attributed holder is corrected

Both this file and the site said `Copyright (c) 2007-2010 Yahoo! Taiwan / Lithoglyph`. That line is **real** — "Lithoglyph" appears 56 times in the release — but it is **scoped, and not to these files**. The release's `COPYING` says:

> Refer to individual source code header for copyright notices. […] Projects under `PreferenceApplications/` and `Utilities/`, if unspecified, are developed by Lithoglyph Inc. for Yahoo! Taiwan. Copyright (c) 2007-2010 Yahoo! Taiwan.

`DataTables/` is neither, and `cj-ext.cin` carries no copyright line at all — only credits to b6s, yylin and opendesktop.org.tw. The operative notice is the project's, from the repository's `LICENSE`:

```
Copyright (c) 2012, Yahoo! Inc.  All rights reserved.
```

The 2007-2010 line is kept as provenance rather than presented as these tables' notice.

## "Uses no source code" now says which is which

That sentence is true — 62 Swift files, no C or Objective-C, and this repository's history starts fresh rather than as a fork. But it stood as the last word on the relationship while sitting beside 145,000 lines of that project's data with no mention, which reads as "nothing from there is used".

The third BSD condition is also *why* the file's non-affiliation sentence exists; that link is now stated rather than left as coincidence.

## Not changed — worth its own decision

**The `.app` bundles none of these notices.** `build-app.sh` copies the data tables but no licence document, so notices reach a user through About's "Open-source licenses" row, which opens the hosted page. ice-2 bundles `Acknowledgements.rtf` and `.pdf` instead.

Whether "documentation and/or other materials provided with the distribution" should mean a bundled file here is a real question — and it affects OpenCC's Apache-2.0 NOTICE requirement too, not just this table.

## Doc-only

No source, resource or build change, so no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)