### PR TITLE
docs: drop the last stale reference to the retired appcast mirror

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -184,8 +184,7 @@ The recommended path is CI: bump the version (step 1 below), commit, then push a
 `v<version>` tag to `teddychan/yahoo-keykey-2`. `.github/workflows/release.yml`
 (GitHub-hosted macOS runner) builds, Developer ID-signs, notarizes, staples, zips,
 uploads the `.zip` to the GitHub release, publishes the EdDSA-signed appcast to
-`docs/yahoo-keykey-2/appcast.xml` **in this repo**, mirrors that same file to the website
-repo, and bumps the Homebrew cask.
+`docs/yahoo-keykey-2/appcast.xml` **in this repo**, and bumps the Homebrew cask.
 It requires these repository secrets: `DEVELOPER_ID_CERT_P12_BASE64`,
 `DEVELOPER_ID_CERT_PASSWORD`, `NOTARY_KEY_P8_BASE64`, `NOTARY_KEY_ID`,
 `NOTARY_ISSUER_ID`, `PUBLIC_RELEASE_TOKEN`, `SPARKLE_EDDSA_PRIVATE_KEY` (the same


### PR DESCRIPTION
## Summary
- `docs/RELEASE.md`'s CI-summary sentence (around line 187) still claimed the release workflow "mirrors that same file to the website repo." That mirror was retired in 2.12.0.
- A previous cleanup at 2.13.0 already fixed the two paragraphs that discuss the mirror directly — "**The website mirror is gone.**" (~line 200) and the manual-fallback note that "This repo is the only destination: do not also copy it into the website repo. That mirror was retired in 2.12.0" (~line 235) — but missed this one summary clause, leaving the file contradicting itself.
- Removed only the mirror clause from the summary sentence; the rest of the step list (build/sign/notarize/staple/zip/upload/publish appcast/bump cask) is untouched.

## Test plan
- [x] Doc-only change; no build/test impact.
- [x] Confirmed the two later paragraphs (~200-206, ~235-236) already state the mirror is gone and were not touched.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>