### PR TITLE
docs: spell the product "Yahoo! KeyKey 2" and leave the company bare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# What's New in Yahoo KeyKey 2
+# What's New in Yahoo! KeyKey 2
 
 A plain-language list of changes in each version, newest first.
 
@@ -42,7 +42,7 @@ A plain-language list of changes in each version, newest first.
 - **Fixed: in 速成, typing on past a two-key code now moves to the next character instead of
   getting stuck.** A 速成 code is two keys — the first and last 倉頡 radical — so once you have
   typed both, the character is as narrowed down as it can get. Type 女木 for 好 and then start the
-  next character with 人, and Yahoo KeyKey 2 would add that 人 to the code you had just finished,
+  next character with 人, and Yahoo! KeyKey 2 would add that 人 to the code you had just finished,
   making a three-key code. No such code exists in 速成, so the candidate list emptied out and 好
   could no longer be picked at all; the only way forward was Backspace.
 
@@ -318,7 +318,7 @@ A plain-language list of changes in each version, newest first.
   default (**1–9** picks an associated phrase) or switch to **Shift + 1–9** — with that on, a
   plain **1–9** types the digit and dismisses the suggestions, so numbers flow naturally right
   after a character (e.g. `這周有7天。`). Default is unchanged, so existing users see no difference.
-- **Fixed: ⌘ and ⌃ shortcuts now pass through to the app.** With Yahoo KeyKey 2 selected,
+- **Fixed: ⌘ and ⌃ shortcuts now pass through to the app.** With Yahoo! KeyKey 2 selected,
   combinations like **⌘C / ⌘X / ⌘V** were intercepted by the input method (⌘C could turn into the
   倉頡 radical 金) instead of copying, cutting, or pasting. ⌘/⌃ key combinations now reach the app
   as expected.
@@ -337,7 +337,7 @@ A plain-language list of changes in each version, newest first.
 
 ## 2.6.4
 
-- **Starts up even faster and lighter.** At launch, Yahoo KeyKey 2 now reads its dictionary file
+- **Starts up even faster and lighter.** At launch, Yahoo! KeyKey 2 now reads its dictionary file
   in a single pass instead of two, and it builds the **速成 (Simplex)** code table and the
   **反查／拆碼提示** reverse-lookup index only when you actually use them. If you type only 倉頡 or
   拼音, that's less work and less memory every time the app starts. Nothing you type changes.
@@ -348,7 +348,7 @@ A plain-language list of changes in each version, newest first.
 
 ## 2.6.3
 
-- **Faster startup and lower memory use.** At launch, Yahoo KeyKey 2 no longer builds a large
+- **Faster startup and lower memory use.** At launch, Yahoo! KeyKey 2 no longer builds a large
   in-memory copy of its whole dictionary just to work out which characters are most common — it
   now reads only what it needs. The app starts up quicker and uses less memory, and nothing you
   type changes.
@@ -377,9 +377,9 @@ A plain-language list of changes in each version, newest first.
 
 ## 2.6.0
 
-- **New input method: 拼音 (Pinyin).** Alongside **倉頡** and **速成**, Yahoo KeyKey 2 now
+- **New input method: 拼音 (Pinyin).** Alongside **倉頡** and **速成**, Yahoo! KeyKey 2 now
   offers a **拼音** phrase input method. Add it the same way as the others — **System Settings ▸
-  Keyboard ▸ Input Sources ▸ + ▸ Chinese, Traditional ▸ Yahoo KeyKey 2** — then pick **拼音**
+  Keyboard ▸ Input Sources ▸ + ▸ Chinese, Traditional ▸ Yahoo! KeyKey 2** — then pick **拼音**
   from the input menu. Type pinyin (no tone marks needed) and it composes whole phrases, not
   just one character at a time:
     - **Space / Return** commit the whole phrase.
@@ -425,12 +425,12 @@ A plain-language list of changes in each version, newest first.
 
 ## 2.2.0
 
