### PR TITLE
fix: the app is "Yahoo! KeyKey 2" — the trademark carries the exclamation mark

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Yahoo KeyKey 2</string>
+	<string>Yahoo! KeyKey 2</string>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIconFile</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.dragonapp.inputmethod.yahoo-keykey</string>
 	<key>CFBundleName</key>
-	<string>Yahoo KeyKey 2</string>
+	<string>Yahoo! KeyKey 2</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/App/en.lproj/InfoPlist.strings
+++ b/App/en.lproj/InfoPlist.strings
@@ -1,5 +1,5 @@
-CFBundleName = "Yahoo KeyKey 2";
-CFBundleDisplayName = "Yahoo KeyKey 2";
+CFBundleName = "Yahoo! KeyKey 2";
+CFBundleDisplayName = "Yahoo! KeyKey 2";
 "com.dragonapp.inputmethod.yahoo-keykey.Cangjie" = "倉頡";
 "com.dragonapp.inputmethod.yahoo-keykey.Simplex" = "速成";
 "com.dragonapp.inputmethod.yahoo-keykey.Pinyin" = "拼音";

--- a/App/en.lproj/Localizable.strings
+++ b/App/en.lproj/Localizable.strings
@@ -22,7 +22,7 @@
 "keykey.general.inputMethod" = "Input Method";
 "keykey.general.cangjieVersion" = "Cangjie version";
 "keykey.general.cangjieV5" = "5th-generation Cangjie";
-"keykey.general.cangjieV3" = "3rd-generation Cangjie (Yahoo KeyKey compatible)";
+"keykey.general.cangjieV3" = "3rd-generation Cangjie (Yahoo! KeyKey compatible)";
 "keykey.general.cangjieVersionHint" = "3rd-generation Cangjie uses the original Yahoo! KeyKey code table and candidate order (applied to both Cangjie and Simplex), effective immediately.";
 "keykey.general.strokeConfirmation" = "Press Space to confirm the code";
 "keykey.general.strokeConfirmationHint" = "In 速成, and in 倉頡 with the * wildcard, candidates appear before the code is finished, so Space flips to the next page instead of confirming what you typed. With this on, the first Space only confirms the code and keeps page 1 — press Space again to page, or 1–9 to pick. Plain 倉頡 is unaffected.";

--- a/App/es.lproj/InfoPlist.strings
+++ b/App/es.lproj/InfoPlist.strings
@@ -1,5 +1,5 @@
-CFBundleName = "Yahoo KeyKey 2";
-CFBundleDisplayName = "Yahoo KeyKey 2";
+CFBundleName = "Yahoo! KeyKey 2";
+CFBundleDisplayName = "Yahoo! KeyKey 2";
 "com.dragonapp.inputmethod.yahoo-keykey.Cangjie" = "倉頡";
 "com.dragonapp.inputmethod.yahoo-keykey.Simplex" = "速成";
 "com.dragonapp.inputmethod.yahoo-keykey.Pinyin" = "拼音";

--- a/App/es.lproj/Localizable.strings
+++ b/App/es.lproj/Localizable.strings
@@ -22,7 +22,7 @@
 "keykey.general.inputMethod" = "Método de entrada";
 "keykey.general.cangjieVersion" = "Versión de Cangjie";
 "keykey.general.cangjieV5" = "Cangjie de 5.ª generación";
-"keykey.general.cangjieV3" = "Cangjie de 3.ª generación (compatible con Yahoo KeyKey)";
+"keykey.general.cangjieV3" = "Cangjie de 3.ª generación (compatible con Yahoo! KeyKey)";
 "keykey.general.cangjieVersionHint" = "El «Cangjie de 3.ª generación» usa la tabla de códigos y el orden de candidatos del Yahoo! KeyKey original (se aplica tanto a 倉頡 como a 速成) y surte efecto de inmediato.";
 "keykey.general.strokeConfirmation" = "Pulsar Espacio para confirmar el código";
 "keykey.general.strokeConfirmationHint" = "En 速成, y en 倉頡 con el comodín *, los candidatos aparecen antes de que el código esté terminado, así que Espacio pasa a la página siguiente en lugar de confirmar lo que has escrito. Con esta opción activada, el primer Espacio solo confirma el código y se queda en la página 1: vuelve a pulsar Espacio para cambiar de página, o 1–9 para elegir. El 倉頡 normal no se ve afectado.";

