### PR TITLE
docs: name it the target version

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,11 +193,11 @@ cd yahoo-keykey-2
 
 For hands-on testing, `./tools/run-debug.sh` builds and installs a separate
 **Yahoo KeyKey 2 Debug** input method with its own bundle id, so it never collides with an
-installed release copy. It reports the version being **developed toward** — the plist version is
-bumped to the next patch as soon as work starts, so a fix for 2.13.0 builds as `v2.13.1 Debug`
-and no modified code ever wears a released number. `Debug` is a build-channel label, never part
-of the numeric version; several debug builds of one version are told apart by the build number
-and commit date printed beside it. See [Versioning
+installed release copy. It reports the **target version** — the release being developed toward,
+bumped as soon as work starts, so a fix for 2.13.0 builds as `v2.13.1 Debug` and no modified
+code ever wears a released number. `Debug` is a build-channel label, never part of the numeric
+version; several debug builds of one target version are told apart by the build number and
+commit date printed beside it. See [Versioning
 convention](docs/RELEASE.md#versioning-convention). Signed release builds are produced by
 [`.github/workflows/release.yml`](.github/workflows/release.yml) on a `v*` tag — see
 [docs/RELEASE.md](docs/RELEASE.md).

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -27,10 +27,10 @@ Two scripts still package the app **locally**, outside CI: `tools/package-releas
 
 ## Versioning convention
 
-**The numeric version is the release the code is being developed *toward*, not the last one
-released.** So the moment work starts on a fix for a released `X.Y.Z`, bump
-`CFBundleShortVersionString` in `App/Info.plist` to `X.Y.(Z+1)` — before the fix is finished,
-not at the end. Every debug build from that branch then reports the version it will ship as:
+`CFBundleShortVersionString` holds the **target version** — the release the code is being
+developed *toward*, not the last one released. So the moment work starts on a fix for a
+released `X.Y.Z`, bump it in `App/Info.plist` to `X.Y.(Z+1)` — before the fix is finished, not
+at the end. Every debug build from that branch then reports the version it will ship as:
 
 ```
 v2.13.0          # released production version
@@ -63,12 +63,12 @@ version suffix:
 
 | Field | Where it comes from | Example |
 | --- | --- | --- |
-| `CFBundleShortVersionString` | `App/Info.plist`, the version being developed toward | `2.13.1` |
+| `CFBundleShortVersionString` | the **target version** in `App/Info.plist` | `2.13.1` |
 | `DragonBuildChannel` | `Debug` on a debug build, absent otherwise | `Debug` |
-| `CFBundleVersion` | `git rev-list --count HEAD` at build time | `213` |
-| `DragonCommitDate` | the HEAD commit's date at build time | `2026-Aug-16 05:15:56 UTC` |
+| `CFBundleVersion` | `git rev-list --count HEAD` at build time | `214` |
+| `DragonCommitDate` | the HEAD commit's date at build time | `2026-Aug-17 00:59:01 UTC` |
 
-rendered as `v2.13.1 Debug (213) · 2026-Aug-16 05:15:56 UTC`. Quote that whole line in a bug
+rendered as `v2.13.1 Debug (214) · 2026-Aug-17 00:59:01 UTC`. Quote that whole line in a bug
 report: the version says which release the code targets, and the build number and commit date
 say which build of it you were running. On 2026-08-16 a debug IME reporting build 210 with an
 Aug-13 commit date was traced to another worktree while the branch under test was at build 212


### PR DESCRIPTION
Wording only — the versioning rule itself is unchanged.

**"Candidate" was ambiguous, and it cost a round of rework.** It reads equally as *the release being voted on* and *the one just shipped*, which is how the convention landed in `docs/RELEASE.md` backwards in #114 before it was restated and corrected. **"Target version"** says what the number means — the release this code is being developed toward — without borrowing release-engineering jargon that has to be decoded first.

Changed in `docs/RELEASE.md` (§Versioning convention and the build-identifier table) and the `README.md` debug paragraph. The same rename is applied to the global `macos-debug-build` skill, which is where the word originated and which governs all five Dragon apps.

The worked example also moves to the build that actually verified the 速成 fix by hand: `v2.13.1 Debug (214) · 2026-Aug-17 00:59:01 UTC`.

Conformance PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)