-- **New: z-code punctuation in 三代倉頡.** In the **三代倉頡（Yahoo KeyKey 相容）** mode you can now type punctuation with the classic Yahoo `z` codes — e.g. `zxcd` → 「, `zxce` → 」, `zxab` → ，, `zxbe` → （. These were part of the original Yahoo table and are available again.
+- **New: z-code punctuation in 三代倉頡.** In the **三代倉頡（Yahoo! KeyKey 相容）** mode you can now type punctuation with the classic Yahoo `z` codes — e.g. `zxcd` → 「, `zxce` → 」, `zxab` → ，, `zxbe` → （. These were part of the original Yahoo table and are available again.
 - **New: 聯想只顯示接續字 option.** A new checkbox in **設定… ▸ 一般** makes the associated-phrase (聯想) window show only the continuation after the character you just typed — e.g. after 關 it shows 係／心／於 instead of the full words 關係／關心／關於, like the classic Yahoo! KeyKey. Off by default; what you commit is unchanged either way.
 
 ## 2.1.0
 
-- **New: choose your 倉頡版本 (Cangjie generation).** In **設定… ▸ 輸入方式** you can now switch between **五代倉頡** (the standard 5th-generation table, the default) and **三代倉頡（Yahoo KeyKey 相容）**. The 三代 option uses the original Yahoo! KeyKey code table and its candidate order, so characters like 面 (`一田卜中`), 鬼 (`竹戈`), and 樓 (`木中田女`) take the codes long-time Yahoo users remember instead of the 5th-generation forms (`一田尸中`, `竹山戈`, `木中中女`). The choice applies to both 倉頡 and 速成 and takes effect immediately — no need to re-select the input method. The default stays 五代 so existing users are unaffected until they opt in.
+- **New: choose your 倉頡版本 (Cangjie generation).** In **設定… ▸ 輸入方式** you can now switch between **五代倉頡** (the standard 5th-generation table, the default) and **三代倉頡（Yahoo! KeyKey 相容）**. The 三代 option uses the original Yahoo! KeyKey code table and its candidate order, so characters like 面 (`一田卜中`), 鬼 (`竹戈`), and 樓 (`木中田女`) take the codes long-time Yahoo users remember instead of the 5th-generation forms (`一田尸中`, `竹山戈`, `木中中女`). The choice applies to both 倉頡 and 速成 and takes effect immediately — no need to re-select the input method. The default stays 五代 so existing users are unaffected until they opt in.
 
 ## 2.0.2
 
@@ -438,7 +438,7 @@ A plain-language list of changes in each version, newest first.
 
 ## 2.0.1
 
-- **Fixed: Yahoo KeyKey 2 now appears in System Settings → Keyboard → Input Sources again.** Version 2.0.0 could be installed but never showed up as an input method you could add, because the rebrand accidentally changed the app's identifier to a form macOS does not recognise as an input method. The identifier now includes the required `inputmethod` component, so the input method registers correctly. If you had 2.0.0, install 2.0.1 and add **Yahoo KeyKey 2** under **Chinese, Traditional**.
+- **Fixed: Yahoo! KeyKey 2 now appears in System Settings → Keyboard → Input Sources again.** Version 2.0.0 could be installed but never showed up as an input method you could add, because the rebrand accidentally changed the app's identifier to a form macOS does not recognise as an input method. The identifier now includes the required `inputmethod` component, so the input method registers correctly. If you had 2.0.0, install 2.0.1 and add **Yahoo! KeyKey 2** under **Chinese, Traditional**.
 
 ## 2.0.0
 
@@ -470,7 +470,7 @@ A plain-language list of changes in each version, newest first.
   **「候選字大小」(Candidate Text Size)** option with **小 / 中 / 大 (Small / Medium /
   Large)**. Pick whichever is easiest on your eyes — the candidate list updates the
   next time you type.