--- a/App/fr.lproj/InfoPlist.strings
+++ b/App/fr.lproj/InfoPlist.strings
@@ -1,5 +1,5 @@
-CFBundleName = "Yahoo KeyKey 2";
-CFBundleDisplayName = "Yahoo KeyKey 2";
+CFBundleName = "Yahoo! KeyKey 2";
+CFBundleDisplayName = "Yahoo! KeyKey 2";
 "com.dragonapp.inputmethod.yahoo-keykey.Cangjie" = "倉頡";
 "com.dragonapp.inputmethod.yahoo-keykey.Simplex" = "速成";
 "com.dragonapp.inputmethod.yahoo-keykey.Pinyin" = "拼音";

--- a/App/fr.lproj/Localizable.strings
+++ b/App/fr.lproj/Localizable.strings
@@ -22,7 +22,7 @@
 "keykey.general.inputMethod" = "Méthode de saisie";
 "keykey.general.cangjieVersion" = "Version de Cangjie";
 "keykey.general.cangjieV5" = "Cangjie de 5e génération";
-"keykey.general.cangjieV3" = "Cangjie de 3e génération (compatible Yahoo KeyKey)";
+"keykey.general.cangjieV3" = "Cangjie de 3e génération (compatible Yahoo! KeyKey)";
 "keykey.general.cangjieVersionHint" = "Le « Cangjie de 3e génération » utilise la table de codes et l’ordre des candidats du Yahoo! KeyKey d’origine (appliqué à 倉頡 comme à 速成), avec effet immédiat.";
 "keykey.general.strokeConfirmation" = "Appuyer sur Espace pour valider le code";
 "keykey.general.strokeConfirmationHint" = "En 速成, et en 倉頡 avec le joker *, les candidats apparaissent avant que le code soit terminé : Espace passe donc à la page suivante au lieu de valider ce que vous avez tapé. Avec cette option, le premier Espace ne fait que valider le code et reste sur la page 1 — appuyez de nouveau sur Espace pour changer de page, ou sur 1–9 pour choisir. Le 倉頡 normal n’est pas affecté.";

--- a/App/ja.lproj/InfoPlist.strings
+++ b/App/ja.lproj/InfoPlist.strings
@@ -1,5 +1,5 @@
-CFBundleName = "Yahoo KeyKey 2";
-CFBundleDisplayName = "Yahoo KeyKey 2";
+CFBundleName = "Yahoo! KeyKey 2";
+CFBundleDisplayName = "Yahoo! KeyKey 2";
 "com.dragonapp.inputmethod.yahoo-keykey.Cangjie" = "倉頡";
 "com.dragonapp.inputmethod.yahoo-keykey.Simplex" = "速成";
 "com.dragonapp.inputmethod.yahoo-keykey.Pinyin" = "拼音";

--- a/App/ja.lproj/Localizable.strings
+++ b/App/ja.lproj/Localizable.strings
@@ -22,7 +22,7 @@
 "keykey.general.inputMethod" = "入力方式";
 "keykey.general.cangjieVersion" = "倉頡のバージョン";
 "keykey.general.cangjieV5" = "第5世代倉頡";
-"keykey.general.cangjieV3" = "第3世代倉頡（Yahoo KeyKey 互換）";
+"keykey.general.cangjieV3" = "第3世代倉頡（Yahoo! KeyKey 互換）";
 "keykey.general.cangjieVersionHint" = "「第3世代倉頡」はオリジナルの Yahoo! KeyKey のコード表と候補順を使います（倉頡と速成の両方に適用）。すぐに反映されます。";
 "keykey.general.strokeConfirmation" = "スペースキーでコードを確定";
 "keykey.general.strokeConfirmationHint" = "速成、および * ワイルドカードを使う倉頡では、コードを打ち終わる前に候補が出るため、スペースキーは打ったコードを確定せずに次のページへ送ってしまいます。オンにすると、最初のスペースキーはコードの確定だけを行い 1 ページ目に留まります。もう一度スペースキーを押すとページが進み、1〜9 で直接選べます。通常の倉頡は影響を受けません。";

