### PR TITLE
chore(deps): DragonKit 4.1.1

### DIFF
--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -86,7 +86,7 @@ echo "==> Building DragonKit (SwiftPM, release) in pinned checkout"
 # tools/test-resolve-dragon-kit.sh can drive every one of them without a swiftc build.
 # DRAGONKIT_TAG stays HERE: the propagation SOP and .github/workflows/tests.yml both read the pin
 # out of this file.
-DRAGONKIT_TAG="v4.1.0"
+DRAGONKIT_TAG="v4.1.1"
 DRAGONKIT_URL="https://github.com/teddychan/dragon-kit"
 "$ROOT/tools/resolve-dragon-kit.sh" "$KIT_DIR" "$DRAGONKIT_TAG" "$DRAGONKIT_URL"
 ( cd "$KIT_DIR" && swift build -c release )


### PR DESCRIPTION
## Summary
- Bumps the DragonKit pin from v4.1.0 to v4.1.1 (`DRAGONKIT_TAG` in `tools/build-app.sh`) to satisfy dragon-kit CONFORMANCE §R10, which requires each app's declared pin to be >= the newest `vX.Y.Z` tag in dragon-kit.
- v4.1.1 is safety-fixes-only: uninstall now refuses to run when more than one copy of the app is present (settings/login item/support files/Homebrew record are keyed to app identity, not location), and local test builds no longer reach the real update checker (Settings > Updates previously surfaced a raw developer error in debug builds).
- yahoo-keykey-2 has no top-level `Package.swift` or Xcode project — it builds with direct `swiftc` — so the pin is a shell variable rather than a package-manifest entry.

## Test plan
- [x] `git diff` limited to the single `DRAGONKIT_TAG` line in `tools/build-app.sh`
- [x] `python3 -c "import re; t=open('tools/build-app.sh').read(); print(re.search(r'DRAGONKIT_TAG=\"v([0-9.]+)\"', t).group(1))"` prints `4.1.1`
- [ ] DO NOT MERGE — dependency bump only, opened for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)