-- **Apple Silicon only.** Yahoo KeyKey 2 now runs exclusively on Apple Silicon Macs
+- **Apple Silicon only.** Yahoo! KeyKey 2 now runs exclusively on Apple Silicon Macs
   (M1 and newer). Older Intel Macs are no longer supported. If you're on an Intel
   Mac, stay on version 1.3.4. This keeps the app smaller and lets us focus on the
   Macs people use today.
@@ -486,6 +486,6 @@ A plain-language list of changes in each version, newest first.
 
 ## 1.3.0
 
-- Added automatic updates: from this version on, Yahoo KeyKey 2 can check for and
+- Added automatic updates: from this version on, Yahoo! KeyKey 2 can check for and
   install new versions on its own (for the direct download — Homebrew users update
   through Homebrew).

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,6 +1,6 @@
 # Credits
 
-**Yahoo KeyKey 2** is an independent, open reimplementation of the discontinued
+**Yahoo! KeyKey 2** is an independent, open reimplementation of the discontinued
 **Yahoo! KeyKey** Traditional-Chinese input method. It is not affiliated with or
 endorsed by Yahoo. This project exists to honor the original work and keep a
 KeyKey-style experience alive on modern macOS.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <div align="center">
-  <img src="App/AppIcon.png" width="160" height="160" alt="Yahoo KeyKey 2 app icon">
-  <h1>Yahoo KeyKey 2</h1>
+  <img src="App/AppIcon.png" width="160" height="160" alt="Yahoo! KeyKey 2 app icon">
+  <h1>Yahoo! KeyKey 2</h1>
   <p><strong>Cangjie (倉頡) &amp; Simplex (速成) Traditional-Chinese input method for macOS</strong></p>
 </div>
 
-**Yahoo KeyKey 2** is an independent, open-source rebuild — in Swift — of the classic
+**Yahoo! KeyKey 2** is an independent, open-source rebuild — in Swift — of the classic
 **Yahoo! KeyKey (Yahoo!奇摩輸入法)** Traditional-Chinese input method that many Mac users
 loved. It brings the familiar Cangjie (倉頡) and Simplex (速成) typing experience back to
 modern macOS — native, fast, and free.
@@ -59,7 +59,7 @@ updated automatically on every release.
 3. **Log out and back in.**
 4. Add the input source under **System Settings ▸ Keyboard ▸ Input Sources ▸ + ▸
    Traditional Chinese** → **倉頡** and/or **速成**.
-5. Press **⌃Space** to switch to Yahoo KeyKey 2 and start typing. Space or `1–9` picks a
+5. Press **⌃Space** to switch to Yahoo! KeyKey 2 and start typing. Space or `1–9` picks a
    candidate; the arrow keys page through them.
 
 Not showing up? See
@@ -76,7 +76,7 @@ Log out and back in afterwards, so macOS reloads the input method.
 ### Uninstall
 
 1. **Remove the input source first:** **System Settings ▸ Keyboard ▸ Input Sources**, select
-   Yahoo KeyKey 2 and remove it. The app's own Uninstall pane cannot do this part for you.
+   Yahoo! KeyKey 2 and remove it. The app's own Uninstall pane cannot do this part for you.
 2. **Then remove the app** — Homebrew: `brew uninstall --cask teddychan/tap/yahoo-keykey-2`;
    otherwise open **設定… ▸ 解除安裝**, or drag `~/Library/Input Methods/YahooKeyKey2.app` to
    the Trash.
@@ -113,7 +113,7 @@ rm -rf ~/Library/HTTPStorages/com.dragonapp.inputmethod.yahoo-keykey
 - **Free and open source** — MIT licensed, signed and notarized, with in-app updates.
 
 > [!NOTE]
-> Yahoo KeyKey 2 is not affiliated with, or endorsed by, Yahoo. It is an independent project
+> Yahoo! KeyKey 2 is not affiliated with, or endorsed by, Yahoo. It is an independent project
 > that exists to honor the original work and keep a KeyKey-style experience alive on modern
 > macOS.
 