--- a/App/ko.lproj/InfoPlist.strings
+++ b/App/ko.lproj/InfoPlist.strings
@@ -1,5 +1,5 @@
-CFBundleName = "Yahoo KeyKey 2";
-CFBundleDisplayName = "Yahoo KeyKey 2";
+CFBundleName = "Yahoo! KeyKey 2";
+CFBundleDisplayName = "Yahoo! KeyKey 2";
 "com.dragonapp.inputmethod.yahoo-keykey.Cangjie" = "倉頡";
 "com.dragonapp.inputmethod.yahoo-keykey.Simplex" = "速成";
 "com.dragonapp.inputmethod.yahoo-keykey.Pinyin" = "拼音";

--- a/App/ko.lproj/Localizable.strings
+++ b/App/ko.lproj/Localizable.strings
@@ -22,7 +22,7 @@
 "keykey.general.inputMethod" = "입력 방식";
 "keykey.general.cangjieVersion" = "창힐 버전";
 "keykey.general.cangjieV5" = "5세대 창힐";
-"keykey.general.cangjieV3" = "3세대 창힐(Yahoo KeyKey 호환)";
+"keykey.general.cangjieV3" = "3세대 창힐(Yahoo! KeyKey 호환)";
 "keykey.general.cangjieVersionHint" = "「3세대 창힐」은 원래 Yahoo! KeyKey의 코드표와 후보 순서를 사용합니다(창힐과 속성 모두에 적용). 즉시 적용됩니다.";
 "keykey.general.strokeConfirmation" = "스페이스로 코드 확정";
 "keykey.general.strokeConfirmationHint" = "속성, 그리고 * 와일드카드를 사용하는 창힐에서는 코드를 다 입력하기 전에 후보가 나타나므로, 스페이스가 입력한 코드를 확정하지 않고 다음 페이지로 넘어갑니다. 이 옵션을 켜면 첫 번째 스페이스는 코드만 확정하고 1페이지에 머무릅니다. 페이지를 넘기려면 스페이스를 한 번 더 누르거나 1~9로 바로 선택하세요. 일반 창힐은 영향을 받지 않습니다.";

--- a/App/zh-Hans.lproj/InfoPlist.strings
+++ b/App/zh-Hans.lproj/InfoPlist.strings
@@ -1,5 +1,5 @@
-CFBundleName = "Yahoo KeyKey 2";
-CFBundleDisplayName = "Yahoo KeyKey 2";
+CFBundleName = "Yahoo! KeyKey 2";
+CFBundleDisplayName = "Yahoo! KeyKey 2";
 "com.dragonapp.inputmethod.yahoo-keykey.Cangjie" = "仓颉";
 "com.dragonapp.inputmethod.yahoo-keykey.Simplex" = "速成";
 "com.dragonapp.inputmethod.yahoo-keykey.Pinyin" = "拼音";

--- a/App/zh-Hans.lproj/Localizable.strings
+++ b/App/zh-Hans.lproj/Localizable.strings
@@ -22,7 +22,7 @@
 "keykey.general.inputMethod" = "输入方式";
 "keykey.general.cangjieVersion" = "仓颉版本";
 "keykey.general.cangjieV5" = "五代仓颉";
-"keykey.general.cangjieV3" = "三代仓颉（兼容 Yahoo KeyKey）";
+"keykey.general.cangjieV3" = "三代仓颉（兼容 Yahoo! KeyKey）";
 "keykey.general.cangjieVersionHint" = "「三代仓颉」使用 Yahoo! KeyKey 原版的拆码与候选字顺序（同时应用于仓颉与速成），立即生效。";
 "keykey.general.strokeConfirmation" = "以空格键确认字根";
 "keykey.general.strokeConfirmationHint" = "在速成、以及使用通配符（*）的仓颉中，字根还没输完就会出现候选字，此时空格键会直接翻到下一页，而不是确认你输入的字根。开启后，第一次按空格键只确认字根并停留在第 1 页；再按一次空格键才翻页，或直接按 1–9 选字。普通仓颉不受影响。";

