### PR TITLE
ci: grant pull-requests: write so the appcast can land via PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ on:
 # depend on this repo's default workflow-token setting being read/write.
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:


### PR DESCRIPTION
The release workflow now lands the appcast via a PR it merges itself, instead of pushing main directly. That needs pull-requests: write on the built-in GITHUB_TOKEN. A reusable workflow cannot exceed what its caller grants, so the line is required here as well as in dragon-release-ci.