### PR TITLE
release: 2.13.0 — the adaptive candidate order is now optional (#85)

### DIFF
--- a/App/GeneralPane.swift
+++ b/App/GeneralPane.swift
@@ -57,6 +57,10 @@ private struct GeneralPaneView: View {
                 .dragonAnnotation(LocalizedStringKey(L("keykey.general.cangjieVersionHint")))
                 Toggle(L("keykey.general.strokeConfirmation"), isOn: $model.strokeConfirmation)
                     .dragonAnnotation(LocalizedStringKey(L("keykey.general.strokeConfirmationHint")))
+                // Governs every input method, not just the 倉頡版本 above it — hence the explicit
+                // 倉頡/速成/拼音 list in the hint rather than a position that implies otherwise.
+                Toggle(L("keykey.general.adaptiveCandidateOrder"), isOn: $model.adaptiveCandidateOrder)
+                    .dragonAnnotation(LocalizedStringKey(L("keykey.general.adaptiveCandidateOrderHint")))
             }
 
             DragonSection(LocalizedStringKey(L("keykey.general.language"))) {

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.12.1</string>
+	<string>2.13.0</string>
 	<key>CFBundleVersion</key>
 	<string>23</string>
 	<key>ComponentInputModeDict</key>

--- a/App/InputController.swift
+++ b/App/InputController.swift
@@ -8,6 +8,10 @@ final class InputController: IMKInputController {
     // User learning: persisted selection-count store providing a live ranking bonus for
     // Cangjie/Simplex candidates, so committed characters surface higher next time.
     private let userFreq: UserFrequency
+    // The gated learning bonus handed to the engines, and read again when ordering 聯想. Stored
+    // rather than local to init because the association path needs the same closure — one gate,
+    // so the setting cannot apply to composition candidates and not to suggestions.
+    private let userRank: (Character) -> Double
     private let associatedPhrases: AssociatedPhrases
     // Traditional→Simplified character converter, applied only when Preferences.outputSimplifiedEnabled.
     private let hanConvertFilter: HanConvertFilter
@@ -40,8 +44,15 @@ final class InputController: IMKInputController {
         self.userFreq = shared.userFreq
 
         // Live user-learning bonus; the closure consults the shared store on every sort, so a
-        // freshly-committed character promotes without rebuilding the engine.
-        let userRank: (Character) -> Double = { shared.userFreq.bonus(for: $0) }
+        // freshly-committed character promotes without rebuilding the engine. It also reads
+        // Preferences on every call, so turning 依選字習慣調整候選字順序 off applies to the next
+        // composition — no engine rebuild and no notification needed (issue #85).
+        let userRank: (Character) -> Double = {
+            AdaptiveCandidateOrder.bonus(for: $0,
+                                         enabled: Preferences.adaptiveCandidateOrderEnabled,
+                                         learned: shared.userFreq.bonus(for:))
+        }
+        self.userRank = userRank
 
         // The input-method registry. Each module's makeEngine reads the shared tables and
         // rank LIVE, so rebuilding an engine after a 倉頡版本 change picks up the new table
@@ -359,6 +370,13 @@ final class InputController: IMKInputController {
                     clearAssociations()
                     if !suffix.isEmpty {
                         client.insertText(applyHanConvert(suffix), replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
+                        // Learn the continuation the user picked (係 from 關係), so it surfaces
+                        // earlier both here and when typed by code. Same store, same gate.
+                        if let ch = AdaptiveCandidateOrder.characterToLearn(
+                            fromAssociationSuffix: suffix,
+                            enabled: Preferences.adaptiveCandidateOrderEnabled) {
+                            userFreq.record(ch)
+                        }
                     }
                     return true
                 }
@@ -564,14 +582,19 @@ final class InputController: IMKInputController {
         if !text.isEmpty {
             client.insertText(applyHanConvert(text), replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
             // User learning: remember single-character selections so they rank higher next time.
-            if text.count == 1, let ch = text.first { userFreq.record(ch) }
+            // Nothing is recorded while adaptive ordering is off — the setting pauses learning as
+            // well as ignoring it, so a user who turned it off is not still being counted.
+            if let ch = AdaptiveCandidateOrder.characterToLearn(
+                fromCommitted: text, enabled: Preferences.adaptiveCandidateOrderEnabled) {
+                userFreq.record(ch)
+            }
         }
         client.setMarkedText("", selectionRange: NSRange(location: 0, length: 0),
                              replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
         // After an explicit user commit of a single character, offer associated phrases (聯想).
         // System-driven commits (focus loss, mode switch) pass offerAssociations: false and stay idle.
         if offerAssociations, Preferences.associatedPhrasesEnabled, text.count == 1, let first = text.first {
-            let phrases = associatedPhrases.associations(for: first)
+            let phrases = associatedPhrases.associations(for: first, userRank: userRank)
             if !phrases.isEmpty {
                 associations = phrases
                 candidatePage = 0

--- a/App/KeyEventPolicy.swift
+++ b/App/KeyEventPolicy.swift
@@ -1,9 +1,9 @@
 import AppKit
 
-// Pure decisions for InputController — key-event routing and input-session lifecycle — kept free
-// of IMK/engine state so they can be unit-tested. Both policies live in this one file because
-// tools/build-app.sh compiles an explicit list of App/ sources; a separate file would need to be
-// added there too.
+// Pure decisions for InputController — key-event routing, input-session lifecycle, and whether
+// user learning shapes the candidate order — kept free of IMK/engine state so they can be
+// unit-tested. All three policies live in this one file because tools/build-app.sh compiles an
+// explicit list of App/ sources; a separate file would need to be added there too.
 // See InputController.handle(_:client:).
 enum KeyEventPolicy {
     /// Whether a keyDown carrying these modifiers is an app/system shortcut the IME must not
@@ -141,5 +141,53 @@ enum SessionEndPolicy {
     static func action(hasComposition: Bool, hasAssociations: Bool) -> Action {
         if hasComposition { return .commit }
         return hasAssociations ? .dismiss : .idle
+    }
+}
+
+// Whether user learning shapes the candidate order, and what gets learned (issue #85).
+// See InputController.init and InputController.commitCurrent(to:offerAssociations:).
+//
+// Adaptive ordering is ON by default — 2.13.0 changes nothing for an existing install. Turned
+// off, candidates keep the static order the selected table and ranking give them (五代 its
+// built-in corpus ranking, 三代 the original Yahoo! KeyKey line order, 拼音 and 聯想 the language
+// model's own), so a typist who has memorised positions can rely on them. Learning is PAUSED, not
+// erased: nothing new is counted, and the counts already on disk are kept, so turning it back on
+// resumes where it left off rather than starting over.
+//
+// InputController itself needs a live IMKServer and cannot be unit-tested, which is why the two
+// decisions live here rather than inline at the call sites.
+enum AdaptiveCandidateOrder {
+    /// The ranking bonus to apply for `char` — the learned bonus while adaptive ordering is on,
+    /// zero when off.
+    ///
+    /// Zero is what makes the fallback work rather than a special case: every consumer adds this
+    /// on top of a static score, so with no bonus the Cangjie/Simplex sorts, the Pinyin walker's
+    /// candidate ordering and the 聯想 sort are each left with that static score alone. The engine
+    /// tests pin exactly that ("Default (zero) userRank must not perturb dict-only ordering").
+    static func bonus(for char: Character, enabled: Bool,
+                      learned: (Character) -> Double) -> Double {
+        enabled ? learned(char) : 0
+    }
+
+    /// The character to learn from a committed composition, or nil when there is nothing to learn.
+    ///
+    /// Only a commit whose WHOLE text is one character is learned, because UserFrequency counts
+    /// characters — a multi-character 拼音 commit has no single character to attribute.
+    static func characterToLearn(fromCommitted text: String, enabled: Bool) -> Character? {
+        guard enabled, text.count == 1 else { return nil }
+        return text.first
+    }
+
+    /// The character to learn from a picked 聯想 phrase, given the suffix that pick inserts
+    /// (`KeyEventPolicy.associationSuffix`), or nil when there is nothing to learn.
+    ///
+    /// The FIRST character of the suffix — 係 for 關係 — whatever the phrase's length. That is the
+    /// character the user chose to add, and it is the same one `AssociatedPhrases` ranks the
+    /// phrase by, so picking a suggestion both surfaces it earlier in 聯想 next time and lifts it
+    /// when typed by code. Unlike a composition commit there is no length condition: a longer
+    /// phrase still turns on that one continuation.
+    static func characterToLearn(fromAssociationSuffix suffix: String, enabled: Bool) -> Character? {
+        guard enabled else { return nil }
+        return suffix.first
     }
 }

--- a/App/Preferences.swift
+++ b/App/Preferences.swift
@@ -29,6 +29,7 @@ enum Preferences {
         static let codeHintEnabled = "codeHintEnabled"
         static let associationSelectionTrigger = "associationSelectionTrigger"
         static let strokeConfirmationEnabled = "strokeConfirmationEnabled"
+        static let adaptiveCandidateOrderEnabled = "adaptiveCandidateOrderEnabled"
     }
 
     static let minFontSize: CGFloat = 14
@@ -47,6 +48,7 @@ enum Preferences {
             Key.codeHintEnabled: false,
             Key.associationSelectionTrigger: AssociationTrigger.number.rawValue,
             Key.strokeConfirmationEnabled: false,
+            Key.adaptiveCandidateOrderEnabled: true,
         ])
     }
 
@@ -109,5 +111,14 @@ enum Preferences {
     static var strokeConfirmationEnabled: Bool {
         get { UserDefaults.standard.bool(forKey: Key.strokeConfirmationEnabled) }
         set { UserDefaults.standard.set(newValue, forKey: Key.strokeConfirmationEnabled) }
+    }
+
+    // When true (the default), the characters the user commits are counted and that count ranks
+    // the candidates — in 倉頡, 速成, 拼音 and 聯想 alike. Off, the built-in order stands and
+    // nothing is counted; see AdaptiveCandidateOrder, which holds the decision this drives, and
+    // issue #85 for why a typist who has memorised the order wants that.
+    static var adaptiveCandidateOrderEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: Key.adaptiveCandidateOrderEnabled) }
+        set { UserDefaults.standard.set(newValue, forKey: Key.adaptiveCandidateOrderEnabled) }
     }
 }

--- a/App/SettingsModel.swift
+++ b/App/SettingsModel.swift
@@ -55,6 +55,14 @@ final class SettingsModel {
         set { Preferences.strokeConfirmationEnabled = newValue }
     }
 
+    // 依選字習慣調整候選字順序 (issue #85): whether user learning ranks candidates and 聯想, or the
+    // built-in order stands. Another plain toggle, so a computed forwarder is right — InputController
+    // reads Preferences live on every sort and every commit, so nothing needs rebuilding here.
+    var adaptiveCandidateOrder: Bool {
+        get { Preferences.adaptiveCandidateOrderEnabled }
+        set { Preferences.adaptiveCandidateOrderEnabled = newValue }
+    }
+
     // Candidate text size. Like `cangjieVersion` below, this is a STORED, observation-tracked
     // property (seeded from Preferences at init) — NOT a computed forwarder. An @Observable
     // *computed* property bound to a Slider never registers an observation dependency in its

--- a/App/WhatsNewConfig.swift
+++ b/App/WhatsNewConfig.swift
@@ -6,36 +6,41 @@ import DragonKit
 // binary isn't. That makes the entries and the date the only things to keep in sync with
 // CHANGELOG.md on release.
 //
-// 2.12.1 claims one fix: `App/Info.plist` had no `NSHumanReadableCopyright`, so Finder's Get Info
-// panel showed no copyright line for Yahoo! KeyKey 2 at all. It now carries `© 2026 Teddy Chan` —
-// byte-for-byte the string the About pane's copyright row renders.
+// 2.13.0 claims one addition and one fix, both from issue #85.
 //
-// Found by auditing the field across all five Dragon apps, where it was in four different states:
-// a tagline in clipmenu-2, two holders in ice-2, and absent here, in spectacle-2 and in the sample
-// app. KeyKey is the app whose About copyright slot once held `倉頡／簡易 輸入法` — the defect
-// DragonKit still cites in `DragonAbout.copyright(years:holder:)` — so having the bundle's own
-// notice missing entirely was the same failure one field over. The key is an optional Apple one
-// that no licence names, so it is presentation, and the rule for presentation is the one About
-// already follows: a single holder, the app's own.
+// `.added` is the 依選字習慣調整候選字順序 toggle. Yahoo! KeyKey 2 has always counted the characters
+// you commit and ranked candidates by that count, with no way to stop it. The issue is from a
+// long-time 速成 typist who had memorised the candidate sequence: for them a list that keeps
+// rearranging itself is worse than one that never moves, because the position they reach for is no
+// longer the position the character is in. On by default, so nobody's existing install changes.
 //
-// `.fixed`, not `.added`. A bundle is expected to carry this field; the app shipped without it.
+// `.fixed` is the 聯想 ordering becoming reproducible. It is a real user-visible change and not
+// merely internal: `AssociatedPhrases` sorted on score alone through Swift's `sorted(by:)`, which
+// is not stable, so equal-scoring phrases sat in an arbitrary order — and because that same sort
+// feeds the 20-per-bucket cap, the arbitrariness decided which suggestions the user could ever see.
+// It is in this release rather than its own because making 聯想 frequency-ranked is what moved the
+// ordering from load time to query time; a promise that the order "does not change based on your
+// selections" is only true if the order is reproducible to begin with.
 //
-// Deliberately NOT in the notes: LICENSE's holder changes from "Lung Sang Chan (teddychan)" to
-// "Teddy Chan", so all five apps name the holder one way. That is the same person either way and
-// nothing a user can observe from inside the app — CHANGELOG.md carries it.
+// Deliberately NOT in the notes: the learning store, the 20-per-bucket cap and the What's New
+// mechanism itself are all unchanged, and the seven .strings files gain the setting's own two
+// strings, which the General pane shows rather than this pane.
 //
-// `keykey.whatsNew.allLanguages` is gone, replaced in place by `keykey.whatsNew.copyrightNotice`
-// in all seven .strings files. 2.12.0's `.added` entry has nothing to say here, and leaving the
-// key behind would strand that release's sentence in seven files waiting to be shown again.
+// `keykey.whatsNew.copyrightNotice` is gone, replaced by the two keys below in all seven .strings
+// files. 2.12.1's entry has nothing to say here, and leaving the key behind would strand that
+// release's sentence in seven files waiting to be shown again.
 enum WhatsNewConfig {
     @MainActor
     static var content: WhatsNewContent {
         WhatsNewContent(
-            date: "2026-08-11",
+            date: "2026-08-12",
             summary: L("keykey.whatsNew.summary"),
             sections: [
+                ChangeSection(kind: .added, entries: [
+                    L("keykey.whatsNew.adaptiveCandidateOrder"),
+                ]),
                 ChangeSection(kind: .fixed, entries: [
-                    L("keykey.whatsNew.copyrightNotice"),
+                    L("keykey.whatsNew.associationOrderStable"),
                 ]),
             ]
         )

--- a/App/en.lproj/Localizable.strings
+++ b/App/en.lproj/Localizable.strings
@@ -26,11 +26,14 @@
 "keykey.general.cangjieVersionHint" = "3rd-generation Cangjie uses the original Yahoo! KeyKey code table and candidate order (applied to both Cangjie and Simplex), effective immediately.";
 "keykey.general.strokeConfirmation" = "Press Space to confirm the code";
 "keykey.general.strokeConfirmationHint" = "In 速成, and in 倉頡 with the * wildcard, candidates appear before the code is finished, so Space flips to the next page instead of confirming what you typed. With this on, the first Space only confirms the code and keeps page 1 — press Space again to page, or 1–9 to pick. Plain 倉頡 is unaffected.";
+"keykey.general.adaptiveCandidateOrder" = "Adapt candidate order based on your selections";
+"keykey.general.adaptiveCandidateOrderHint" = "Applies to 倉頡, 速成, 拼音 and associated phrases: characters you pick move gradually forward. Turn it off for the built-in order — 五代 and 拼音 use their built-in rankings, 三代 the original Yahoo! KeyKey order — which also pauses learning, without erasing what you have already learned.";
 "keykey.general.language" = "Language";
 
-/* What's New pane (2.12.0) */
-"keykey.whatsNew.summary" = "A small fix: Yahoo! KeyKey 2 now carries a copyright notice, the same one shown in About. Nothing about typing changes.";
-"keykey.whatsNew.copyrightNotice" = "Finder's Get Info panel now shows Yahoo! KeyKey 2's copyright notice. The app carried none at all, so that line was simply blank.";
+/* What's New pane (2.13.0) */
+"keykey.whatsNew.summary" = "You can now turn off the adaptive candidate order, so the list stops rearranging itself and stays where you remember it.";
+"keykey.whatsNew.adaptiveCandidateOrder" = "A new setting in General ▸ Input Method, “Adapt candidate order based on your selections”, on by default. Turn it off and candidates in 倉頡, 速成, 拼音 and associated phrases keep their built-in order and stay there, and Yahoo! KeyKey 2 stops counting what you pick. Anything already learned is kept, so you can turn it back on whenever you like.";
+"keykey.whatsNew.associationOrderStable" = "Associated phrases that share the same score now always appear in the same order. That order used to be arbitrary and could differ between launches — and it also decided which suggestions made the list at all.";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "Disable Cangjie and Simplex from Input Sources";

--- a/App/es.lproj/Localizable.strings
+++ b/App/es.lproj/Localizable.strings
@@ -26,11 +26,14 @@
 "keykey.general.cangjieVersionHint" = "El «Cangjie de 3.ª generación» usa la tabla de códigos y el orden de candidatos del Yahoo! KeyKey original (se aplica tanto a 倉頡 como a 速成) y surte efecto de inmediato.";
 "keykey.general.strokeConfirmation" = "Pulsar Espacio para confirmar el código";
 "keykey.general.strokeConfirmationHint" = "En 速成, y en 倉頡 con el comodín *, los candidatos aparecen antes de que el código esté terminado, así que Espacio pasa a la página siguiente en lugar de confirmar lo que has escrito. Con esta opción activada, el primer Espacio solo confirma el código y se queda en la página 1: vuelve a pulsar Espacio para cambiar de página, o 1–9 para elegir. El 倉頡 normal no se ve afectado.";
+"keykey.general.adaptiveCandidateOrder" = "Adaptar el orden de los candidatos a tus selecciones";
+"keykey.general.adaptiveCandidateOrderHint" = "Se aplica a 倉頡, 速成, 拼音 y a las frases asociadas: los caracteres que eliges avanzan poco a poco. Desactívalo para conservar el orden incorporado — 五代 y 拼音 usan su clasificación incorporada; 三代, el orden original de Yahoo! KeyKey —, lo que además pausa el aprendizaje sin borrar lo ya aprendido.";
 "keykey.general.language" = "Idioma";
 
-/* What's New pane (2.12.0) */
-"keykey.whatsNew.summary" = "Una pequeña corrección: Yahoo! KeyKey 2 ya incluye un aviso de copyright, el mismo que muestra Acerca de. Nada cambia al escribir.";
-"keykey.whatsNew.copyrightNotice" = "El panel «Obtener información» del Finder ahora muestra el aviso de copyright de Yahoo! KeyKey 2. La app no incluía ninguno, así que esa línea aparecía vacía.";
+/* What's New pane (2.13.0) */
+"keykey.whatsNew.summary" = "Ya puedes desactivar el orden adaptativo de los candidatos, de modo que la lista deje de reordenarse y se quede donde la recuerdas.";
+"keykey.whatsNew.adaptiveCandidateOrder" = "Un nuevo ajuste en General ▸ Método de entrada, «Adaptar el orden de los candidatos a tus selecciones», activado de forma predeterminada. Si lo desactivas, los candidatos de 倉頡, 速成, 拼音 y las frases asociadas conservan su orden incorporado y ya no se mueven, y Yahoo! KeyKey 2 deja de registrar lo que eliges. Lo aprendido hasta ahora se conserva, así que puedes volver a activarlo cuando quieras.";
+"keykey.whatsNew.associationOrderStable" = "Las frases asociadas con la misma puntuación aparecen ahora siempre en el mismo orden. Antes ese orden era arbitrario y podía variar entre arranques, y además decidía qué sugerencias llegaban a la lista.";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "Desactivar 倉頡 y 速成 en Fuentes de entrada";

--- a/App/fr.lproj/Localizable.strings
+++ b/App/fr.lproj/Localizable.strings
@@ -26,11 +26,14 @@
 "keykey.general.cangjieVersionHint" = "Le « Cangjie de 3e génération » utilise la table de codes et l’ordre des candidats du Yahoo! KeyKey d’origine (appliqué à 倉頡 comme à 速成), avec effet immédiat.";
 "keykey.general.strokeConfirmation" = "Appuyer sur Espace pour valider le code";
 "keykey.general.strokeConfirmationHint" = "En 速成, et en 倉頡 avec le joker *, les candidats apparaissent avant que le code soit terminé : Espace passe donc à la page suivante au lieu de valider ce que vous avez tapé. Avec cette option, le premier Espace ne fait que valider le code et reste sur la page 1 — appuyez de nouveau sur Espace pour changer de page, ou sur 1–9 pour choisir. Le 倉頡 normal n’est pas affecté.";
+"keykey.general.adaptiveCandidateOrder" = "Adapter l’ordre des candidats à vos sélections";
+"keykey.general.adaptiveCandidateOrderHint" = "S’applique à 倉頡, 速成, 拼音 et aux phrases associées : les caractères que vous choisissez avancent peu à peu. Désactivez cette option pour conserver l’ordre intégré — 五代 et 拼音 utilisent leur classement intégré, 三代 l’ordre d’origine de Yahoo! KeyKey —, ce qui met aussi l’apprentissage en pause sans effacer ce qui a déjà été appris.";
 "keykey.general.language" = "Langue";
 
-/* What's New pane (2.12.0) */
-"keykey.whatsNew.summary" = "Une petite correction : Yahoo! KeyKey 2 comporte désormais une mention de copyright, la même que celle affichée dans À propos. Rien ne change à la saisie.";
-"keykey.whatsNew.copyrightNotice" = "La fenêtre « Lire les informations » du Finder affiche désormais la mention de copyright de Yahoo! KeyKey 2. L’app n’en comportait aucune, la ligne restait donc vide.";
+/* What's New pane (2.13.0) */
+"keykey.whatsNew.summary" = "Vous pouvez désormais désactiver l’ordre adaptatif des candidats : la liste cesse de se réorganiser et reste là où vous l’avez mémorisée.";
+"keykey.whatsNew.adaptiveCandidateOrder" = "Un nouveau réglage dans Général ▸ Méthode de saisie, « Adapter l’ordre des candidats à vos sélections », activé par défaut. Une fois désactivé, les candidats de 倉頡, 速成, 拼音 et les phrases associées conservent leur ordre intégré et n’en bougent plus, et Yahoo! KeyKey 2 cesse de comptabiliser vos choix. Ce qui a déjà été appris est conservé : vous pouvez le réactiver quand vous voulez.";
+"keykey.whatsNew.associationOrderStable" = "Les phrases associées de score identique apparaissent désormais toujours dans le même ordre. Cet ordre était auparavant arbitraire et pouvait changer d’un lancement à l’autre — il déterminait aussi quelles suggestions figuraient dans la liste.";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "Désactiver 倉頡 et 速成 dans les sources de saisie";

--- a/App/ja.lproj/Localizable.strings
+++ b/App/ja.lproj/Localizable.strings
@@ -26,11 +26,14 @@
 "keykey.general.cangjieVersionHint" = "「第3世代倉頡」はオリジナルの Yahoo! KeyKey のコード表と候補順を使います（倉頡と速成の両方に適用）。すぐに反映されます。";
 "keykey.general.strokeConfirmation" = "スペースキーでコードを確定";
 "keykey.general.strokeConfirmationHint" = "速成、および * ワイルドカードを使う倉頡では、コードを打ち終わる前に候補が出るため、スペースキーは打ったコードを確定せずに次のページへ送ってしまいます。オンにすると、最初のスペースキーはコードの確定だけを行い 1 ページ目に留まります。もう一度スペースキーを押すとページが進み、1〜9 で直接選べます。通常の倉頡は影響を受けません。";
+"keykey.general.adaptiveCandidateOrder" = "選んだ字に合わせて候補の順序を調整";
+"keykey.general.adaptiveCandidateOrderHint" = "倉頡・速成・拼音と聯想語に適用されます。よく選ぶ字が少しずつ前に移動します。オフにすると内蔵の順序のまま固定され（五代と拼音は内蔵の頻度順、三代は Yahoo! KeyKey 本来の順序）、学習も一時停止します。すでに学習した内容は消えずに残ります。";
 "keykey.general.language" = "言語";
 
-/* What's New pane (2.12.0) */
-"keykey.whatsNew.summary" = "小さな修正です。Yahoo! KeyKey 2 に著作権表示が追加され、「情報」に表示されるものと同じになりました。入力の動作は何も変わりません。";
-"keykey.whatsNew.copyrightNotice" = "Finder の「情報を見る」に Yahoo! KeyKey 2 の著作権表示が表示されるようになりました。これまではアプリが著作権表示を持っておらず、その欄は空のままでした。";
+/* What's New pane (2.13.0) */
+"keykey.whatsNew.summary" = "候補の自動並べ替えをオフにできるようになりました。候補が動かなくなり、覚えた位置のままになります。";
+"keykey.whatsNew.adaptiveCandidateOrder" = "「一般 ▸ 入力方式」に「選んだ字に合わせて候補の順序を調整」を追加しました（初期設定はオン）。オフにすると、倉頡・速成・拼音と聯想語の候補は内蔵の順序のまま動かなくなり、Yahoo! KeyKey 2 は選んだ字の記録も行いません。すでに学習した内容は保持されるので、いつでもオンに戻せます。";
+"keykey.whatsNew.associationOrderStable" = "スコアが同じ聯想語が、常に同じ順序で表示されるようになりました。これまでは順序が一定でなく、起動のたびに変わることがあり、どの候補が一覧に載るかにも影響していました。";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "入力ソースから倉頡と速成を無効にする";

--- a/App/ko.lproj/Localizable.strings
+++ b/App/ko.lproj/Localizable.strings
@@ -26,11 +26,14 @@
 "keykey.general.cangjieVersionHint" = "「3세대 창힐」은 원래 Yahoo! KeyKey의 코드표와 후보 순서를 사용합니다(창힐과 속성 모두에 적용). 즉시 적용됩니다.";
 "keykey.general.strokeConfirmation" = "스페이스로 코드 확정";
 "keykey.general.strokeConfirmationHint" = "속성, 그리고 * 와일드카드를 사용하는 창힐에서는 코드를 다 입력하기 전에 후보가 나타나므로, 스페이스가 입력한 코드를 확정하지 않고 다음 페이지로 넘어갑니다. 이 옵션을 켜면 첫 번째 스페이스는 코드만 확정하고 1페이지에 머무릅니다. 페이지를 넘기려면 스페이스를 한 번 더 누르거나 1~9로 바로 선택하세요. 일반 창힐은 영향을 받지 않습니다.";
+"keykey.general.adaptiveCandidateOrder" = "선택한 글자에 맞춰 후보 순서 조정";
+"keykey.general.adaptiveCandidateOrderHint" = "倉頡, 速成, 拼音과 연상 어구에 적용됩니다. 자주 선택하는 글자가 점차 앞으로 이동합니다. 끄면 기본 순서가 그대로 유지되고(五代와 拼音은 내장 빈도순, 三代는 Yahoo! KeyKey 원래 순서) 학습도 일시 중지됩니다. 이미 학습한 내용은 지워지지 않고 남습니다.";
 "keykey.general.language" = "언어";
 
-/* What's New pane (2.12.0) */
-"keykey.whatsNew.summary" = "작은 수정입니다. Yahoo! KeyKey 2에 저작권 표시가 추가되어 정보 화면에 표시되는 것과 같아졌습니다. 입력 동작은 전혀 바뀌지 않습니다.";
-"keykey.whatsNew.copyrightNotice" = "Finder의 ‘정보 가져오기’ 창에 Yahoo! KeyKey 2의 저작권 표시가 나옵니다. 앱에 저작권 표시가 전혀 없어 해당 줄이 비어 있었습니다.";
+/* What's New pane (2.13.0) */
+"keykey.whatsNew.summary" = "이제 후보 순서 자동 조정을 끌 수 있습니다. 목록이 더 이상 재배열되지 않고 기억하는 자리에 그대로 있습니다.";
+"keykey.whatsNew.adaptiveCandidateOrder" = "일반 ▸ 입력 방식에 ‘선택한 글자에 맞춰 후보 순서 조정’ 설정이 추가되었습니다. 기본값은 켬입니다. 끄면 倉頡, 速成, 拼音과 연상 어구의 후보가 기본 순서를 유지하며 움직이지 않고, Yahoo! KeyKey 2도 무엇을 선택했는지 기록하지 않습니다. 이미 학습한 내용은 유지되므로 언제든 다시 켤 수 있습니다.";
+"keykey.whatsNew.associationOrderStable" = "점수가 같은 연상 어구가 이제 항상 같은 순서로 표시됩니다. 이전에는 그 순서가 일정하지 않아 실행할 때마다 달라질 수 있었고, 어떤 제안이 목록에 오르는지에도 영향을 주었습니다.";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "입력 소스에서 창힐과 속성 사용 중지";

--- a/App/zh-Hans.lproj/Localizable.strings
+++ b/App/zh-Hans.lproj/Localizable.strings
@@ -26,11 +26,14 @@
 "keykey.general.cangjieVersionHint" = "「三代仓颉」使用 Yahoo! KeyKey 原版的拆码与候选字顺序（同时应用于仓颉与速成），立即生效。";
 "keykey.general.strokeConfirmation" = "以空格键确认字根";
 "keykey.general.strokeConfirmationHint" = "在速成、以及使用通配符（*）的仓颉中，字根还没输完就会出现候选字，此时空格键会直接翻到下一页，而不是确认你输入的字根。开启后，第一次按空格键只确认字根并停留在第 1 页；再按一次空格键才翻页，或直接按 1–9 选字。普通仓颉不受影响。";
+"keykey.general.adaptiveCandidateOrder" = "依选字习惯调整候选字顺序";
+"keykey.general.adaptiveCandidateOrderHint" = "适用于仓颉、速成、拼音与联想词：你常选的字会逐渐往前移。关闭后改用内建顺序（五代与拼音使用内建词频，三代使用 Yahoo! KeyKey 原版顺序），同时暂停学习，但已经学到的记录会保留，不会清除。";
 "keykey.general.language" = "语言";
 
-/* What's New pane (2.12.0) */
-"keykey.whatsNew.summary" = "一处小修复：Yahoo! KeyKey 2 现在带有版权声明，与「关于」中显示的一致。打字的部分完全没有改变。";
-"keykey.whatsNew.copyrightNotice" = "访达的「显示简介」现在会显示 Yahoo! KeyKey 2 的版权声明。此前应用完全没有版权声明，该行一直是空的。";
+/* What's New pane (2.13.0) */
+"keykey.whatsNew.summary" = "现在可以关闭自动调整候选字顺序，候选字不再随你的选字而移动，永远停在你记得的位置。";
+"keykey.whatsNew.adaptiveCandidateOrder" = "「通用 ▸ 输入方式」新增「依选字习惯调整候选字顺序」，默认开启。关闭后，仓颉、速成、拼音与联想词都会维持内建顺序不再变动，Yahoo! KeyKey 2 也会停止记录你选了哪些字；已经学到的记录会保留，随时可以再开启。";
+"keykey.whatsNew.associationOrderStable" = "分数相同的联想词现在每次都会以相同顺序出现。此前这个顺序并不固定，重新启动后可能不同，也会影响哪些联想词能出现在列表中。";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "从输入源中停用仓颉与速成";

--- a/App/zh-Hant.lproj/Localizable.strings
+++ b/App/zh-Hant.lproj/Localizable.strings
@@ -26,11 +26,14 @@
 "keykey.general.cangjieVersionHint" = "「三代倉頡」使用 Yahoo! KeyKey 原版的拆碼與候選字順序（同時套用到倉頡與速成），立即生效。";
 "keykey.general.strokeConfirmation" = "以空白鍵確認字根";
 "keykey.general.strokeConfirmationHint" = "在速成、以及使用萬用字元（*）的倉頡中，字根還沒打完就會出現候選字，此時空白鍵會直接翻到下一頁，而不是確認你打的字根。開啟後，第一次按空白鍵只會確認字根並停留在第 1 頁；再按一次空白鍵才翻頁，或直接按 1–9 選字。一般倉頡不受影響。";
+"keykey.general.adaptiveCandidateOrder" = "依選字習慣調整候選字順序";
+"keykey.general.adaptiveCandidateOrderHint" = "套用於倉頡、速成、拼音與聯想字詞：你常選的字會逐漸往前移。關閉後改用內建順序（五代與拼音使用內建詞頻，三代使用 Yahoo! KeyKey 原版順序），同時暫停學習，但已經學到的紀錄會保留，不會清除。";
 "keykey.general.language" = "語言";
 
-/* What's New pane (2.12.0) */
-"keykey.whatsNew.summary" = "一處小修正：Yahoo! KeyKey 2 現在帶有版權聲明，與「關於」中顯示的一致。打字的部分完全沒有改變。";
-"keykey.whatsNew.copyrightNotice" = "Finder 的「顯示簡介」現在會顯示 Yahoo! KeyKey 2 的版權聲明。先前應用程式完全沒有版權聲明，該行一直是空的。";
+/* What's New pane (2.13.0) */
+"keykey.whatsNew.summary" = "現在可以關閉自動調整候選字順序，候選字不再隨你的選字而移動，永遠停在你記得的位置。";
+"keykey.whatsNew.adaptiveCandidateOrder" = "「一般 ▸ 輸入方式」新增「依選字習慣調整候選字順序」，預設開啟。關閉後，倉頡、速成、拼音與聯想字詞都會維持內建順序不再變動，Yahoo! KeyKey 2 也會停止記錄你選了哪些字；已經學到的紀錄會保留，隨時可以再開啟。";
+"keykey.whatsNew.associationOrderStable" = "分數相同的聯想字詞現在每次都會以相同順序出現。先前這個順序並不固定，重新啟動後可能不同，也會影響哪些聯想詞能出現在清單中。";
 
 /* Uninstall pane checklist */
 "keykey.uninstall.item.inputSources" = "從輸入來源中停用倉頡與速成";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,19 @@ A plain-language list of changes in each version, newest first.
   moved the ordering from load time to typing time: an order can only be promised not to change
   with your selections if it is reproducible to begin with.
 
+- **Known limitation, now written down: a rare character you keep picking may never reach the
+  front.** Adaptive ranking lifts a character *within* the dictionary's own ordering, so a
+  character the bundled language model does not know cannot overtake one it does, however many
+  times you pick it. Under `卜月卜尸心`, 龍 is in the model and the variant 㡣 is not, so 㡣 stays
+  second permanently. Roughly four in five characters in the 五代 table are outside the model, and
+  about two in five codes with more than one candidate mix the two kinds.
+
+  Nothing here changes — this is how ranking has always worked, and it is now described in the
+  README's Troubleshooting section instead of being a surprise. It does not affect 聯想字詞, where
+  every phrase is scored and one selection is enough to reach the top. Fixing it means changing
+  the ranking for everyone who has learning switched on, not only those using the new toggle, so
+  it is deliberately left for a release of its own.
+
 - **Under the hood: `docs/RELEASE.md` no longer describes the retired appcast mirror.** The
   release workflow stopped publishing a second copy of the update feed to the website in 2.12.0,
   but the release instructions still described that mirror as live and said it would be dropped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 A plain-language list of changes in each version, newest first.
 
+## 2.13.0
+
+- **Added: the adaptive candidate order can now be turned off.** A new toggle in **設定… ▸ 一般 ▸
+  輸入方式**, **依選字習慣調整候選字順序**, on by default — so nothing changes unless you want it to.
+  Turn it off and candidates keep their built-in order and stay there: 五代 and 拼音 use their
+  built-in rankings, 三代 the original Yahoo! KeyKey order, and 聯想字詞 the language model's. It
+  covers all three input methods and the associated phrases, not just one of them.
+
+  Yahoo! KeyKey 2 has always counted the characters you commit and ranked candidates by that
+  count, with no way to stop it. [Issue #85](https://github.com/teddychan/yahoo-keykey-2/issues/85)
+  is from a long-time 速成 typist who had memorised the candidate sequence, and for them a list
+  that keeps rearranging itself is worse than one that never moves — the position they reach for
+  is no longer the position the character is in.
+
+  Turning it off **pauses** learning rather than erasing it. Nothing new is counted, and what has
+  already been learned stays on disk, so turning it back on resumes where you left off instead of
+  starting from nothing. (Uninstall still removes that data, as it always has.)
+
+- **Fixed: associated phrases with the same score now always appear in the same order.** They were
+  sorted on score alone, and Swift's sort makes no promise about equally-scoring items, so their
+  order was arbitrary and could differ between launches. Because that same sort decides which 20
+  suggestions per character are kept, it also decided which ones you could see at all. Both the
+  order and the selection are now reproducible. A few phrases may sit in slightly different
+  positions than before, with the new toggle on or off — that is the fix.
+
+  It ships here rather than on its own because making 聯想字詞 respond to what you pick is what
+  moved the ordering from load time to typing time: an order can only be promised not to change
+  with your selections if it is reproducible to begin with.
+
+- **Under the hood: `docs/RELEASE.md` no longer describes the retired appcast mirror.** The
+  release workflow stopped publishing a second copy of the update feed to the website in 2.12.0,
+  but the release instructions still described that mirror as live and said it would be dropped
+  "at the next minor release" — which is this one. Anyone cutting a manual release by that
+  document would have pushed to an unrelated repository for no reason. Nothing about update
+  delivery changes; only the instructions were stale.
+
 ## 2.12.1
 
 - **Fixed: Yahoo! KeyKey 2 now carries a copyright notice.** `App/Info.plist` had no

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/ConfigContentTests.swift
@@ -88,25 +88,26 @@ final class ConfigContentTests: XCTestCase {
         let short = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         XCTAssertEqual(content.displayVersion, DragonVersion.display(short ?? "1.0.0"))
         XCTAssertTrue(content.displayVersion.hasPrefix("v"))
-        XCTAssertEqual(content.date, "2026-08-11")
+        XCTAssertEqual(content.date, "2026-08-12")
     }
 
-    // 2.12.1 is a single `.fixed`: `App/Info.plist` had no `NSHumanReadableCopyright`, so Finder's
-    // Get Info panel showed no copyright line for the app at all. It now carries
-    // `© 2026 Teddy Chan`, byte-for-byte what About's copyright row renders.
+    // 2.13.0 is an `.added` and a `.fixed`, both from issue #85.
     //
-    // `.fixed`, not `.added` — a bundle is expected to carry that field, and this one shipped
-    // without it. KeyKey is the app whose About copyright slot once held `倉頡／簡易 輸入法`, the
-    // defect DragonKit still cites in `DragonAbout.copyright(years:holder:)`; the bundle's own
-    // notice being absent was the same failure one field over.
+    // `.added` is the 依選字習慣調整候選字順序 toggle. KeyKey has always counted committed characters
+    // and ranked candidates by that count with no way to stop it; the issue is from a long-time 速成
+    // typist who had memorised the sequence, for whom a list that rearranges itself is worse than
+    // one that never moves. On by default, so no existing install changes.
     //
-    // One entry, and no second section. LICENSE's holder also changes here, from "Lung Sang Chan
-    // (teddychan)" to "Teddy Chan" so all five apps name it one way — but that is the same person
-    // either way and nothing observable from inside the app, so claiming it would be padding.
+    // `.fixed` is 聯想 ordering becoming reproducible — user-visible, not internal plumbing.
+    // `AssociatedPhrases` sorted on score alone through `sorted(by:)`, which is not a stable sort,
+    // so equal-scoring phrases sat in an arbitrary order; because that sort also feeds the
+    // 20-per-bucket cap, it decided which suggestions the user could ever see. It ships here
+    // because making 聯想 frequency-ranked is what moved ordering from load time to query time.
     //
-    // 2.12.0 pinned a single `.added` for the five localizations KeyKey did not have. 2.11.5 and
-    // 2.11.6 each carried a DragonKit pin entry because the bump was the substance of those
-    // releases; 2.11.2 pinned [.improved, .fixed] for a different pair.
+    // Two sections, so this is the first release since 2.11.2 ([.improved, .fixed]) to carry more
+    // than one. 2.12.1 was a single `.fixed` for the bundle's missing `NSHumanReadableCopyright`;
+    // 2.12.0 a single `.added` for the five missing localizations; 2.11.5 and 2.11.6 each a
+    // DragonKit pin entry, because the bump was the substance of those releases.
     //
     // Entry KEYS are pinned, not just kinds and counts, because kinds and counts had stopped
     // catching anything: 2.11.3, 2.11.4 and the 2.11.5 draft were all [.changed] with one entry —
@@ -117,12 +118,13 @@ final class ConfigContentTests: XCTestCase {
     // text SAYS is the release gate's job — it diffs every locale's .strings file — so between
     // them a stale pane cannot ship.
     @MainActor
-    func testWhatsNewAnnouncesTheCopyrightNoticeFix() {
+    func testWhatsNewAnnouncesTheAdaptiveOrderToggleAndTheStableAssociationOrder() {
         let content = WhatsNewConfig.content
-        XCTAssertEqual(content.sections.map(\.kind), [.fixed])
-        XCTAssertEqual(content.sections.map(\.entries.count), [1])
+        XCTAssertEqual(content.sections.map(\.kind), [.added, .fixed])
+        XCTAssertEqual(content.sections.map(\.entries.count), [1, 1])
         XCTAssertEqual(content.sections.flatMap(\.entries), [
-            L("keykey.whatsNew.copyrightNotice"),
+            L("keykey.whatsNew.adaptiveCandidateOrder"),
+            L("keykey.whatsNew.associationOrderStable"),
         ])
     }
 

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/KeyEventPolicyTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/KeyEventPolicyTests.swift
@@ -54,4 +54,62 @@ final class KeyEventPolicyTests: XCTestCase {
         XCTAssertFalse(KeyEventPolicy.isSystemShortcut([.option]))
         XCTAssertFalse(KeyEventPolicy.isSystemShortcut([.shift, .capsLock]))
     }
+
+    // MARK: - AdaptiveCandidateOrder (issue #85)
+
+    func testBonusIsTheLearnedValueWhenEnabled() {
+        XCTAssertEqual(AdaptiveCandidateOrder.bonus(for: "漏", enabled: true,
+                                                    learned: { $0 == "漏" ? 7 : 0 }), 7)
+    }
+
+    func testBonusIsZeroWhenDisabled() {
+        // Zero is the whole mechanism: every consumer adds this to a static score, so zero leaves
+        // the Cangjie/Simplex sorts, the Pinyin walker and the 聯想 sort on that score alone.
+        XCTAssertEqual(AdaptiveCandidateOrder.bonus(for: "漏", enabled: false,
+                                                    learned: { _ in 999 }), 0)
+    }
+
+    func testSingleCharacterCommitIsLearnedWhenEnabled() {
+        XCTAssertEqual(AdaptiveCandidateOrder.characterToLearn(fromCommitted: "漏", enabled: true), "漏")
+    }
+
+    func testNothingIsLearnedFromACommitWhenDisabled() {
+        // The setting pauses learning as well as ignoring it — a user who turned it off is not
+        // still being counted in the background.
+        XCTAssertNil(AdaptiveCandidateOrder.characterToLearn(fromCommitted: "漏", enabled: false))
+    }
+
+    func testMultiCharacterCommitIsNotLearned() {
+        // UserFrequency counts characters, so a multi-character 拼音 commit has no single
+        // character to attribute. Unchanged from the pre-toggle behaviour.
+        XCTAssertNil(AdaptiveCandidateOrder.characterToLearn(fromCommitted: "今天", enabled: true))
+    }
+
+    func testEmptyCommitIsNotLearned() {
+        XCTAssertNil(AdaptiveCandidateOrder.characterToLearn(fromCommitted: "", enabled: true))
+    }
+
+    func testAssociationPickLearnsTheContinuation() {
+        // 關係 inserts the suffix 係, and 係 is what the user chose — the same character
+        // AssociatedPhrases ranks the phrase by.
+        XCTAssertEqual(AdaptiveCandidateOrder.characterToLearn(fromAssociationSuffix: "係",
+                                                               enabled: true), "係")
+    }
+
+    func testLongerAssociationLearnsOnlyTheFirstContinuation() {
+        // No length condition here, unlike a composition commit: a three-character phrase still
+        // turns on the one continuation character it adds first.
+        XCTAssertEqual(AdaptiveCandidateOrder.characterToLearn(fromAssociationSuffix: "係人",
+                                                               enabled: true), "係")
+    }
+
+    func testNothingIsLearnedFromAnAssociationWhenDisabled() {
+        XCTAssertNil(AdaptiveCandidateOrder.characterToLearn(fromAssociationSuffix: "係",
+                                                             enabled: false))
+    }
+
+    func testEmptyAssociationSuffixLearnsNothing() {
+        // A one-character "phrase" inserts nothing, so there is nothing to attribute.
+        XCTAssertNil(AdaptiveCandidateOrder.characterToLearn(fromAssociationSuffix: "", enabled: true))
+    }
 }

--- a/Packages/KeyKeyApp/Tests/KeyKeyAppTests/PreferencesTests.swift
+++ b/Packages/KeyKeyApp/Tests/KeyKeyAppTests/PreferencesTests.swift
@@ -10,7 +10,8 @@ final class PreferencesTests: XCTestCase {
     override func tearDown() {
         for key in ["candidateFontSize", "associatedPhrasesEnabled", "fullWidthPunctuationEnabled",
                     "outputSimplifiedEnabled", "cangjieVersion", "associationContinuationOnly",
-                    "codeHintEnabled", "associationSelectionTrigger", "strokeConfirmationEnabled"] {
+                    "codeHintEnabled", "associationSelectionTrigger", "strokeConfirmationEnabled",
+                    "adaptiveCandidateOrderEnabled"] {
             defaults.removeObject(forKey: key)
         }
         super.tearDown()
@@ -78,6 +79,11 @@ final class PreferencesTests: XCTestCase {
         XCTAssertTrue(Preferences.strokeConfirmationEnabled)
         Preferences.strokeConfirmationEnabled = false
         XCTAssertFalse(Preferences.strokeConfirmationEnabled)
+
+        Preferences.adaptiveCandidateOrderEnabled = false
+        XCTAssertFalse(Preferences.adaptiveCandidateOrderEnabled)
+        Preferences.adaptiveCandidateOrderEnabled = true
+        XCTAssertTrue(Preferences.adaptiveCandidateOrderEnabled)
     }
 
     // Issue #61: absent (never set) must read false, so an existing install keeps today's
@@ -85,6 +91,18 @@ final class PreferencesTests: XCTestCase {
     func testStrokeConfirmationDefaultsOffWhenAbsent() {
         defaults.removeObject(forKey: "strokeConfirmationEnabled")
         XCTAssertFalse(Preferences.strokeConfirmationEnabled)
+    }
+
+    // Issue #85: this is the one new toggle that defaults ON, so the registered default is what
+    // an existing install relies on. Written explicitly rather than removing the key and reading,
+    // because `bool(forKey:)` on a truly absent key with no registration returns false — the
+    // opposite of the intended default. testRegisterDefaultsSuppliesSensibleFirstLaunchValues
+    // covers the registration itself.
+    func testAdaptiveCandidateOrderRoundTripsBothWays() {
+        defaults.set(false, forKey: "adaptiveCandidateOrderEnabled")
+        XCTAssertFalse(Preferences.adaptiveCandidateOrderEnabled)
+        defaults.set(true, forKey: "adaptiveCandidateOrderEnabled")
+        XCTAssertTrue(Preferences.adaptiveCandidateOrderEnabled)
     }
 
     // MARK: cangjieVersion
@@ -141,7 +159,8 @@ final class PreferencesTests: XCTestCase {
     func testRegisterDefaultsSuppliesSensibleFirstLaunchValues() {
         for key in ["candidateFontSize", "associatedPhrasesEnabled", "fullWidthPunctuationEnabled",
                     "outputSimplifiedEnabled", "cangjieVersion", "associationContinuationOnly",
-                    "codeHintEnabled", "associationSelectionTrigger", "strokeConfirmationEnabled"] {
+                    "codeHintEnabled", "associationSelectionTrigger", "strokeConfirmationEnabled",
+                    "adaptiveCandidateOrderEnabled"] {
             defaults.removeObject(forKey: key)
         }
         Preferences.registerDefaults()
@@ -151,6 +170,11 @@ final class PreferencesTests: XCTestCase {
         XCTAssertFalse(Preferences.associationContinuationOnly)
         XCTAssertFalse(Preferences.codeHintEnabled)
         XCTAssertFalse(Preferences.strokeConfirmationEnabled)
+        // ON by default (issue #85): 2.13.0 must not change how an existing install ranks
+        // candidates. Asserted HERE and not only via tearDown, because a registered default
+        // outlives removeObject — a key missing from the removal list above could otherwise pass
+        // on a value some earlier test left behind.
+        XCTAssertTrue(Preferences.adaptiveCandidateOrderEnabled)
         XCTAssertEqual(Preferences.cangjieVersion, .v5)
         XCTAssertEqual(Preferences.associationSelectionTrigger, .number)
         XCTAssertEqual(Preferences.candidateFontSize, 18)    // defaultFontSize

--- a/Packages/KeyKeyEngine/Sources/KeyKeyEngine/AssociatedPhrases.swift
+++ b/Packages/KeyKeyEngine/Sources/KeyKeyEngine/AssociatedPhrases.swift
@@ -5,7 +5,15 @@ import Foundation
 public struct AssociatedPhrases {
     private static let maxPerBucket = 20
 
-    private var table: [Character: [String]] = [:]
+    // A phrase and the LM score it was loaded with. The score is KEPT rather than consumed by a
+    // load-time sort because ordering is decided per query: `associations(for:userRank:)` adds the
+    // live user-learning bonus on top of it (issue #85), and that bonus changes as the user types.
+    private struct Entry {
+        let phrase: String
+        let score: Double
+    }
+
+    private var table: [Character: [Entry]] = [:]
 
     /// Builds from already-split LM lines. Callers that already have the file split into
     /// lines (e.g. to also build `LanguageModel.characterScores` from the same lines) should
@@ -25,14 +33,24 @@ public struct AssociatedPhrases {
         table.reserveCapacity(scored.count)
         for (first, entries) in scored {
             var seen = Set<String>()
-            var phrases: [String] = []
-            for entry in entries.sorted(by: { $0.score > $1.score }) {
+            var kept: [Entry] = []
+            // Ties broken by the order the lines were read. `sorted(by:)` is NOT a stable sort, so
+            // score alone left equal-scoring phrases in an arbitrary order — and because this sort
+            // feeds the cap below, that arbitrariness decided WHICH phrases survive, i.e. which
+            // ones the user can ever see. The offset makes the bucket reproducible.
+            let ordered = entries.enumerated().sorted { lhs, rhs in
+                if lhs.element.score != rhs.element.score { return lhs.element.score > rhs.element.score }
+                return lhs.offset < rhs.offset
+            }
+            for (_, entry) in ordered {
                 if seen.insert(entry.phrase).inserted {
-                    phrases.append(entry.phrase)
-                    if phrases.count == Self.maxPerBucket { break }
+                    kept.append(Entry(phrase: entry.phrase, score: entry.score))
+                    // Cap at load: it bounds memory, and a phrase below the top 20 by LM score is
+                    // out of reach in the 9-per-page window whatever the user bonus does to it.
+                    if kept.count == Self.maxPerBucket { break }
                 }
             }
-            table[first] = phrases
+            table[first] = kept
         }
     }
 
@@ -44,5 +62,27 @@ public struct AssociatedPhrases {
         try self.init(text: String(contentsOf: url, encoding: .utf8))
     }
 
-    public func associations(for first: Character) -> [String] { table[first] ?? [] }
+    /// The phrases suggested after `first` was committed, best first.
+    ///
+    /// Ordered by LM score plus the live user-learning bonus for each phrase's CONTINUATION
+    /// character — 係 in 關係 — which is the character the user is actually choosing to add, and
+    /// what the 聯想只顯示接續字 display option already shows. The phrase's FIRST character would
+    /// be the wrong input: it is this bucket's index key, identical for every phrase in it, so its
+    /// bonus is a constant that reorders nothing.
+    ///
+    /// With the default (zero) bonus the static LM order is preserved exactly, so a caller that
+    /// does not opt into user learning sees what it always saw. Ties resolve by the bucket's own
+    /// order, so the result is reproducible.
+    public func associations(for first: Character,
+                             userRank: (Character) -> Double = { _ in 0 }) -> [String] {
+        guard let entries = table[first] else { return [] }
+        // Score each entry ONCE, then sort the (offset, phrase, score) triples — same shape as
+        // CangjieEngine/SimplexEngine.computeCandidates.
+        return entries.enumerated().map { offset, entry in
+            (offset, entry.phrase, entry.score + (entry.phrase.dropFirst().first.map(userRank) ?? 0))
+        }.sorted { lhs, rhs in
+            if lhs.2 != rhs.2 { return lhs.2 > rhs.2 }
+            return lhs.0 < rhs.0
+        }.map(\.1)
+    }
 }

--- a/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/AssociatedPhrasesTests.swift
+++ b/Packages/KeyKeyEngine/Tests/KeyKeyEngineTests/AssociatedPhrasesTests.swift
@@ -37,4 +37,43 @@ final class AssociatedPhrasesTests: XCTestCase {
         let ap = AssociatedPhrases(text: Self.fixture)
         XCTAssertEqual(ap.associations(for: "#"), [])
     }
+
+    // MARK: user-learning bonus (issue #85)
+
+    func testDefaultZeroBonusPreservesTheStaticOrder() {
+        // The off path: no userRank argument must mean exactly what the LM scores said. Same
+        // expectation as testAssociationsBestFirst, asserted here as the contract it now is.
+        let ap = AssociatedPhrases(text: Self.fixture)
+        XCTAssertEqual(ap.associations(for: "今", userRank: { _ in 0 }), ["今天", "今日", "今晚"])
+    }
+
+    func testBonusOnTheContinuationLiftsThatPhrase() {
+        // 晚 is last on LM score (-5.0 against -3.2). A bonus on it — the CONTINUATION character,
+        // the one the user picks — carries 今晚 to the front.
+        let ap = AssociatedPhrases(text: Self.fixture)
+        XCTAssertEqual(ap.associations(for: "今", userRank: { $0 == "晚" ? 100 : 0 }),
+                       ["今晚", "今天", "今日"])
+    }
+
+    func testBonusOnTheIndexCharacterChangesNothing() {
+        // 今 is the bucket's key, shared by every phrase in it, so its bonus is a constant that
+        // must not reorder anything. This is why the continuation is what the sort reads.
+        let ap = AssociatedPhrases(text: Self.fixture)
+        XCTAssertEqual(ap.associations(for: "今", userRank: { $0 == "今" ? 100 : 0 }),
+                       ["今天", "今日", "今晚"])
+    }
+
+    func testEqualScoresResolveBySourceOrder() {
+        // `sorted(by:)` is not stable, so equal scores need the explicit tie-break to be
+        // reproducible — 甲乙 was read first and must stay ahead of 甲丙.
+        let text = """
+        ㄐㄧㄚˇ-ㄧˇ 甲乙 -4.00000000
+        ㄐㄧㄚˇ-ㄅㄧㄥˇ 甲丙 -4.00000000
+        """
+        let ap = AssociatedPhrases(text: text)
+        XCTAssertEqual(ap.associations(for: "甲"), ["甲乙", "甲丙"])
+        // And a bonus still breaks that tie the other way, rather than the order being frozen.
+        XCTAssertEqual(ap.associations(for: "甲", userRank: { $0 == "丙" ? 1 : 0 }),
+                       ["甲丙", "甲乙"])
+    }
 }

--- a/README.md
+++ b/README.md
@@ -161,6 +161,17 @@ and stays on page 1, a second Space pages, and `1–9` picks.
 **Shift + 1–9** in **設定… ▸ 一般**; a plain `1–9` then types the digit and dismisses the
 suggestions, so numbers flow naturally right after a character.
 
+**A rare character I keep picking never moves to the front.** Known limitation, and it applies
+only to the candidate list — not to 聯想. Adaptive ranking lifts a character *within* the
+dictionary's own ordering, so a character the bundled language model does not know cannot
+overtake one it does, however many times you pick it. Under `卜月卜尸心`, for example, 龍 is in
+the model and the variant 㡣 is not, so 㡣 stays second permanently. Roughly four in five
+characters in the 五代 table are outside the model, and about two in five codes with more than
+one candidate mix the two kinds. Learning still reorders such characters relative to each other,
+and works normally whenever the characters involved are in the model. See
+[#111](https://github.com/teddychan/yahoo-keykey-2/pull/111) for the measurements and why the
+fix was kept out of that release.
+
 **⌘C / ⌘X / ⌘V don't copy, cut, or paste.** Fixed in **2.7.0** — ⌘ and ⌃ combinations now pass
 through to the app instead of being read as radicals. Update if you are on an older version.
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,10 @@ Log out and back in after any update so macOS reloads the input method.
   remember every radical.
 - **拼音 (Pinyin) phrase input** — a third mode that composes whole phrases from toneless
   pinyin; `'` splits ambiguous syllables, so `xi'an` gives 西安.
-- **Frequency-ranked &amp; adaptive** — candidates are ordered by how common they are, and
-  the characters you pick rank higher over time.
+- **Frequency-ranked &amp; adaptive, or fixed** — candidates start in a built-in order, and by
+  default the characters you pick rank higher over time. Turn **依選字習慣調整候選字順序** off in
+  Settings and that built-in order stands: nothing moves, and nothing is counted. On or off
+  applies to 倉頡, 速成, 拼音 and 聯想字詞 alike.
 - **Associated phrases (聯想字詞)** — after you commit a character, Yahoo KeyKey 2 suggests
   the words that usually follow, pickable with `1–9` or `Shift + 1–9`, and optionally showing
   only the continuation (聯想只顯示接續字).
@@ -124,10 +126,14 @@ Log out and back in after any update so macOS reloads the input method.
 Choose the decomposition table in **設定… ▸ 輸入方式**. The choice drives both 倉頡 and
 速成 and applies immediately.
 
-| Mode | Table source | Candidate order | Example codes |
+| Mode | Table source | Built-in candidate order | Example codes |
 |---|---|---|---|
-| **五代倉頡** (default) | ibus `cangjie5` (`Resources/cangjie.txt`) | frequency / adaptive ranking | 面 `一田尸中`, 鬼 `竹山戈` |
+| **五代倉頡** (default) | ibus `cangjie5` (`Resources/cangjie.txt`) | corpus frequency ranking | 面 `一田尸中`, 鬼 `竹山戈` |
 | **三代倉頡（Yahoo KeyKey 相容）** | original Yahoo! KeyKey `cj-ext.cin` / `simplex-ext.cin` | Yahoo's original native order | 面 `一田卜中`, 鬼 `竹戈` |
+
+Both built-in orders are static. Adaptive ranking is layered on top of whichever one is in
+effect, and **依選字習慣調整候選字順序** turns that layer off — so 三代 with it off is the
+original Yahoo! KeyKey order and nothing else.
 
 The default is **五代**, so existing users are unaffected until they opt in. Note that
 Yahoo! KeyKey's *associated-phrase (關聯字表) ranking* cannot be reproduced — that data was

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -137,11 +137,15 @@ The appcast became app-owned across 2.11.3 and 2.11.4 — the caller passes `app
 teddychan/yahoo-keykey-2`, where it used to take the default of the marketing-site repo. A
 Sparkle appcast is update infrastructure, not marketing content, so it belongs in the app's
 own repository: an outage, a permission problem, or a rejected change on the marketing site
-then cannot interfere with update delivery. `appcast_mirror_repo:
-teddychan/www.dragonapp.com` keeps publishing the identical file to the old location for
-copies still at 2.11.3 or older, which read the site and only the site; the mirror is
-dropped at the next **minor** release. The three-step migration, and why the mirror cannot
-go sooner, is spelled out in the comments in `.github/workflows/release.yml`.
+then cannot interfere with update delivery.
+
+**The website mirror is gone.** `appcast_mirror_repo: teddychan/www.dragonapp.com` published the
+identical file to the old location for copies still at 2.11.3 or older, which read the site and
+only the site. It was dropped in **2.12.0**, the "next minor release" its own trigger named, so
+the release publishes to this repository and nowhere else. The website's old file is left in
+place, stale, rather than deleted — a stale file is a quiet no-op where a missing one would be a
+visible failure. The three-step migration is spelled out in the comments in
+`.github/workflows/release.yml`; nothing about it is still pending.
 
 1. Bump **only** `CFBundleShortVersionString` in `App/Info.plist`. (The CI build fails if
    the tag doesn't match it.) Leave `CFBundleVersion` alone — the committed value is an
@@ -168,10 +172,8 @@ If running locally instead of CI:
    **in this repo**, commit, and push. That is the file the app reads — `App/Info.plist`'s
    `SUFeedURL` is
    `https://raw.githubusercontent.com/teddychan/yahoo-keykey-2/main/docs/yahoo-keykey-2/appcast.xml`.
-   While the mirror is still in place ([above](#per-release-automated)), copy the same file
-   into the website repo at `docs/yahoo-keykey-2/appcast.xml` as well: GitHub Pages serves
-   it at `https://www.dragonapp.com/yahoo-keykey-2/appcast.xml`, which is the only feed
-   2.11.3 and older know about.
+   This repo is the only destination: do **not** also copy it into the website repo. That
+   mirror was retired in 2.12.0 ([above](#per-release-automated)).
 5. Bump the Homebrew cask `Casks/yahoo-keykey-2.rb` in `teddychan/homebrew-tap`
    (version + the `.zip` sha256; the cask installs the app from the `.zip`).
 

--- a/docs/superpowers/specs/2026-08-12-adaptive-candidate-order-design.md
+++ b/docs/superpowers/specs/2026-08-12-adaptive-candidate-order-design.md
@@ -173,6 +173,37 @@ each app file is a single edit.
 `docs/yahoo-keykey-2/appcast.xml` is **not** touched — the release workflow publishes it after the
 tag, and it must keep describing the latest published release until then.
 
+## A limit on what learning can do, left as it is
+
+Found while testing 2.13.0, pre-existing, and **deliberately not fixed here**: a character the
+language model does not know can never be learned above one it does.
+
+`CangjieEngine.score` and `SimplexEngine.score` floor an unranked character at `-1e9`:
+
+```swift
+let base = rank[c] ?? -1e9
+```
+
+The largest bonus `UserFrequency` can ever produce is `log(1 + 100_000) * 10 ≈ 115`, so the floor
+is unbridgeable. Under code `ybysp`, 龍 scores −3.89 and the variant 㡣 is absent from the model
+entirely; picking 㡣 any number of times leaves it second. The comment above that line claims the
+floor leaves "headroom for a finite user bonus to lift an otherwise-unranked character", which the
+value does not deliver — it only lets unranked characters reorder among themselves.
+
+It is not small: **79%** of the 五代 table's 64,544 characters are absent from the model, and
+**41%** of the 8,410 multi-candidate codes mix ranked with unranked characters.
+
+The fix is one constant — real single-character scores span `[-8, 0]`, so a floor of `-20` would
+keep today's no-learning order byte-identical while making ~5 deliberate picks enough to promote a
+variant. It is left out because it changes ranking for **every** user with learning on, not only
+those who touch the new toggle, so it deserves its own release note and review.
+
+**聯想 has no equivalent problem.** Every phrase in `AssociatedPhrases` carries a real model score —
+there is no unranked path, because a phrase only enters the table if its line parsed with a numeric
+score. Bucket spreads are small (median 1.38, 95th percentile 2.71, max 8.00) against a first-pick
+bonus of 6.93, so one pick reaches the top in 99.8% of the 5,319 buckets and two picks in all of
+them.
+
 ## Deliberately out of scope
 
 - **A "reset learned data" button.** Not asked for, and the Uninstall pane already removes the

--- a/docs/superpowers/specs/2026-08-12-adaptive-candidate-order-design.md
+++ b/docs/superpowers/specs/2026-08-12-adaptive-candidate-order-design.md
@@ -1,0 +1,200 @@
+# Optional frequency-ranked & adaptive candidate order (issue #85)
+
+**Date:** 2026-08-12
+**Issue:** [#85](https://github.com/teddychan/yahoo-keykey-2/issues/85) — "Frequency-ranked &
+adaptive as an option"
+**Ships in:** 2.13.0
+
+## The problem
+
+From the issue, filed by a long-time 速成 user:
+
+> For the long time users of simplex, we remembered all the candidate in sequence. It would be
+> easier and more user friendly for us if the candidate table doesn't change with the pick up
+> frequency.
+
+Yahoo! KeyKey 2 learns. `UserFrequency` counts every single character the user commits and adds
+`log(1 + count) * 10` to that character's ranking score, so characters you pick often drift toward
+the front of the candidate list. For a typist who learned the classic layout by muscle memory, a
+list that keeps rearranging itself is worse than one that never moves: the position they reach for
+is no longer the position the character is in.
+
+Nothing today can turn that off.
+
+## What ships
+
+One toggle, **設定… ▸ 一般 ▸ 輸入方式 ▸ 依選字習慣調整候選字順序**, on by default so no existing
+install changes behaviour.
+
+**On** (today's behaviour, plus 聯想): characters the user commits are counted, and that count
+ranks both the composition candidates (倉頡 / 速成 / 拼音) and the 聯想 suggestions.
+
+**Off**: candidates and 聯想 come out in their built-in order and stay there, and nothing is
+counted. Already-learned counts are **kept on disk**, so turning it back on resumes where it left
+off rather than starting over.
+
+"Built-in order" is per table, and is static in every case:
+
+| Mode | Order with the toggle off |
+| --- | --- |
+| 五代倉頡 / 速成 | the bundled corpus language-model character ranking |
+| 三代倉頡 / 速成 | the original Yahoo! KeyKey table's native line order |
+| 拼音 | the language model's own ordering |
+| 聯想 | the language model's phrase scores |
+
+## Architecture
+
+### The gate
+
+Adaptive ranking reaches the user through exactly one closure and two learning sites, all in
+`App/InputController.swift`:
+
+- `userRank: (Character) -> Double`, built once in `init` and handed to all three engines. The
+  engines add its result to a static dictionary rank when sorting candidates; the Pinyin walker
+  adds it when ordering candidates within a chosen span. Return zero and every one of them falls
+  back to its static order — a property the engine tests already pin.
+- `userFreq.record(_:)` on a single-character composition commit.
+- `userFreq.record(_:)` on an 聯想 pick (**new** — see below).
+
+So the feature is a gate on one closure and two calls. **No engine needs to know the setting
+exists**, which is why `KeyKeyEngine` stays free of any `Preferences` dependency.
+
+### The policy
+
+`AdaptiveCandidateOrder`, a third enum in `App/KeyEventPolicy.swift` alongside `KeyEventPolicy`
+and `SessionEndPolicy`. That file exists to hold pure, IMK-free decisions so they can be unit
+tested — `InputController` needs a live `IMKServer` and cannot be — and its header explains why
+they share one file: `tools/build-app.sh` compiles an explicit list of `App/` sources, so a new
+file costs a build-script edit for no benefit at this size.
+
+```swift
+static func bonus(for char: Character, enabled: Bool,
+                  learned: (Character) -> Double) -> Double
+static func characterToLearn(fromCommitted text: String, enabled: Bool) -> Character?
+static func characterToLearn(fromAssociationSuffix suffix: String, enabled: Bool) -> Character?
+```
+
+Two `characterToLearn` overloads rather than one with a mode flag, because the rules genuinely
+differ: a composition commit is learned only when the whole committed text is one character
+(`UserFrequency` counts characters), while an 聯想 pick learns the first character of the suffix
+whatever the phrase's length.
+
+`Preferences.adaptiveCandidateOrderEnabled` is read live at each call, exactly as every other
+setting in this app is, so the toggle applies to the next composition with no engine rebuild and
+no notification.
+
+### 聯想 becomes frequency-ranked
+
+This is the one piece that is new functionality rather than a gate.
+
+`AssociatedPhrases` sorted each character's phrases **once at load**, kept the top 20, and
+discarded the scores; `associations(for:)` returned that frozen array. Ranking it by a live,
+changing bonus means ordering has to happen per query instead.
+
+The struct now keeps `(phrase, score)` pairs — still deduped and still capped at 20 per bucket at
+load, because the cap bounds memory and a phrase below the top 20 by LM score is not reachable in
+the 9-per-page window anyway — and `associations(for:userRank:)` re-sorts on
+`score + userRank(continuation)`. The parameter defaults to `{ _ in 0 }`, matching the engines'
+convention, so the off path and every existing caller get the unchanged static order.
+
+**The bonus applies to the phrase's continuation character, not its first.** The first character
+is the bucket's index key and is identical for every phrase in it, so its bonus is a constant that
+reorders nothing. The continuation — 係 in 關係 — is the character the user is actually choosing
+to add, and is what the existing 聯想只顯示接續字 option already displays.
+
+Cost is a sort of at most 20 elements, once per commit.
+
+### Determinism
+
+Both sorts get an explicit source-index tie-break, the same one `CangjieEngine` and
+`SimplexEngine` already use for their table offsets. Swift's `sorted(by:)` is not a stable sort,
+so `sorted(by: { $0.score > $1.score })` left equal-scoring phrases in an arbitrary order. That
+was always a latent defect; it becomes load-bearing here for two reasons:
+
+1. At load, the score sort decides **which 20 phrases survive the cap** — so an arbitrary
+   tie-break decides which phrases the user can ever see.
+2. At query time, a promise that the order "does not change based on your selections" is only
+   true if the order is reproducible in the first place.
+
+Equal-scoring 聯想 phrases may therefore sit in slightly different positions than before, with the
+toggle on or off. That is the fix, and it belongs in the release notes.
+
+### Learning from 聯想 picks
+
+Picking 關係 records 係. The user selected that character, it goes into the document, and it is
+the same per-character store the composition candidates use — so a character learned in 聯想 also
+surfaces earlier when typed by code, and vice versa. Without it, 聯想 could only inherit what was
+learned elsewhere and would never learn from its own use.
+
+## Files
+
+| File | Change |
+| --- | --- |
+| `Packages/KeyKeyEngine/Sources/KeyKeyEngine/AssociatedPhrases.swift` | keep scores; query-time re-sort with the user bonus; tie-breaks on both sorts |
+| `App/KeyEventPolicy.swift` | `AdaptiveCandidateOrder` |
+| `App/Preferences.swift` | `adaptiveCandidateOrderEnabled`, default `true`, registered |
+| `App/InputController.swift` | store `userRank`; gate both learn sites; pass `userRank` to `associations` |
+| `App/SettingsModel.swift` | computed forwarder (plain `Bool` needs no stored-property treatment) |
+| `App/GeneralPane.swift` | `Toggle` + `.dragonAnnotation` in the 輸入方式 section |
+| `App/{en,es,fr,ja,ko,zh-Hans,zh-Hant}.lproj/Localizable.strings` | 2 setting strings + the 2.13.0 What's New strings, ×7 |
+| `App/WhatsNewConfig.swift` | 2.13.0 notes |
+| `CHANGELOG.md`, `README.md`, `docs/RELEASE.md` | see below |
+| `App/Info.plist` | `2.12.1` → `2.13.0` |
+
+The package sources under `Packages/KeyKeyApp/Sources/KeyKeyApp/` are **symlinks** to `App/`, so
+each app file is a single edit.
+
+## Tests
+
+- `KeyEventPolicyTests` — the gate: zero bonus when disabled, the learned value when enabled;
+  `characterToLearn` nil when disabled, nil for a multi-character commit, nil for an empty commit,
+  the character itself for a single-character commit; the association overload taking the suffix's
+  first character and nil when disabled.
+- `AssociatedPhrasesTests` — a zero bonus preserves the static LM order; a bonus on a
+  continuation character lifts that phrase; equal scores resolve by source order at both the cap
+  and the query.
+- `PreferencesTests` — default is `true`, round-trips, and the key is added to **both** `tearDown`
+  and `testRegisterDefaultsSuppliesSensibleFirstLaunchValues` (registered defaults outlive a
+  `removeObject`, so a key missing from that second list could pass by accident).
+- `ConfigContentTests` — updated to the 2.13.0 date and the new What's New key. These
+  deliberately pin the shipping release so a stale pane cannot ship; they fail until updated.
+
+## Documentation corrections this release must make
+
+- `README.md:96` presents adaptation as unconditional, and `:130` calls 三代 "Yahoo's original
+  native order" — true only once the new toggle is off. Both are made inaccurate by this change.
+- `docs/RELEASE.md:136-144` and `:171-174` still describe the appcast mirror to the marketing-site
+  repo as live and say it "is dropped at the next **minor** release". `.github/workflows/release.yml`
+  retired it in 2.12.0 and no longer passes `appcast_mirror_repo`. 2.13.0 **is** the next minor, so
+  anyone following that doc for a manual release would push to an external repo for no reason.
+- The `/* What's New pane (2.12.0) */` comment in all seven `.strings` files is stale, and the
+  `keykey.whatsNew.copyrightNotice` key is replaced rather than left behind.
+
+`docs/yahoo-keykey-2/appcast.xml` is **not** touched — the release workflow publishes it after the
+tag, and it must keep describing the latest published release until then.
+
+## Deliberately out of scope
+
+- **A "reset learned data" button.** Not asked for, and the Uninstall pane already removes the
+  whole support directory. Registering `true` means no migration is needed either.
+- **The variation-selector mismatch.** `characterToLearn` uses `text.count == 1`, which counts
+  grapheme clusters, so a CJK character carrying a variation selector is recorded — but
+  `UserFrequency.load` accepts only single-scalar keys, so it is silently dropped on the next
+  launch. Real, pre-existing, and a change to the persistence contract with its own hardening
+  tests. Filed separately.
+
+## Verification
+
+`swift test` in both packages, then `tools/run-debug.sh`, which installs **Yahoo KeyKey 2 Debug**
+under its own bundle id **and its own Application Support directory** — so hand-testing cannot
+train or wipe the installed release IME's counts.
+
+Manual matrix:
+
+1. 倉頡, 速成 and 拼音, each on 五代 and 三代 where applicable.
+2. Seed learning with the toggle on: commit one character repeatedly, confirm it moves forward.
+3. Turn the toggle off: the order returns to the built-in one and stays there across restarts.
+4. Type more with it off, turn it back on: the pre-existing ranking returns, and nothing typed
+   while off has been learned.
+5. 聯想: confirm suggestions reorder with the toggle on and do not with it off.
+6. A large 速成 or `*`-wildcard composition, for the per-candidate preference read.


### PR DESCRIPTION
Closes #85.

## What this is

Yahoo! KeyKey 2 has always counted the characters you commit and ranked candidates by that count, with no way to stop it. [#85](https://github.com/teddychan/yahoo-keykey-2/issues/85), from a long-time 速成 typist:

> For the long time users of simplex, we remembered all the candidate in sequence. It would be easier and more user friendly for us if the candidate table doesn't change with the pick up frequency.

For someone who learned the layout by muscle memory, a list that keeps rearranging itself is worse than one that never moves — the position they reach for is no longer the position the character is in.

Adds **設定… ▸ 一般 ▸ 輸入方式 ▸ 依選字習慣調整候選字順序**, **on by default**, so no existing install changes. Off, candidates keep their built-in order and stay there, and nothing is counted.

| Surface | Order with the toggle off |
| --- | --- |
| 五代 倉頡/速成 | the bundled corpus ranking |
| 三代 倉頡/速成 | the original Yahoo! KeyKey line order |
| 拼音 | the language model's own ordering |
| 聯想字詞 | the language model's phrase scores |

Learning is **paused**, not erased — counts already on disk are kept, so turning it back on resumes where it left off.

## How it works

Adaptive ranking reached the user through one closure and one `record()` call, so the gate is small and **no engine learns that the setting exists**:

- `AdaptiveCandidateOrder` — a third pure policy beside `KeyEventPolicy` and `SessionEndPolicy`. `InputController` needs a live `IMKServer` and can't be unit-tested, so the decisions live where they can be.
- `Preferences.adaptiveCandidateOrderEnabled`, default `true`, read live like every other setting — the toggle applies to the next composition with no engine rebuild and no notification.

One gated closure feeds all four surfaces: `CangjieEngine`, `SimplexEngine`, `PinyinEngine` and `AssociatedPhrases`.

### 聯想 becomes frequency-ranked

The one piece of genuinely new behaviour. `AssociatedPhrases` sorted once at load and froze the result, so ranking it live meant moving ordering to query time: it now keeps `(phrase, score)` pairs and re-sorts on `score + userRank(continuation)`.

The **continuation** character (係 in 關係) is what the user actually picks, and what 聯想只顯示接續字 already displays. The first character is the bucket key, identical across it, so its bonus would reorder nothing. Picking a suggestion learns that character too, so 聯想 and the composition candidates feed one store.

### Determinism

Both `AssociatedPhrases` sorts gain the source-index tie-break the Cangjie/Simplex engines already use. `sorted(by:)` isn't stable, so equal scores were arbitrary — and since that sort feeds the 20-per-bucket cap, it decided which suggestions were reachable at all. An order can only be promised not to change with your selections if it's reproducible to begin with.

## Also corrected

- **`docs/RELEASE.md` was a live trap.** It described the appcast mirror to the marketing site as active and due to be dropped "at the next minor release" — `release.yml` retired it in 2.12.0, and this *is* that next minor. A manual release following it would have pushed to an unrelated repo for nothing.
- **`README.md`** presented adaptation as unconditional and called 三代 "Yahoo's original native order" while a default-on bonus was layered over it.
- The stale `/* What's New pane (2.12.0) */` comment in all seven `.strings` files.

## Known limitation, documented rather than fixed

A character absent from the language model can never be learned above one that's in it: `CangjieEngine`/`SimplexEngine` floor an unranked character at `-1e9`, and the largest bonus `UserFrequency` can produce is ~115. Under `ybysp`, 龍 scores −3.89 and the variant 㡣 is unranked, so picking 㡣 never moves it.

It isn't small — **79%** of the 五代 table's characters are outside the model, and **41%** of multi-candidate codes mix the two kinds. The fix is one constant (`-20` instead of `-1e9`, since real scores span `[-8, 0]`), but it would change ranking for **every** user with learning on, not only those touching this toggle, so it stays out of this release. Recorded in `README.md` under Troubleshooting and in the spec.

**聯想 has no equivalent problem**: every phrase carries a real score, bucket spreads are small (median 1.38, max 8.00) against a 6.93 first-pick bonus, so one pick reaches the top in 99.8% of the 5,319 buckets.

## Verification

277 tests green across both packages — 12 policy cases for the gate and both learn rules, 4 for 聯想 ordering, plus the registered default asserted inside `registerDefaults`' own test (a registered default outlives `removeObject`, so `tearDown` alone could pass on a stale value).

Hand-tested on a debug build with its own bundle id and its own learning store:

- **聯想** — picking 也 after 我 moves 我也 from 9th to 1st, matching the measured prediction that one pick suffices.
- **速成, code 人十** — 什/午 are 0.65 apart in the model; picking 午 promotes it, and with the toggle off the order does not change. That is #85's actual request, confirmed on a real build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)