--- a/App/zh-Hant.lproj/InfoPlist.strings
+++ b/App/zh-Hant.lproj/InfoPlist.strings
@@ -1,5 +1,5 @@
-CFBundleName = "Yahoo KeyKey 2";
-CFBundleDisplayName = "Yahoo KeyKey 2";
+CFBundleName = "Yahoo! KeyKey 2";
+CFBundleDisplayName = "Yahoo! KeyKey 2";
 "com.dragonapp.inputmethod.yahoo-keykey.Cangjie" = "倉頡";
 "com.dragonapp.inputmethod.yahoo-keykey.Simplex" = "速成";
 "com.dragonapp.inputmethod.yahoo-keykey.Pinyin" = "拼音";

--- a/App/zh-Hant.lproj/Localizable.strings
+++ b/App/zh-Hant.lproj/Localizable.strings
@@ -22,7 +22,7 @@
 "keykey.general.inputMethod" = "輸入方式";
 "keykey.general.cangjieVersion" = "倉頡版本";
 "keykey.general.cangjieV5" = "五代倉頡";
-"keykey.general.cangjieV3" = "三代倉頡（Yahoo KeyKey 相容）";
+"keykey.general.cangjieV3" = "三代倉頡（Yahoo! KeyKey 相容）";
 "keykey.general.cangjieVersionHint" = "「三代倉頡」使用 Yahoo! KeyKey 原版的拆碼與候選字順序（同時套用到倉頡與速成），立即生效。";
 "keykey.general.strokeConfirmation" = "以空白鍵確認字根";
 "keykey.general.strokeConfirmationHint" = "在速成、以及使用萬用字元（*）的倉頡中，字根還沒打完就會出現候選字，此時空白鍵會直接翻到下一頁，而不是確認你打的字根。開啟後，第一次按空白鍵只會確認字根並停留在第 1 頁；再按一次空白鍵才翻頁，或直接按 1–9 選字。一般倉頡不受影響。";


### PR DESCRIPTION
"Yahoo!" is trademarked **with** the exclamation mark, so the product name takes it. The app called itself "Yahoo KeyKey 2" while its own marketing page, the site's app config and the fleet docs all wrote "Yahoo! KeyKey 2" — the app and its own marketing disagreed on the product's name.

## Changed — the three places macOS actually reads

| File | What |
|---|---|
| `App/Info.plist` | `CFBundleName`, `CFBundleDisplayName` |
| `App/<locale>.lproj/InfoPlist.strings` × 7 | **these override `Info.plist` per locale** |
| `keykey.general.cangjieV3` × 7 locales | the one `Localizable.strings` entry still missing the mark |

**The `InfoPlist.strings` files are the point.** Editing `Info.plist` alone would have displayed nothing new — those seven files override it per locale, and all seven said "Yahoo KeyKey 2". I only found them by grepping for the old spelling *after* editing the plist. Every other mention of the original IME already carried the mark.

## Why this one is user-visible, unlike clipmenu-2's equivalent

`tools/build-app.sh` copies the committed `Info.plist` verbatim (resolving `${EXECUTABLE_NAME}` only) and never sets `CFBundleName`, and dragon-release-ci does not overwrite it for `build_kind: script`. So the committed value is what ships. ClipMenu's is overwritten by an app-name template in every build path, which is why that change was a source-tree tidy and this one is not.

## Deliberately unchanged

- **The `.app` filename** stays `YahooKeyKey2.app` (release) and `Yahoo KeyKey 2 Debug.app` (debug). The release name already avoids spaces and punctuation because it installs into `~/Library/Input Methods/`; `!` in a path buys nothing a user sees and adds shell-escaping friction. The Homebrew cask's `app` stanza points at that filename and is unaffected.
- `CFBundleIdentifier`, the `~/Library/Application Support/YahooKeyKey2` data directory (a hardcoded literal in `SharedResources.swift` — **verified**, no learning data moves), and the entitlements filename.
- `docs/THIRD-PARTY-NOTICES.md` — 24 occurrences, and it carries the "not affiliated with, or endorsed by, Yahoo" disclaimer. Rewriting a legal notice is the owner's call.

## Worth verifying by hand before release

This is an input method, so the name appears in the Input Sources picker. macOS caches input-source registrations, so the renamed source may need re-selecting on an existing install. Worth a hands-on check rather than trusting CI.

Separate from the 2.13.3 release PR (#125) on purpose — that one is a release, this is a rename. Whoever cuts the next release should mention it in What's New, since it *is* user-visible.