### PR TITLE
docs: record the missing README screenshots in known_issues.md

### DIFF
--- a/known_issues.md
+++ b/known_issues.md
@@ -12,6 +12,9 @@ you are on and which mode you were typing in.
 6. [A rare character never moves to the top](#6-a-rare-character-never-moves-to-the-top)
 7. [Already fixed in earlier versions](#7-already-fixed-in-earlier-versions)
 
+Also: [documentation gaps](#documentation-gaps) — things missing from these docs rather than
+problems with the app.
+
 ## 1. Yahoo KeyKey 2 does not show up after installing
 
 macOS only looks for new input methods when you log in.
@@ -90,3 +93,16 @@ Update if you are on an older release.
   offered 含, which really decomposes as `人戈弓口`. 五代 was never affected.
 - **⌘C / ⌘X / ⌘V did not copy, cut or paste** — fixed in **2.7.0**. ⌘ and ⌃ combinations now
   pass through to the app instead of being read as radicals.
+
+## Documentation gaps
+
+Not problems with the app — things missing from these docs, recorded here so they are not
+forgotten.
+
+- **The README has no screenshots.** The
+  [unified README design](docs/superpowers/specs/2026-07-25-unified-readme-design.md) gives every
+  Dragon app a `## Screenshots` section above the badge row, but this repo has no `docs/images/`
+  and has never had that heading — `clipmenu-2` is in the same position. Filling it needs real
+  captures from an **installed release build**, not a local debug build, which would render as
+  "Yahoo KeyKey 2 Debug" in the menus and About pane. Worth showing: the candidate window mid-code
+  with 反查提示 on, the input menu, and the 設定… 一般 pane.


### PR DESCRIPTION
Follow-up to #122, which flagged this but left it untracked. Docs only — no code change, no version bump.

## What

Adds a **Documentation gaps** section to `known_issues.md` recording that the README has no screenshots.

The [unified README design](docs/superpowers/specs/2026-07-25-unified-readme-design.md) gives every Dragon app a `## Screenshots` section above the badge row, but this repo has no `docs/images/` and has never had that heading. `clipmenu-2` is in the same position.

## Why it is not in the numbered list

Sections 1–7 are problems users hit while typing. Someone scanning for help with 倉頡 should not have to scroll past a documentation chore to find it, so this sits under its own heading after the "already fixed" list, with a pointer from the contents.

## Note for whoever picks it up

Captures must come from an **installed release build**, not a local debug build — a debug build renders as "Yahoo KeyKey 2 Debug" in the menus and About pane. Suggested shots: the candidate window mid-code with 反查提示 on, the input menu, and the 設定… 一般 pane.

## Verified

Every anchor in both docs resolves, and every relative file link points at a path that exists on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)