@@ -125,14 +125,14 @@ immediately.
 | Mode | Based on | Candidate order | Example codes |
 |---|---|---|---|
 | **五代倉頡** (default) | ibus `cangjie5` | corpus frequency | 面 `一田尸中`, 鬼 `竹山戈` |
-| **三代倉頡** (Yahoo KeyKey compatible) | original Yahoo! KeyKey tables | Yahoo's original order | 面 `一田卜中`, 鬼 `竹戈` |
+| **三代倉頡** (Yahoo! KeyKey compatible) | original Yahoo! KeyKey tables | Yahoo's original order | 面 `一田卜中`, 鬼 `竹戈` |
 
 **五代** is the default, so existing users are unaffected until they opt in. Both orders are
 fixed; the learning layer sits on top and **依選字習慣調整候選字順序** turns it off — so 三代
 with learning off is the original Yahoo! KeyKey order and nothing else.
 
 Yahoo! KeyKey's *associated-phrase* ranking cannot be reproduced — that data was never
-open-sourced — so associations use Yahoo KeyKey 2's own ordering in both modes.
+open-sourced — so associations use Yahoo! KeyKey 2's own ordering in both modes.
 
 ## Troubleshooting
 
@@ -165,7 +165,7 @@ cd yahoo-keykey-2
 ```
 
 For hands-on testing, `./tools/run-debug.sh` builds and installs a separate
-**Yahoo KeyKey 2 Debug** input method with its own bundle id, so it never collides with an
+**Yahoo! KeyKey 2 Debug** input method with its own bundle id, so it never collides with an
 installed release copy. It reports the **target version** — the release being developed toward —
 so a fix for 2.13.0 builds as `v2.13.1 Debug` and no modified code ever wears a released number.
 See [Versioning convention](docs/RELEASE.md#versioning-convention). Signed release builds come
@@ -208,12 +208,12 @@ Release mechanics are documented in [docs/RELEASE.md](docs/RELEASE.md).
 
 ## Credits
 
-Yahoo KeyKey 2 is built in tribute to the original **Yahoo! KeyKey (Yahoo!奇摩輸入法)**.
+Yahoo! KeyKey 2 is built in tribute to the original **Yahoo! KeyKey (Yahoo!奇摩輸入法)**.
 See [CREDITS.md](CREDITS.md) for the original projects, data sources, and engine
 attributions, and [docs/THIRD-PARTY-NOTICES.md](docs/THIRD-PARTY-NOTICES.md) for full
 third-party license details.
 
 ## License
 
-Yahoo KeyKey 2 is released under the [MIT License](LICENSE). Bundled third-party data keeps
+Yahoo! KeyKey 2 is released under the [MIT License](LICENSE). Bundled third-party data keeps
 its own permissive license — see [docs/THIRD-PARTY-NOTICES.md](docs/THIRD-PARTY-NOTICES.md).

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
-# Releasing Yahoo KeyKey 2
+# Releasing Yahoo! KeyKey 2
 
-This describes how to produce a downloadable build of **Yahoo KeyKey 2** (an
+This describes how to produce a downloadable build of **Yahoo! KeyKey 2** (an
 InputMethodKit input method) for distribution **outside the Mac App Store**.
 App Store distribution is **not** used for this version.
 
@@ -255,8 +255,8 @@ If running locally instead of CI:
    (create the folder if it doesn't exist). No admin password needed.
 3. **Log out and log back in** — macOS only scans for input methods at login.
 4. Open **System Settings ▸ Keyboard ▸ Input Sources ▸ `+`**, choose
-   **Traditional Chinese**, and add **Yahoo KeyKey 2 — Cangjie** and/or
-   **Yahoo KeyKey 2 — Simplex**.
+   **Traditional Chinese**, and add **Yahoo! KeyKey 2 — Cangjie** and/or
+   **Yahoo! KeyKey 2 — Simplex**.
 5. Switch input source with **Ctrl-Space** and start typing.
 
 ---
@@ -352,6 +352,6 @@ version, pkg signing status, and notarization status.
 3. At the end, click **Log Out** (then log back in) — required so macOS
    registers the new input method.
 4. Open **System Settings ▸ Keyboard ▸ Input Sources ▸ `+`**, choose
-   **Traditional Chinese**, and add **Yahoo KeyKey 2 — Cangjie** and/or
-   **Yahoo KeyKey 2 — Simplex**.
+   **Traditional Chinese**, and add **Yahoo! KeyKey 2 — Cangjie** and/or
+   **Yahoo! KeyKey 2 — Simplex**.
 5. Switch input source with **Ctrl-Space** and start typing.

--- a/docs/THIRD-PARTY-NOTICES.md
+++ b/docs/THIRD-PARTY-NOTICES.md
@@ -1,6 +1,6 @@
 # Third-Party Notices
 
-The MIT license in `LICENSE` covers the original Yahoo KeyKey 2 source code (the
+The MIT license in `LICENSE` covers the original Yahoo! KeyKey 2 source code (the
 Swift engine and the macOS app). Bundled third-party **data** keeps its own
 license — all of them permit redistribution, including commercial use:
 
@@ -12,7 +12,7 @@ license — all of them permit redistribution, including commercial use:
 | Cangjie-5 table | "Freely redistributable without restriction" (upstream table header; see `Resources/CANGJIE-DATA-LICENSE.txt`) |
 | Yahoo! KeyKey 三代 tables (倉頡第三代 / 速成) | New BSD (BSD-3-Clause) |
 
-Yahoo KeyKey 2 is an independent reimplementation and is not affiliated with, or
+Yahoo! KeyKey 2 is an independent reimplementation and is not affiliated with, or
 endorsed by, Yahoo. See `CREDITS.md`.
 
 ## McBopomofo (language model + algorithm reference)
@@ -60,7 +60,7 @@ notices", and its `Copyright (c) 2007-2010 Yahoo! Taiwan` line is scoped to
 `PreferenceApplications/` and `Utilities/` — not to `DataTables/` — so it is
 recorded as provenance rather than presented as these tables' notice.
 
-Only the data tables are reused. Yahoo KeyKey 2 uses no source code from the
+Only the data tables are reused. Yahoo! KeyKey 2 uses no source code from the
 original Yahoo! KeyKey. See `Resources/CANGJIE-DATA-LICENSE.txt` for the exact
 extraction and de-duplication steps.
 
@@ -102,10 +102,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
 The third condition is why the summary at the top of this file states that
-Yahoo KeyKey 2 is not affiliated with, or endorsed by, Yahoo.
+Yahoo! KeyKey 2 is not affiliated with, or endorsed by, Yahoo.
 
 ## Project source code
-The original Yahoo KeyKey 2 source code (Swift engine + macOS app) is released
+The original Yahoo! KeyKey 2 source code (Swift engine + macOS app) is released
 under the MIT License — see `LICENSE`. It is an independent reimplementation and
 uses no source code from the original Yahoo! KeyKey (credited in `CREDITS.md`).
 Its bundled **data** is another matter: the 三代 tables above come from that

--- a/known_issues.md
+++ b/known_issues.md
@@ -4,7 +4,7 @@ Common problems and what to do about them. If yours is not here, please
 [open an issue](https://github.com/teddychan/yahoo-keykey-2/issues) — say which macOS version
 you are on and which mode you were typing in.
 
-1. [Yahoo KeyKey 2 does not show up after installing](#1-yahoo-keykey-2-does-not-show-up-after-installing)
+1. [Yahoo! KeyKey 2 does not show up after installing](#1-yahoo-keykey-2-does-not-show-up-after-installing)
 2. [倉頡 is greyed out and will not turn on](#2-倉頡-is-greyed-out-and-will-not-turn-on)
 3. [A character's code is not what I expect](#3-a-characters-code-is-not-what-i-expect)
 4. [Space pages instead of accepting my code](#4-space-pages-instead-of-accepting-my-code)
@@ -15,7 +15,7 @@ you are on and which mode you were typing in.
 Also: [documentation gaps](#documentation-gaps) — things missing from these docs rather than
 problems with the app.
 
-## 1. Yahoo KeyKey 2 does not show up after installing
+## 1. Yahoo! KeyKey 2 does not show up after installing
 
 macOS only looks for new input methods when you log in.
 
@@ -29,7 +29,7 @@ Another app has switched on a macOS privacy feature called **secure input**, the
 used while you type a password. While it is on, macOS blocks every input method that did not
 come from Apple — so 倉頡 goes grey while the U.S. keyboard keeps working.
 
-Nothing is wrong with your installation, and no update to Yahoo KeyKey 2 can change this: only
+Nothing is wrong with your installation, and no update to Yahoo! KeyKey 2 can change this: only
 the app that switched secure input on is able to switch it off again.
 
 Usually that app simply forgot to turn it off after showing a password box. **1Password** is the
@@ -61,7 +61,7 @@ the code and stays on page 1, a second Space pages, and `1–9` picks.
 
 ## 5. Typing a number inserts a word instead
 
-After you commit a character, Yahoo KeyKey 2 suggests words that commonly follow it
+After you commit a character, Yahoo! KeyKey 2 suggests words that commonly follow it
 (**聯想字詞**), and `1–9` picks one of those suggestions.
 
 **Fix:** in **設定… ▸ 一般**, change the 聯想 selection key to **Shift + 1–9**. A plain `1–9`
@@ -104,5 +104,5 @@ forgotten.
   Dragon app a `## Screenshots` section above the badge row, but this repo has no `docs/images/`
   and has never had that heading — `clipmenu-2` is in the same position. Filling it needs real
   captures from an **installed release build**, not a local debug build, which would render as
-  "Yahoo KeyKey 2 Debug" in the menus and About pane. Worth showing: the candidate window mid-code
+  "Yahoo! KeyKey 2 Debug" in the menus and About pane. Worth showing: the candidate window mid-code
   with 反查提示 on, the input menu, and the 設定… 一般 pane.


### PR DESCRIPTION
The app now calls itself "Yahoo! KeyKey 2" (#126), but **41** references across the live docs still spelled it without the mark.

## The distinction, and why this is mechanical rather than per-line judgement

| Kind | Form | Takes the mark? |
|---|---|---|
| The **product** | contains "KeyKey" | yes |
| The **company** | bare "Yahoo" | **no** |

The two never collide, so replacing `Yahoo KeyKey` → `Yahoo! KeyKey` cannot touch a company reference. Verified per file by counting bare-company matches before and after and asserting equality — **32** of them across these files, all untouched.

## The case that makes it concrete

`THIRD-PARTY-NOTICES.md` now reads:

> Yahoo! KeyKey 2 is not affiliated with, or endorsed by, Yahoo.

Product named with its mark, company named without. A blind replace on "Yahoo" would have produced "endorsed by, Yahoo! KeyKey 2", which is nonsense — that's the failure this split avoids.

## Files

| File | Product refs fixed | Company refs left bare |
|---|---|---|
| `README.md` | 11 | 5 |
| `CHANGELOG.md` | 13 | 5 |
| `known_issues.md` | 5 | 0 |
| `docs/RELEASE.md` | 6 | 15 |
| `docs/THIRD-PARTY-NOTICES.md` | 5 | 4 |
| `CREDITS.md` | 1 | 3 |

`CHANGELOG.md` is included even though past entries are historical. The name isn't a historical fact that changed — the trademark always carried the mark and the app was spelling it wrong, so correcting it falsifies nothing.

`docs/superpowers/**` is deliberately **left alone**: 18 further references in dated planning artifacts describing decisions as they stood, the same treatment those directories got in every other Dragon repo this session.